### PR TITLE
Send individual change requests from frontend queue

### DIFF
--- a/api/src/socketio.ts
+++ b/api/src/socketio.ts
@@ -84,7 +84,7 @@ export class Socketio {
      * @param socket
      */
     @SubscribeMessage("changeRequest")
-    async onChangeRequest(@MessageBody() changeRequests: any[], @ConnectedSocket() socket: Socket) {
+    async onChangeRequest(@MessageBody() changeRequest: any, @ConnectedSocket() socket: Socket) {
         // TODO: Get userId from JWT or determine if public user and link to configurable "public" user doc
         const user = "super-admin";
         const groups = ["group-super-admins"];
@@ -92,20 +92,14 @@ export class Socketio {
         // Get user accessible groups and validate change request
         const userAccessMap = PermissionSystem.getAccessMap(groups);
 
-        const sortedChangeRequests = changeRequests.sort((a, b) => {
-            return a.id - b.id;
-        });
-
-        // Process each change request individually
-        for (const changeRequest of sortedChangeRequests) {
-            await processChangeRequest(user, changeRequest, userAccessMap, this.db)
-                .then(() => {
-                    this.emitAck(socket, AckStatus.Accepted, changeRequest);
-                })
-                .catch((err) => {
-                    this.emitAck(socket, AckStatus.Rejected, changeRequest, err.message);
-                });
-        }
+        // Process change request
+        await processChangeRequest(user, changeRequest, userAccessMap, this.db)
+            .then(() => {
+                this.emitAck(socket, AckStatus.Accepted, changeRequest);
+            })
+            .catch((err) => {
+                this.emitAck(socket, AckStatus.Rejected, changeRequest, err.message);
+            });
     }
 
     /**

--- a/cms/src/db/repositories/localChangesRepository.spec.ts
+++ b/cms/src/db/repositories/localChangesRepository.spec.ts
@@ -22,6 +22,19 @@ describe("localChangesRepository", () => {
         expect(result).toEqual([mockLocalChange1, mockLocalChange2]);
     });
 
+    it("can get all syncing changes", async () => {
+        const syncingChange = {
+            ...mockLocalChange1,
+            status: LocalChangeStatus.Syncing,
+        };
+        db.localChanges.put(syncingChange);
+        const repository = new LocalChangesRepository();
+
+        const result = await repository.getSyncing();
+
+        expect(result).toEqual([syncingChange]);
+    });
+
     it("can get a single document", async () => {
         const repository = new LocalChangesRepository();
 

--- a/cms/src/db/repositories/localChangesRepository.ts
+++ b/cms/src/db/repositories/localChangesRepository.ts
@@ -6,6 +6,10 @@ export class LocalChangesRepository {
         return db.localChanges.where("status").equals(LocalChangeStatus.Unsynced).toArray();
     }
 
+    getSyncing() {
+        return db.localChanges.where("status").equals(LocalChangeStatus.Syncing).toArray();
+    }
+
     get(id: number) {
         return db.localChanges.where("id").equals(id).first();
     }

--- a/cms/src/stores/localChanges.ts
+++ b/cms/src/stores/localChanges.ts
@@ -46,13 +46,13 @@ export const useLocalChangeStore = defineStore("localChanges", () => {
                 ) {
                     // TODO instead send changes that are younger than a certain timestamp
                     // so non-acknowledged onces are resent instead of being stuck in Syncing forever and blocking the queue
-                    await syncLocalChangesToApi(currentUnsyncedChanges[0]);
+                    await syncLocalChangeToApi(currentUnsyncedChanges[0]);
                 }
             },
         );
     };
 
-    const syncLocalChangesToApi = async (change: LocalChange) => {
+    const syncLocalChangeToApi = async (change: LocalChange) => {
         await localChangesRepository.update(change, {
             status: LocalChangeStatus.Syncing,
         });


### PR DESCRIPTION
Instead of batching them together which doesn't actually work as the watcher already triggers for the first `put` to localChanges, even with `bulkPut`
