### PR TITLE
Redirect to translation after create

### DIFF
--- a/cms/src/components/content/ContentForm.spec.ts
+++ b/cms/src/components/content/ContentForm.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import ContentForm from "./ContentForm.vue";
-import { mockContent, mockPost, mockUnpublishableContent } from "@/tests/mockData";
+import { mockEnglishContent, mockPost, mockUnpublishableContent } from "@/tests/mockData";
 import waitForExpect from "wait-for-expect";
 import { ContentStatus, DocType } from "@/types";
 import { useLocalChangeStore } from "@/stores/localChanges";
@@ -29,7 +29,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -49,7 +49,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -69,7 +69,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -92,7 +92,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -113,7 +113,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -132,7 +132,7 @@ describe("ContentForm", () => {
             props: {
                 post: mockPost,
                 content: {
-                    ...mockContent,
+                    ...mockEnglishContent,
                     text: undefined,
                 },
             },
@@ -151,7 +151,7 @@ describe("ContentForm", () => {
             props: {
                 post: mockPost,
                 content: {
-                    ...mockContent,
+                    ...mockEnglishContent,
                     text: undefined,
                 },
             },
@@ -195,7 +195,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 
@@ -213,7 +213,7 @@ describe("ContentForm", () => {
         const wrapper = mount(ContentForm, {
             props: {
                 post: mockPost,
-                content: mockContent,
+                content: mockEnglishContent,
             },
         });
 

--- a/cms/src/db/repositories/postRepository.spec.ts
+++ b/cms/src/db/repositories/postRepository.spec.ts
@@ -2,7 +2,7 @@ import "fake-indexeddb/auto";
 import { describe, it, afterEach, expect } from "vitest";
 import { db } from "../baseDatabase";
 import {
-    mockContent,
+    mockEnglishContent,
     mockEnglishContentDto,
     mockFrenchContentDto,
     mockLanguageDtoEng,
@@ -75,7 +75,7 @@ describe("postRepository", () => {
         ]);
         const repository = new PostRepository();
         const content: Content = {
-            ...mockContent,
+            ...mockEnglishContent,
             title: "Updated Title",
             publishDate: undefined,
         };

--- a/cms/src/pages/posts/CreatePost.vue
+++ b/cms/src/pages/posts/CreatePost.vue
@@ -48,7 +48,10 @@ const save = handleSubmit(async (values) => {
 
     const postId = await postStore.createPost(post);
 
-    return router.push({ name: "posts.edit", params: { id: postId } });
+    return router.push({
+        name: "posts.edit",
+        params: { postId, language: post.language.languageCode },
+    });
 });
 </script>
 

--- a/cms/src/pages/posts/EditPost.spec.ts
+++ b/cms/src/pages/posts/EditPost.spec.ts
@@ -4,16 +4,22 @@ import EditPost from "./EditPost.vue";
 import { createTestingPinia } from "@pinia/testing";
 import { setActivePinia } from "pinia";
 import { useLanguageStore } from "@/stores/language";
-import { mockContent, mockLanguageEng, mockLanguageFra, mockPost } from "@/tests/mockData";
+import { mockEnglishContent, mockLanguageEng, mockLanguageFra, mockPost } from "@/tests/mockData";
 import ContentForm from "@/components/content/ContentForm.vue";
 import { usePostStore } from "@/stores/post";
 import waitForExpect from "wait-for-expect";
 
+let routeLanguage: string;
+
 vi.mock("vue-router", () => ({
     resolve: vi.fn(),
+    useRouter: vi.fn().mockImplementation(() => ({
+        replace: vi.fn(),
+    })),
     useRoute: vi.fn().mockImplementation(() => ({
         params: {
-            id: mockPost._id,
+            postId: mockPost._id,
+            language: routeLanguage,
         },
     })),
 }));
@@ -61,7 +67,15 @@ describe("EditPost", () => {
         await wrapper.find("button[data-test='publish']").trigger("click");
 
         await waitForExpect(() => {
-            expect(postStore.updatePost).toHaveBeenCalledWith(mockContent, mockPost);
+            expect(postStore.updatePost).toHaveBeenCalledWith(mockEnglishContent, mockPost);
         });
+    });
+
+    it("can set the language from the route params", async () => {
+        routeLanguage = "fra";
+
+        const wrapper = mount(EditPost);
+
+        expect(wrapper.text()).toContain(mockPost.content[1].title);
     });
 });

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -23,11 +23,13 @@ const content = computed(() => {
 });
 
 const languageOptions = computed(() => {
-    if (!languages.value) {
+    if (!post.value) {
         return [];
     }
 
-    return languages.value.map((language) => {
+    const languages = post.value.content.map((c) => c.language);
+
+    return languages.map((language) => {
         return {
             label: language.name,
             value: language.languageCode,

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -6,13 +6,15 @@ import { useLanguageStore } from "@/stores/language";
 import { usePostStore } from "@/stores/post";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
 const route = useRoute();
+const router = useRouter();
 const postStore = usePostStore();
 const { languages } = storeToRefs(useLanguageStore());
 
-const postId = route.params.id as string;
+const postId = route.params.postId as string;
+const language = route.params.language as string;
 
 const post = computed(() => postStore.post(postId));
 const isLoading = computed(() => postStore.posts == undefined);
@@ -33,6 +35,12 @@ const languageOptions = computed(() => {
     });
 });
 const selectedLanguage = ref("eng");
+
+if (language) {
+    selectedLanguage.value = language;
+
+    router.replace({ name: "posts.edit", params: { postId } });
+}
 </script>
 
 <template>

--- a/cms/src/pages/posts/PostOverview.spec.ts
+++ b/cms/src/pages/posts/PostOverview.spec.ts
@@ -9,11 +9,7 @@ import LBadge from "@/components/common/LBadge.vue";
 import { useLanguageStore } from "@/stores/language";
 import { setActivePinia } from "pinia";
 import { useLocalChangeStore } from "@/stores/localChanges";
-
-vi.mock("vue-router", () => ({
-    resolve: vi.fn(),
-    RouterLink: vi.fn(),
-}));
+import { RouterLinkStub } from "@vue/test-utils";
 
 describe("PostOverview", () => {
     beforeEach(() => {
@@ -31,7 +27,9 @@ describe("PostOverview", () => {
         postStore.posts = [mockPost];
         languageStore.languages = [mockLanguageEng];
 
-        const wrapper = mount(PostOverview);
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
 
         expect(wrapper.html()).toContain("English translation title");
 
@@ -50,7 +48,9 @@ describe("PostOverview", () => {
         // @ts-expect-error - Property is read-only but we are mocking it
         localChangeStore.isLocalChange = () => true;
 
-        const wrapper = mount(PostOverview);
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
 
         // Assert there is a badge that indicates a post has unsynced local changes
         const badge = wrapper.findComponent(LBadge);
@@ -62,13 +62,17 @@ describe("PostOverview", () => {
         const store = usePostStore();
         store.posts = [];
 
-        const wrapper = mount(PostOverview);
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
 
         expect(wrapper.findComponent(EmptyState).exists()).toBe(true);
     });
 
     it("doesn't display anything when the db is still loading", async () => {
-        const wrapper = mount(PostOverview);
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
 
         expect(wrapper.find("button").exists()).toBe(false);
         expect(wrapper.findComponent(EmptyState).exists()).toBe(false);
@@ -83,7 +87,9 @@ describe("PostOverview", () => {
 
         postStore.posts = [post];
 
-        const wrapper = mount(PostOverview);
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
 
         expect(wrapper.html()).toContain("No translation");
     });

--- a/cms/src/pages/posts/PostOverview.vue
+++ b/cms/src/pages/posts/PostOverview.vue
@@ -107,23 +107,33 @@ const translationStatus = computed(() => {
                         Offline changes
                     </LBadge>
                 </template>
-                <template #item.translations="{ content }">
-                    <div class="flex gap-2" v-if="content.length > 0">
-                        <LBadge
+                <template #item.translations="post">
+                    <div class="flex gap-2" v-if="post.content.length > 0">
+                        <RouterLink
                             v-for="language in languages"
                             :key="language.languageCode"
-                            type="language"
-                            :variant="
-                                translationStatus(
-                                    content.find(
-                                        (c: Content) =>
-                                            c.language.languageCode == language.languageCode,
-                                    ),
-                                )
-                            "
+                            :to="{
+                                name: 'posts.edit',
+                                params: {
+                                    postId: post._id,
+                                    language: language.languageCode,
+                                },
+                            }"
                         >
-                            {{ language.languageCode }}
-                        </LBadge>
+                            <LBadge
+                                type="language"
+                                :variant="
+                                    translationStatus(
+                                        post.content.find(
+                                            (c: Content) =>
+                                                c.language.languageCode == language.languageCode,
+                                        ),
+                                    )
+                                "
+                            >
+                                {{ language.languageCode }}
+                            </LBadge>
+                        </RouterLink>
                     </div>
                 </template>
                 <template #item.updatedTime="post">
@@ -137,7 +147,7 @@ const translationStatus = computed(() => {
                         :to="{
                             name: 'posts.edit',
                             params: {
-                                id: post._id,
+                                postId: post._id,
                             },
                         }"
                     ></LButton>

--- a/cms/src/router/index.ts
+++ b/cms/src/router/index.ts
@@ -60,7 +60,7 @@ const router = createRouter({
                             },
                         },
                         {
-                            path: "edit/:id",
+                            path: "edit/:postId/:language?",
                             name: "posts.edit",
                             component: () => import("../pages/posts/EditPost.vue"),
                             meta: {

--- a/cms/src/stores/post.spec.ts
+++ b/cms/src/stores/post.spec.ts
@@ -3,7 +3,7 @@ import { usePostStore } from "./post";
 import { setActivePinia, createPinia } from "pinia";
 import { liveQuery } from "dexie";
 import { PostRepository } from "@/db/repositories/postRepository";
-import { mockContent, mockLanguageEng, mockPost } from "@/tests/mockData";
+import { mockEnglishContent, mockLanguageEng, mockPost } from "@/tests/mockData";
 
 vi.mock("@/db/repositories/postRepository");
 
@@ -59,8 +59,8 @@ describe("post store", () => {
         const createSpy = vi.spyOn(PostRepository.prototype, "update");
 
         const store = usePostStore();
-        store.updatePost(mockContent, mockPost);
+        store.updatePost(mockEnglishContent, mockPost);
 
-        expect(createSpy).toHaveBeenCalledWith(mockContent, mockPost);
+        expect(createSpy).toHaveBeenCalledWith(mockEnglishContent, mockPost);
     });
 });

--- a/cms/src/tests/mockData.ts
+++ b/cms/src/tests/mockData.ts
@@ -93,7 +93,7 @@ export const mockLanguageDtoFra: LanguageDto = {
     name: "Français",
 };
 
-export const mockContent: Content = {
+export const mockEnglishContent: Content = {
     _id: "content-post1-eng",
     type: DocType.Content,
     updatedTimeUtc: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
@@ -105,6 +105,24 @@ export const mockContent: Content = {
     summary: "This is an example post",
     author: "ChatGPT",
     text: "In the quiet town of Willowdale, little Lily wept as her beloved cat, Whiskers, went missing. Frantically searching the neighborhood, she stumbled upon Fireman Jake, known for his kind heart. With a reassuring smile, he promised to help. Lily clung to hope as they combed the streets together. Beneath a dusty porch, they found Whiskers, scared but unharmed. Grateful tears filled Lily's eyes as Fireman Jake handed her the rescued feline. Their small town echoed with cheers as Lily hugged her furry friend, and from that day forward, Fireman Jake became a hero in her heart and the community's beloved guardian.",
+    localisedImage: undefined,
+    audio: undefined,
+    video: undefined,
+    publishDate: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
+    expiryDate: undefined,
+};
+export const mockFrenchContent: Content = {
+    _id: "content-post1-fra",
+    type: DocType.Content,
+    updatedTimeUtc: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
+    memberOf: [],
+    language: mockLanguageFra,
+    status: ContentStatus.Published,
+    slug: "post1-fra",
+    title: "Post 1",
+    summary: "Ceci est un exemple de publication.",
+    author: "ChatGPT",
+    text: "Dans la paisible ville de Willowdale, la petite Lily pleurait la disparition de son cher chat, Whiskers. Cherchant frénétiquement dans le quartier, elle tomba sur le pompier Jake, réputé pour son cœur généreux. Avec un sourire rassurant, il promit de l'aider. Lily s'accrocha à l'espoir alors qu'ils parcouraient les rues ensemble. Sous un porche poussiéreux, ils trouvèrent Whiskers, effrayé mais sain et sauf. Des larmes de gratitude remplirent les yeux de Lily lorsque le pompier Jake lui remit le félin sauvé. Leur petite ville résonna de joie tandis que Lily serrait son ami à fourrure dans ses bras, et dès ce jour, le pompier Jake devint un héros dans son cœur et le gardien bien-aimé de la communauté.",
     localisedImage: undefined,
     audio: undefined,
     video: undefined,
@@ -137,7 +155,7 @@ export const mockPost: Post = {
     image: "test.jpg",
     updatedTimeUtc: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
     memberOf: [],
-    content: [mockContent],
+    content: [mockEnglishContent, mockFrenchContent],
     tags: [],
 };
 


### PR DESCRIPTION
- Make language badges clickable
- Only show actual languages on dropdown

Known issue is that it can route to a non-existing language, will be solved in follow-up PR with the actual language switcher.
