### PR TITLE
Add language selector to create new translation for post

### DIFF
--- a/cms/src/components/BasePage.spec.ts
+++ b/cms/src/components/BasePage.spec.ts
@@ -7,7 +7,6 @@ describe("BasePage", () => {
         const wrapper = mount(BasePage, {
             props: { title: "Page title" },
             slots: { default: "Default slot content" },
-            global: { stubs: { RouterLink: RouterLinkStub } },
         });
 
         expect(wrapper.text()).toContain("Page title");
@@ -17,7 +16,6 @@ describe("BasePage", () => {
     it("renders the back link", async () => {
         const wrapper = mount(BasePage, {
             props: { backLinkLocation: { name: "posts.index" }, backLinkText: "Posts" },
-            global: { stubs: { RouterLink: RouterLinkStub } },
         });
 
         const routerLink = await wrapper.findComponent(RouterLinkStub);

--- a/cms/src/components/BasePage.spec.ts
+++ b/cms/src/components/BasePage.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { RouterLinkStub, mount } from "@vue/test-utils";
 import BasePage from "./BasePage.vue";
 
 describe("BasePage", () => {
@@ -7,9 +7,21 @@ describe("BasePage", () => {
         const wrapper = mount(BasePage, {
             props: { title: "Page title" },
             slots: { default: "Default slot content" },
+            global: { stubs: { RouterLink: RouterLinkStub } },
         });
 
-        expect(wrapper.html()).toContain("Page title");
-        expect(wrapper.html()).toContain("Default slot content");
+        expect(wrapper.text()).toContain("Page title");
+        expect(wrapper.text()).toContain("Default slot content");
+    });
+
+    it("renders the back link", async () => {
+        const wrapper = mount(BasePage, {
+            props: { backLinkLocation: { name: "posts.index" }, backLinkText: "Posts" },
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
+
+        const routerLink = await wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.props().to).toEqual({ name: "posts.index" });
+        expect(wrapper.text()).toContain("Posts");
     });
 });

--- a/cms/src/components/BasePage.vue
+++ b/cms/src/components/BasePage.vue
@@ -27,7 +27,7 @@ withDefaults(defineProps<Props>(), {
             <RouterLink
                 v-if="backLinkLocation"
                 :to="backLinkLocation"
-                class="mb-1 flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
+                class="-mx-2 mb-1 inline-flex items-center gap-1 rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900 active:bg-gray-200"
             >
                 <ArrowLeftIcon class="h-4 w-4" /> {{ backLinkText }}
             </RouterLink>

--- a/cms/src/components/BasePage.vue
+++ b/cms/src/components/BasePage.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
+import { ArrowLeftIcon } from "@heroicons/vue/16/solid";
+import type { RouteLocationRaw } from "vue-router";
+
 type Props = {
     title?: string;
     loading?: boolean;
     centered?: boolean;
+    backLinkLocation?: RouteLocationRaw;
+    backLinkText?: string;
 };
 
 withDefaults(defineProps<Props>(), {
     loading: false,
     centered: false,
+    backLinkText: "Back",
 });
 </script>
 
@@ -18,6 +24,13 @@ withDefaults(defineProps<Props>(), {
         enter-to-class="opacity-100"
     >
         <div v-if="!loading">
+            <RouterLink
+                v-if="backLinkLocation"
+                :to="backLinkLocation"
+                class="mb-1 flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
+            >
+                <ArrowLeftIcon class="h-4 w-4" /> {{ backLinkText }}
+            </RouterLink>
             <header
                 v-if="title || $slots.actions"
                 :class="[

--- a/cms/src/components/EmptyState.spec.ts
+++ b/cms/src/components/EmptyState.spec.ts
@@ -59,4 +59,18 @@ describe("EmptyState", () => {
         expect(wrapper.html()).toContain("Button text");
         expect(buttonAction).toHaveBeenCalled();
     });
+
+    it("renders the default slot", async () => {
+        const wrapper = mount(EmptyState, {
+            props: {
+                title: "Empty state title",
+                description: "Empty state description",
+            },
+            slots: {
+                default: "Test slot",
+            },
+        });
+
+        expect(wrapper.html()).toContain("Test slot");
+    });
 });

--- a/cms/src/components/EmptyState.vue
+++ b/cms/src/components/EmptyState.vue
@@ -36,6 +36,7 @@ defineProps<{
             >
                 {{ buttonText }}
             </LButton>
+            <slot />
         </div>
     </div>
 </template>

--- a/cms/src/components/common/LTable.vue
+++ b/cms/src/components/common/LTable.vue
@@ -1,15 +1,17 @@
-<script setup lang="ts">
-import { ArrowsUpDownIcon, ArrowUpIcon, ArrowDownIcon } from "@heroicons/vue/20/solid";
-import { computed, toRefs } from "vue";
-
-type Column = {
+<script lang="ts">
+export type Column = {
     key: string;
     text?: string;
     sortable?: boolean;
     sortMethod?: (a: Item, b: Item) => number;
 };
-type Item = any;
-type SortDirection = "ascending" | "descending";
+export type Item = any;
+export type SortDirection = "ascending" | "descending";
+</script>
+
+<script setup lang="ts">
+import { ArrowsUpDownIcon, ArrowUpIcon, ArrowDownIcon } from "@heroicons/vue/20/solid";
+import { computed, toRefs } from "vue";
 
 type Props = {
     columns: Column[];

--- a/cms/src/components/content/LanguageSelector.spec.ts
+++ b/cms/src/components/content/LanguageSelector.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import LanguageSelector from "./LanguageSelector.vue";
+import { mockLanguageEng, mockLanguageFra, mockLanguageSwa, mockPost } from "@/tests/mockData";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useLanguageStore } from "@/stores/language";
+import LBadge from "@/components/common/LBadge.vue";
+
+describe("LanguageSelector", () => {
+    beforeEach(() => {
+        setActivePinia(createTestingPinia());
+
+        const languageStore = useLanguageStore();
+        languageStore.languages = [mockLanguageEng, mockLanguageFra, mockLanguageSwa];
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("displays the current language", async () => {
+        const wrapper = mount(LanguageSelector, {
+            props: {
+                post: mockPost,
+                modelValue: "swa",
+            },
+        });
+
+        expect(wrapper.text()).toContain("Swahili");
+        expect(wrapper.text()).not.toContain("English");
+        expect(wrapper.text()).not.toContain("Français");
+    });
+
+    it("can display a dropdown with all languages", async () => {
+        const wrapper = mount(LanguageSelector, {
+            props: {
+                post: mockPost,
+                modelValue: "eng",
+            },
+        });
+
+        await wrapper.find("button[data-test='language-selector']").trigger("click");
+
+        expect(wrapper.text()).toContain("English");
+        expect(wrapper.text()).toContain("Français");
+        expect(wrapper.text()).toContain("Add translation");
+        expect(wrapper.text()).toContain("Swahili");
+    });
+
+    it("displays a label with the translation status", async () => {
+        const wrapper = mount(LanguageSelector, {
+            props: {
+                post: mockPost,
+                modelValue: "eng",
+            },
+        });
+
+        await wrapper.find("button[data-test='language-selector']").trigger("click");
+
+        const badge = await wrapper.findAllComponents(LBadge);
+        expect(badge[0].props().variant).toBe("success"); // English content = Published
+        expect(badge[1].props().variant).toBe("info"); // French content = Draft
+        expect(badge[2].props().variant).toBe("default"); // Swahili = no translation yet
+    });
+});

--- a/cms/src/components/content/LanguageSelector.spec.ts
+++ b/cms/src/components/content/LanguageSelector.spec.ts
@@ -32,6 +32,20 @@ describe("LanguageSelector", () => {
         expect(wrapper.text()).not.toContain("Français");
     });
 
+    it("can handle an unset language", async () => {
+        const wrapper = mount(LanguageSelector, {
+            props: {
+                post: undefined,
+                modelValue: undefined,
+            },
+        });
+
+        expect(wrapper.text()).toContain("Select language");
+        expect(wrapper.text()).not.toContain("Swahili");
+        expect(wrapper.text()).not.toContain("English");
+        expect(wrapper.text()).not.toContain("Français");
+    });
+
     it("can display a dropdown with all languages", async () => {
         const wrapper = mount(LanguageSelector, {
             props: {

--- a/cms/src/components/content/LanguageSelector.vue
+++ b/cms/src/components/content/LanguageSelector.vue
@@ -7,6 +7,7 @@ import { useLanguageStore } from "@/stores/language";
 import { ContentStatus, type Content, type Post } from "@/types";
 import { computed, toRefs } from "vue";
 import { ArrowRightIcon, CheckCircleIcon } from "@heroicons/vue/16/solid";
+import { sortByName } from "@/util/sortByName";
 
 const props = defineProps<{
     post?: Post;
@@ -29,7 +30,9 @@ const translatedLanguages = computed(() => {
         return [];
     }
 
-    return post.value.content.map((c) => c.language);
+    const list = post.value.content.map((c) => c.language);
+
+    return list.sort(sortByName);
 });
 
 const untranslatedLanguages = computed(() => {
@@ -37,9 +40,11 @@ const untranslatedLanguages = computed(() => {
         return [];
     }
 
-    return languages.value.filter(
+    const list = languages.value.filter(
         (language) => translatedLanguages.value.findIndex((t) => t._id == language._id) < 0,
     );
+
+    return list.sort(sortByName);
 });
 
 const translationStatus = computed(() => {

--- a/cms/src/components/content/LanguageSelector.vue
+++ b/cms/src/components/content/LanguageSelector.vue
@@ -17,7 +17,7 @@ const { post } = toRefs(props);
 
 const emit = defineEmits(["createTranslation"]);
 
-const selectedLanguage = defineModel<string>({ required: true });
+const selectedLanguage = defineModel<string>();
 
 const { languages } = storeToRefs(useLanguageStore());
 
@@ -69,7 +69,10 @@ const translationStatus = computed(() => {
                 class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
                 data-test="language-selector"
             >
-                {{ selectedLanguageName }}
+                <span v-if="selectedLanguage">
+                    {{ selectedLanguageName }}
+                </span>
+                <span v-else>Select language</span>
                 <ChevronDownIcon class="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
             </MenuButton>
         </div>

--- a/cms/src/components/content/LanguageSelector.vue
+++ b/cms/src/components/content/LanguageSelector.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
+import { ChevronDownIcon } from "@heroicons/vue/20/solid";
+import LBadge from "@/components/common/LBadge.vue";
+import { storeToRefs } from "pinia";
+import { useLanguageStore } from "@/stores/language";
+import { ContentStatus, type Content, type Post } from "@/types";
+import { computed, toRefs } from "vue";
+import { ArrowRightIcon, CheckCircleIcon } from "@heroicons/vue/16/solid";
+
+const props = defineProps<{
+    post?: Post;
+}>();
+
+const { post } = toRefs(props);
+
+const selectedLanguage = defineModel<string>({ required: true });
+
+const { languages } = storeToRefs(useLanguageStore());
+
+const selectedLanguageName = computed(() => {
+    return languages.value?.find((l) => l.languageCode == selectedLanguage.value)?.name;
+});
+
+const translatedLanguages = computed(() => {
+    if (!post.value) {
+        return [];
+    }
+
+    return post.value.content.map((c) => c.language);
+});
+
+const untranslatedLanguages = computed(() => {
+    if (!post.value || !languages.value) {
+        return [];
+    }
+
+    return languages.value.filter(
+        (language) => translatedLanguages.value.findIndex((t) => t._id == language._id) < 0,
+    );
+});
+
+const translationStatus = computed(() => {
+    return (content: Content | undefined) => {
+        if (content?.status == ContentStatus.Published) {
+            return "success";
+        }
+
+        if (content?.status == ContentStatus.Draft) {
+            return "info";
+        }
+
+        return "default";
+    };
+});
+</script>
+
+<template>
+    <Menu as="div" class="relative inline-block text-left">
+        <div>
+            <MenuButton
+                class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+            >
+                {{ selectedLanguageName }}
+                <ChevronDownIcon class="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
+            </MenuButton>
+        </div>
+
+        <transition
+            enter-active-class="transition ease-out duration-100"
+            enter-from-class="transform opacity-0 scale-95"
+            enter-to-class="transform opacity-100 scale-100"
+            leave-active-class="transition ease-in duration-75"
+            leave-from-class="transform opacity-100 scale-100"
+            leave-to-class="transform opacity-0 scale-95"
+        >
+            <MenuItems
+                class="absolute -right-1 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+            >
+                <div class="py-1">
+                    <MenuItem
+                        v-slot="{ active }"
+                        v-for="language in translatedLanguages"
+                        :key="language.languageCode"
+                    >
+                        <button
+                            @click="selectedLanguage = language.languageCode"
+                            :class="[
+                                active || selectedLanguage == language.languageCode
+                                    ? 'bg-gray-100 text-gray-900'
+                                    : 'text-gray-700',
+                                'flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm',
+                            ]"
+                        >
+                            <span class="flex items-center gap-2">
+                                <LBadge
+                                    type="language"
+                                    :variant="
+                                        translationStatus(
+                                            post?.content.find(
+                                                (c: Content) =>
+                                                    c.language.languageCode ==
+                                                    language.languageCode,
+                                            ),
+                                        )
+                                    "
+                                    no-icon
+                                >
+                                    {{ language.languageCode }}
+                                </LBadge>
+                                {{ language.name }}
+                            </span>
+
+                            <CheckCircleIcon
+                                v-if="selectedLanguage == language.languageCode"
+                                class="h-4 w-4 text-gray-500"
+                            />
+                        </button>
+                    </MenuItem>
+
+                    <div
+                        v-if="untranslatedLanguages"
+                        class="mb-1 mt-4 px-4 text-xs uppercase tracking-wider text-gray-600"
+                    >
+                        Add translation
+                    </div>
+
+                    <MenuItem
+                        v-slot="{ active }"
+                        v-for="language in untranslatedLanguages"
+                        :key="language.languageCode"
+                    >
+                        <button
+                            :class="[
+                                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                                'group flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm',
+                            ]"
+                        >
+                            <span class="flex items-center gap-2">
+                                <LBadge type="language" no-icon>
+                                    {{ language.languageCode }}
+                                </LBadge>
+                                {{ language.name }}
+                            </span>
+
+                            <ArrowRightIcon
+                                class="hidden h-4 w-4 text-gray-600 sm:group-hover:inline-block sm:group-active:inline-block"
+                            />
+                        </button>
+                    </MenuItem>
+                </div>
+            </MenuItems>
+        </transition>
+    </Menu>
+</template>

--- a/cms/src/components/content/LanguageSelector.vue
+++ b/cms/src/components/content/LanguageSelector.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
 
 const { post } = toRefs(props);
 
+const emit = defineEmits(["createTranslation"]);
+
 const selectedLanguage = defineModel<string>({ required: true });
 
 const { languages } = storeToRefs(useLanguageStore());
@@ -60,6 +62,7 @@ const translationStatus = computed(() => {
         <div>
             <MenuButton
                 class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                data-test="language-selector"
             >
                 {{ selectedLanguageName }}
                 <ChevronDownIcon class="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
@@ -91,6 +94,7 @@ const translationStatus = computed(() => {
                                     : 'text-gray-700',
                                 'flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm',
                             ]"
+                            :data-test="`select-language-${language.languageCode}`"
                         >
                             <span class="flex items-center gap-2">
                                 <LBadge
@@ -119,7 +123,7 @@ const translationStatus = computed(() => {
                     </MenuItem>
 
                     <div
-                        v-if="untranslatedLanguages"
+                        v-if="untranslatedLanguages.length > 0"
                         class="mb-1 mt-4 px-4 text-xs uppercase tracking-wider text-gray-600"
                     >
                         Add translation
@@ -131,10 +135,12 @@ const translationStatus = computed(() => {
                         :key="language.languageCode"
                     >
                         <button
+                            @click="emit('createTranslation', language)"
                             :class="[
                                 active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
                                 'group flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm',
                             ]"
+                            :data-test="`select-language-${language.languageCode}`"
                         >
                             <span class="flex items-center gap-2">
                                 <LBadge type="language" no-icon>

--- a/cms/src/components/content/LanguageSelector.vue
+++ b/cms/src/components/content/LanguageSelector.vue
@@ -86,7 +86,7 @@ const translationStatus = computed(() => {
             leave-to-class="transform opacity-0 scale-95"
         >
             <MenuItems
-                class="absolute -right-1 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                class="absolute -left-1 z-10 mt-2 w-56 origin-top-left rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:-right-1 sm:left-auto sm:origin-top-right"
             >
                 <div class="py-1">
                     <MenuItem

--- a/cms/src/db/repositories/contentRepository.spec.ts
+++ b/cms/src/db/repositories/contentRepository.spec.ts
@@ -9,6 +9,7 @@ import {
     mockLanguageDtoFra,
     mockPostDto,
 } from "@/tests/mockData";
+import { DocType, type ContentDto, ContentStatus } from "@/types";
 
 describe("contentRepository", () => {
     afterEach(() => {
@@ -34,5 +35,27 @@ describe("contentRepository", () => {
         expect(result[1]._id).toBe(mockFrenchContentDto._id);
         expect(result[1].title).toBe(mockFrenchContentDto.title);
         expect(result[1].language.languageCode).toBe("fra");
+    });
+
+    it("can create content", async () => {
+        const repository = new ContentRepository();
+
+        await repository.create({
+            parentId: "test-parent-id",
+            language: "eng",
+            title: "Test title",
+        });
+
+        // Assert content was created
+        const content = (await db.docs.where("type").equals(DocType.Content).first()) as ContentDto;
+        expect(content.title).toBe("Test title");
+        expect(content.parentId).toBe("test-parent-id");
+        expect(content.language).toBe("eng");
+        expect(content.status).toBe(ContentStatus.Draft);
+
+        // Assert content was logged in the localChanges table
+        const localChanges = await db.localChanges.toArray();
+        expect(localChanges.length).toBe(1);
+        expect(localChanges[0].doc).toEqual(content);
     });
 });

--- a/cms/src/db/repositories/contentRepository.ts
+++ b/cms/src/db/repositories/contentRepository.ts
@@ -1,7 +1,9 @@
-import { type ContentDto, type Uuid, type Content } from "@/types";
+import { type ContentDto, type Uuid, type Content, ContentStatus, DocType } from "@/types";
 import { BaseRepository } from "./baseRepository";
 import { LanguageRepository } from "./languageRepository";
 import { DateTime } from "luxon";
+import { db } from "../baseDatabase";
+import { v4 as uuidv4 } from "uuid";
 
 export class ContentRepository extends BaseRepository {
     private _languageRepository: LanguageRepository;
@@ -15,6 +17,27 @@ export class ContentRepository extends BaseRepository {
         return this.whereParentId(id).toArray((content) => {
             return Promise.all(this.fromDtos(content as ContentDto[]));
         });
+    }
+
+    async create(values: Partial<ContentDto>) {
+        const contentId = uuidv4();
+        const content = {
+            ...values,
+            _id: contentId,
+            updatedTimeUtc: Date.now(),
+            type: DocType.Content,
+            status: ContentStatus.Draft,
+            slug: `slug-${values.title}`, // TODO create actual slug from title
+            memberOf: ["group-private-content"], // TODO set right group
+        };
+
+        await db.docs.put(content);
+
+        await db.localChanges.put({
+            doc: content,
+        });
+
+        return contentId;
     }
 
     private fromDtos(dtos: ContentDto[]) {

--- a/cms/src/db/repositories/postRepository.ts
+++ b/cms/src/db/repositories/postRepository.ts
@@ -21,20 +21,7 @@ export class PostRepository extends BaseRepository {
     }
 
     async create(dto: CreatePostDto) {
-        const contentId = uuidv4();
         const postId = uuidv4();
-
-        const content: ContentDto = {
-            _id: contentId,
-            parentId: postId,
-            updatedTimeUtc: Date.now(),
-            type: DocType.Content,
-            status: ContentStatus.Draft,
-            language: dto.language._id,
-            title: dto.title,
-            slug: `slug-${dto.title}`, // TODO create actual slug from title
-            memberOf: ["group-private-content"], // TODO set right group
-        };
 
         const post: PostDto = {
             _id: postId,
@@ -45,15 +32,18 @@ export class PostRepository extends BaseRepository {
             memberOf: ["group-private-content"], // TODO set right group
         };
 
-        await db.docs.put(content);
         await db.docs.put(post);
 
         // Save change, which will be sent to the API later
         await db.localChanges.put({
             doc: post,
         });
-        await db.localChanges.put({
-            doc: content,
+
+        // Create content
+        await this._contentRepository.create({
+            parentId: postId,
+            language: dto.language._id,
+            title: dto.title,
         });
 
         return postId;

--- a/cms/src/db/repositories/postRepository.ts
+++ b/cms/src/db/repositories/postRepository.ts
@@ -1,12 +1,4 @@
-import {
-    DocType,
-    type CreatePostDto,
-    type Post,
-    type PostDto,
-    type ContentDto,
-    ContentStatus,
-    type Content,
-} from "@/types";
+import { DocType, type CreatePostDto, type Post, type PostDto, type Content } from "@/types";
 import { ContentRepository } from "./contentRepository";
 import { BaseRepository } from "./baseRepository";
 import { db } from "../baseDatabase";

--- a/cms/src/pages/posts/EditPost.spec.ts
+++ b/cms/src/pages/posts/EditPost.spec.ts
@@ -4,10 +4,17 @@ import EditPost from "./EditPost.vue";
 import { createTestingPinia } from "@pinia/testing";
 import { setActivePinia } from "pinia";
 import { useLanguageStore } from "@/stores/language";
-import { mockEnglishContent, mockLanguageEng, mockLanguageFra, mockPost } from "@/tests/mockData";
+import {
+    mockEnglishContent,
+    mockLanguageEng,
+    mockLanguageFra,
+    mockLanguageSwa,
+    mockPost,
+} from "@/tests/mockData";
 import ContentForm from "@/components/content/ContentForm.vue";
 import { usePostStore } from "@/stores/post";
 import waitForExpect from "wait-for-expect";
+import LanguageSelector from "@/components/content/LanguageSelector.vue";
 
 let routeLanguage: string;
 
@@ -30,7 +37,7 @@ describe("EditPost", () => {
 
         const languageStore = useLanguageStore();
         const postStore = usePostStore();
-        languageStore.languages = [mockLanguageEng, mockLanguageFra];
+        languageStore.languages = [mockLanguageEng, mockLanguageFra, mockLanguageSwa];
         postStore.posts = [mockPost];
     });
 
@@ -77,5 +84,19 @@ describe("EditPost", () => {
         const wrapper = mount(EditPost);
 
         expect(wrapper.text()).toContain(mockPost.content[1].title);
+    });
+
+    it("can create a translation", async () => {
+        const postStore = usePostStore();
+        const wrapper = mount(EditPost);
+
+        await wrapper.find("button[data-test='language-selector']").trigger("click");
+        await wrapper.find("button[data-test='select-language-swa']").trigger("click");
+
+        expect(postStore.createTranslation).toHaveBeenCalledWith(mockPost, mockLanguageSwa);
+        // Test that it switched the current language
+        expect(wrapper.text()).toContain("Swahili");
+        expect(wrapper.text()).not.toContain("Français");
+        expect(wrapper.text()).not.toContain("English");
     });
 });

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -16,7 +16,7 @@ const postId = route.params.postId as string;
 const routeLanguage = route.params.language as string;
 
 const post = computed(() => postStore.post(postId));
-const isLoading = computed(() => postStore.posts == undefined);
+const isLoading = computed(() => post.value == undefined);
 const content = computed(() => {
     return post.value?.content.find((c) => c.language.languageCode == selectedLanguage.value);
 });

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -3,7 +3,8 @@ import BasePage from "@/components/BasePage.vue";
 import ContentForm from "@/components/content/ContentForm.vue";
 import LanguageSelector from "@/components/content/LanguageSelector.vue";
 import { usePostStore } from "@/stores/post";
-import { computed, ref } from "vue";
+import type { Content, Language } from "@/types";
+import { computed, ref, toRaw, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 const route = useRoute();
@@ -26,14 +27,36 @@ if (language) {
 
     router.replace({ name: "posts.edit", params: { postId } });
 }
+
+async function createTranslation(language: Language) {
+    await postStore.createTranslation(post.value!, language);
+
+    selectedLanguage.value = language.languageCode;
+}
 </script>
 
 <template>
     <BasePage :title="content?.title" :loading="isLoading">
         <template #actions>
-            <LanguageSelector :post="post" v-model="selectedLanguage" />
+            <LanguageSelector
+                :post="post"
+                v-model="selectedLanguage"
+                @create-translation="createTranslation"
+            />
         </template>
 
-        <ContentForm :post="post" :content="content" v-if="content" @save="postStore.updatePost" />
+        <transition
+            enter-active-class="transition ease duration-500"
+            enter-from-class="opacity-0 scale-90"
+            enter-to-class="opacity-100 scale-100"
+        >
+            <ContentForm
+                v-if="content"
+                :key="content._id"
+                :post="post"
+                :content="content"
+                @save="postStore.updatePost"
+            />
+        </transition>
     </BasePage>
 </template>

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
 import BasePage from "@/components/BasePage.vue";
 import ContentForm from "@/components/content/ContentForm.vue";
-import LSelect from "@/components/forms/LSelect.vue";
-import { useLanguageStore } from "@/stores/language";
+import LanguageSelector from "@/components/content/LanguageSelector.vue";
 import { usePostStore } from "@/stores/post";
-import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 const route = useRoute();
 const router = useRouter();
 const postStore = usePostStore();
-const { languages } = storeToRefs(useLanguageStore());
 
 const postId = route.params.postId as string;
 const language = route.params.language as string;
@@ -22,20 +19,6 @@ const content = computed(() => {
     return post.value?.content.find((c) => c.language.languageCode == selectedLanguage.value);
 });
 
-const languageOptions = computed(() => {
-    if (!post.value) {
-        return [];
-    }
-
-    const languages = post.value.content.map((c) => c.language);
-
-    return languages.map((language) => {
-        return {
-            label: language.name,
-            value: language.languageCode,
-        };
-    });
-});
 const selectedLanguage = ref("eng");
 
 if (language) {
@@ -48,7 +31,7 @@ if (language) {
 <template>
     <BasePage :title="content?.title" :loading="isLoading">
         <template #actions>
-            <LSelect :options="languageOptions" v-model="selectedLanguage" />
+            <LanguageSelector :post="post" v-model="selectedLanguage" />
         </template>
 
         <ContentForm :post="post" :content="content" v-if="content" @save="postStore.updatePost" />

--- a/cms/src/pages/posts/EditPost.vue
+++ b/cms/src/pages/posts/EditPost.vue
@@ -62,7 +62,12 @@ async function createTranslation(language: Language) {
 </script>
 
 <template>
-    <BasePage :title="content ? content.title : 'Edit post'" :loading="isLoading">
+    <BasePage
+        :title="content ? content.title : 'Edit post'"
+        :loading="isLoading"
+        :back-link-location="{ name: 'posts.index' }"
+        back-link-text="Posts"
+    >
         <template #actions>
             <LanguageSelector
                 v-if="content"

--- a/cms/src/pages/posts/PostOverview.spec.ts
+++ b/cms/src/pages/posts/PostOverview.spec.ts
@@ -4,7 +4,7 @@ import { createTestingPinia } from "@pinia/testing";
 import PostOverview from "./PostOverview.vue";
 import { usePostStore } from "@/stores/post";
 import EmptyState from "@/components/EmptyState.vue";
-import { mockLanguageEng, mockPost } from "@/tests/mockData";
+import { mockFrenchContent, mockLanguageEng, mockLanguageFra, mockPost } from "@/tests/mockData";
 import LBadge from "@/components/common/LBadge.vue";
 import { useLanguageStore } from "@/stores/language";
 import { setActivePinia } from "pinia";
@@ -36,6 +36,25 @@ describe("PostOverview", () => {
         // Assert there is a badge that indicates a published translation
         const badge = await wrapper.findComponent(LBadge);
         expect(badge.props().variant).toBe("success");
+    });
+
+    it("displays a different translation title if the default isn't available", async () => {
+        const postStore = usePostStore();
+        const languageStore = useLanguageStore();
+
+        postStore.posts = [
+            {
+                ...mockPost,
+                content: [mockFrenchContent],
+            },
+        ];
+        languageStore.languages = [mockLanguageEng, mockLanguageFra];
+
+        const wrapper = mount(PostOverview, {
+            global: { stubs: { RouterLink: RouterLinkStub } },
+        });
+
+        expect(wrapper.html()).toContain("French translation title");
     });
 
     it("displays a badge for a post with local unsynced changes", async () => {

--- a/cms/src/pages/posts/PostOverview.spec.ts
+++ b/cms/src/pages/posts/PostOverview.spec.ts
@@ -9,7 +9,6 @@ import LBadge from "@/components/common/LBadge.vue";
 import { useLanguageStore } from "@/stores/language";
 import { setActivePinia } from "pinia";
 import { useLocalChangeStore } from "@/stores/localChanges";
-import { RouterLinkStub } from "@vue/test-utils";
 
 describe("PostOverview", () => {
     beforeEach(() => {
@@ -27,9 +26,7 @@ describe("PostOverview", () => {
         postStore.posts = [mockPost];
         languageStore.languages = [mockLanguageEng];
 
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         expect(wrapper.html()).toContain("English translation title");
 
@@ -50,9 +47,7 @@ describe("PostOverview", () => {
         ];
         languageStore.languages = [mockLanguageEng, mockLanguageFra];
 
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         expect(wrapper.html()).toContain("French translation title");
     });
@@ -67,9 +62,7 @@ describe("PostOverview", () => {
         // @ts-expect-error - Property is read-only but we are mocking it
         localChangeStore.isLocalChange = () => true;
 
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         // Assert there is a badge that indicates a post has unsynced local changes
         const badge = wrapper.findComponent(LBadge);
@@ -81,17 +74,13 @@ describe("PostOverview", () => {
         const store = usePostStore();
         store.posts = [];
 
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         expect(wrapper.findComponent(EmptyState).exists()).toBe(true);
     });
 
     it("doesn't display anything when the db is still loading", async () => {
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         expect(wrapper.find("button").exists()).toBe(false);
         expect(wrapper.findComponent(EmptyState).exists()).toBe(false);
@@ -106,9 +95,7 @@ describe("PostOverview", () => {
 
         postStore.posts = [post];
 
-        const wrapper = mount(PostOverview, {
-            global: { stubs: { RouterLink: RouterLinkStub } },
-        });
+        const wrapper = mount(PostOverview);
 
         expect(wrapper.html()).toContain("No translation");
     });

--- a/cms/src/pages/posts/PostOverview.vue
+++ b/cms/src/pages/posts/PostOverview.vue
@@ -6,7 +6,7 @@ import LButton from "@/components/button/LButton.vue";
 import { PlusIcon, PencilSquareIcon } from "@heroicons/vue/20/solid";
 import { usePostStore } from "@/stores/post";
 import LCard from "@/components/common/LCard.vue";
-import LTable from "@/components/common/LTable.vue";
+import LTable, { type SortDirection } from "@/components/common/LTable.vue";
 import { computed, ref } from "vue";
 import { ContentStatus, type Content, type Post, type Language } from "@/types";
 import { useLanguageStore } from "@/stores/language";
@@ -20,7 +20,7 @@ const { languages } = storeToRefs(useLanguageStore());
 const { isLocalChange } = useLocalChangeStore();
 
 const sortBy = ref("updatedTime");
-const sortDirection = ref("descending");
+const sortDirection = ref<SortDirection>("descending");
 const columns = [
     {
         text: "Title",

--- a/cms/src/pages/posts/PostOverview.vue
+++ b/cms/src/pages/posts/PostOverview.vue
@@ -19,8 +19,8 @@ const { posts } = storeToRefs(usePostStore());
 const { languages } = storeToRefs(useLanguageStore());
 const { isLocalChange } = useLocalChangeStore();
 
-const sortBy = ref(undefined);
-const sortDirection = ref(undefined);
+const sortBy = ref("updatedTime");
+const sortDirection = ref("descending");
 const columns = [
     {
         text: "Title",
@@ -46,7 +46,13 @@ const columns = [
     {
         text: "Last updated",
         key: "updatedTime",
-        sortable: false,
+        sortMethod: (a: Post, b: Post) => {
+            const firstItem = a.updatedTimeUtc;
+            const secondItem = b.updatedTimeUtc;
+            if (firstItem < secondItem) return sortDirection.value == "descending" ? 1 : -1;
+            if (firstItem > secondItem) return sortDirection.value == "descending" ? -1 : 1;
+            return 0;
+        },
     },
     {
         text: "",

--- a/cms/src/pages/posts/PostOverview.vue
+++ b/cms/src/pages/posts/PostOverview.vue
@@ -26,8 +26,8 @@ const columns = [
         text: "Title",
         key: "title",
         sortMethod: (a: Post, b: Post) => {
-            const firstItem = a.content[0].title;
-            const secondItem = b.content[0].title;
+            const firstItem = a.content[0]?.title;
+            const secondItem = b.content[0]?.title;
             if (firstItem < secondItem) return sortDirection.value == "descending" ? 1 : -1;
             if (firstItem > secondItem) return sortDirection.value == "descending" ? -1 : 1;
             return 0;

--- a/cms/src/stores/language.ts
+++ b/cms/src/stores/language.ts
@@ -4,13 +4,14 @@ import { liveQuery } from "dexie";
 import { useObservable } from "@vueuse/rxjs";
 import { type Ref } from "vue";
 import { LanguageRepository } from "@/db/repositories/languageRepository";
+import { sortByName } from "@/util/sortByName";
 
 export const useLanguageStore = defineStore("language", () => {
     const languageRepository = new LanguageRepository();
 
     const languages: Readonly<Ref<Language[] | undefined>> = useObservable(
         liveQuery(async () => {
-            return await languageRepository.getAll();
+            return (await languageRepository.getAll()).sort(sortByName);
         }) as any,
     );
 

--- a/cms/src/stores/language.ts
+++ b/cms/src/stores/language.ts
@@ -11,7 +11,7 @@ export const useLanguageStore = defineStore("language", () => {
 
     const languages: Readonly<Ref<Language[] | undefined>> = useObservable(
         liveQuery(async () => {
-            return (await languageRepository.getAll()).sort(sortByName);
+            return (await languageRepository.getAll())?.sort(sortByName);
         }) as any,
     );
 

--- a/cms/src/stores/post.spec.ts
+++ b/cms/src/stores/post.spec.ts
@@ -3,11 +3,28 @@ import { usePostStore } from "./post";
 import { setActivePinia, createPinia } from "pinia";
 import { liveQuery } from "dexie";
 import { PostRepository } from "@/db/repositories/postRepository";
-import { mockEnglishContent, mockLanguageEng, mockPost } from "@/tests/mockData";
+import { mockEnglishContent, mockLanguageEng, mockLanguageSwa, mockPost } from "@/tests/mockData";
+import { ContentRepository } from "@/db/repositories/contentRepository";
 
 vi.mock("@/db/repositories/postRepository");
 
-vi.mock("@/db/baseDatabase", () => ({}));
+const docsDb = vi.hoisted(() => {
+    return {
+        put: vi.fn(),
+        where: vi.fn().mockReturnThis(),
+        equals: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+    };
+});
+
+vi.mock("@/db/baseDatabase", () => {
+    return {
+        db: {
+            docs: docsDb,
+            localChanges: docsDb,
+        },
+    };
+});
 
 vi.mock("dexie", () => {
     return {
@@ -62,5 +79,18 @@ describe("post store", () => {
         store.updatePost(mockEnglishContent, mockPost);
 
         expect(createSpy).toHaveBeenCalledWith(mockEnglishContent, mockPost);
+    });
+
+    it("can create a translation", () => {
+        const createSpy = vi.spyOn(ContentRepository.prototype, "create");
+
+        const store = usePostStore();
+        store.createTranslation(mockPost, mockLanguageSwa);
+
+        expect(createSpy).toHaveBeenCalledWith({
+            parentId: mockPost._id,
+            language: mockLanguageSwa._id,
+            title: mockLanguageSwa.name,
+        });
     });
 });

--- a/cms/src/stores/post.ts
+++ b/cms/src/stores/post.ts
@@ -1,13 +1,15 @@
 import { defineStore } from "pinia";
-import { type Content, type CreatePostDto, type Post, type Uuid } from "@/types";
+import { type Content, type CreatePostDto, type Language, type Post, type Uuid } from "@/types";
 import { liveQuery } from "dexie";
 import { useObservable } from "@vueuse/rxjs";
 import { computed, type Ref } from "vue";
 import { PostRepository } from "@/db/repositories/postRepository";
 import type { Observable } from "rxjs";
+import { ContentRepository } from "@/db/repositories/contentRepository";
 
 export const usePostStore = defineStore("post", () => {
     const postRepository = new PostRepository();
+    const contentRepository = new ContentRepository();
 
     const posts: Readonly<Ref<Post[] | undefined>> = useObservable(
         liveQuery(async () => postRepository.getAll()) as unknown as Observable<Post[]>,
@@ -27,5 +29,13 @@ export const usePostStore = defineStore("post", () => {
         return postRepository.update(content, post);
     };
 
-    return { post, posts, createPost, updatePost };
+    const createTranslation = async (post: Post, language: Language) => {
+        return contentRepository.create({
+            parentId: post._id,
+            language: language._id,
+            title: language.name,
+        });
+    };
+
+    return { post, posts, createPost, updatePost, createTranslation };
 });

--- a/cms/src/tests/mockData.ts
+++ b/cms/src/tests/mockData.ts
@@ -127,7 +127,7 @@ export const mockFrenchContent: Content = {
     language: mockLanguageFra,
     status: ContentStatus.Draft,
     slug: "post1-fra",
-    title: "Post 1",
+    title: "French translation title",
     summary: "Ceci est un exemple de publication.",
     author: "ChatGPT",
     text: "Dans la paisible ville de Willowdale, la petite Lily pleurait la disparition de son cher chat, Whiskers. Cherchant frénétiquement dans le quartier, elle tomba sur le pompier Jake, réputé pour son cœur généreux. Avec un sourire rassurant, il promit de l'aider. Lily s'accrocha à l'espoir alors qu'ils parcouraient les rues ensemble. Sous un porche poussiéreux, ils trouvèrent Whiskers, effrayé mais sain et sauf. Des larmes de gratitude remplirent les yeux de Lily lorsque le pompier Jake lui remit le félin sauvé. Leur petite ville résonna de joie tandis que Lily serrait son ami à fourrure dans ses bras, et dès ce jour, le pompier Jake devint un héros dans son cœur et le gardien bien-aimé de la communauté.",

--- a/cms/src/tests/mockData.ts
+++ b/cms/src/tests/mockData.ts
@@ -75,6 +75,14 @@ export const mockLanguageFra: Language = {
     languageCode: "fra",
     name: "Français",
 };
+export const mockLanguageSwa: Language = {
+    _id: "lang-swa",
+    type: DocType.Language,
+    updatedTimeUtc: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
+    memberOf: [],
+    languageCode: "swa",
+    name: "Swahili",
+};
 
 export const mockLanguageDtoEng: LanguageDto = {
     _id: "lang-eng",
@@ -117,7 +125,7 @@ export const mockFrenchContent: Content = {
     updatedTimeUtc: DateTime.fromObject({ year: 2024, month: 1, day: 1 }),
     memberOf: [],
     language: mockLanguageFra,
-    status: ContentStatus.Published,
+    status: ContentStatus.Draft,
     slug: "post1-fra",
     title: "Post 1",
     summary: "Ceci est un exemple de publication.",

--- a/cms/src/util/sortByName.spec.ts
+++ b/cms/src/util/sortByName.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { sortByName } from "./sortByName";
+
+describe("sortByName", () => {
+    it("can sort an array by name", () => {
+        const array = [
+            {
+                id: 1,
+                name: "Z",
+            },
+            {
+                id: 2,
+                name: "A",
+            },
+            {
+                id: 3,
+                name: "B",
+            },
+        ];
+
+        const result = array.sort(sortByName);
+
+        expect(result).toEqual([
+            {
+                id: 2,
+                name: "A",
+            },
+            {
+                id: 3,
+                name: "B",
+            },
+            {
+                id: 1,
+                name: "Z",
+            },
+        ]);
+    });
+});

--- a/cms/src/util/sortByName.ts
+++ b/cms/src/util/sortByName.ts
@@ -1,0 +1,5 @@
+export function sortByName(a: any, b: any) {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+}

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -10,6 +10,7 @@ export default mergeConfig(
             environment: "jsdom",
             exclude: [...configDefaults.exclude, "e2e/*"],
             root: fileURLToPath(new URL("./", import.meta.url)),
+            setupFiles: ["vitest.setup.ts"],
         },
     }),
 );

--- a/cms/vitest.setup.ts
+++ b/cms/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { RouterLinkStub, config } from "@vue/test-utils";
+
+config.global.stubs["RouterLink"] = RouterLinkStub;


### PR DESCRIPTION
- Create new translation
- Re-render ContentForm on language change
- Always sort languages by name
- Add empty state to Edit post
- Always display default language if possible (hardcoded to English for now)