### PR TITLE
Clear revoked documents from CMS

### DIFF
--- a/api/src/changeRequests/processChangeRequest.ts
+++ b/api/src/changeRequests/processChangeRequest.ts
@@ -43,9 +43,13 @@ export async function processChangeRequest(
         if (upsertResult.changes.memberOf) {
             changeDoc.memberOf = upsertResult.changes.memberOf;
         }
-
         if (upsertResult.changes.acl) {
             changeDoc.acl = upsertResult.changes.acl;
+        }
+
+        // Apply the parentId of the included document to the change document
+        if (upsertResult.changes.parentId) {
+            changeDoc.parentId = upsertResult.changes.parentId;
         }
 
         return db.insertDoc(changeDoc);

--- a/api/src/changeRequests/processChangeRequest.ts
+++ b/api/src/changeRequests/processChangeRequest.ts
@@ -52,6 +52,11 @@ export async function processChangeRequest(
             changeDoc.parentId = upsertResult.changes.parentId;
         }
 
+        // Apply the language of the included document to the change document
+        if (upsertResult.changes.language) {
+            changeDoc.language = upsertResult.changes.language;
+        }
+
         return db.insertDoc(changeDoc);
     }
 

--- a/api/src/dto/ChangeDto.ts
+++ b/api/src/dto/ChangeDto.ts
@@ -38,6 +38,11 @@ export class ChangeDto extends _baseDto {
     @Expose()
     acl?: GroupAclEntryDto[];
 
+    @IsOptional()
+    @IsString()
+    @Expose()
+    parentId?: Uuid;
+
     @IsObject()
     @Expose()
     changes: any;

--- a/api/src/dto/ChangeDto.ts
+++ b/api/src/dto/ChangeDto.ts
@@ -43,6 +43,11 @@ export class ChangeDto extends _baseDto {
     @Expose()
     parentId?: Uuid;
 
+    @IsOptional()
+    @IsString()
+    @Expose()
+    language?: Uuid;
+
     @IsObject()
     @Expose()
     changes: any;

--- a/api/src/socketio.ts
+++ b/api/src/socketio.ts
@@ -225,7 +225,7 @@ export class Socketio implements OnGatewayInit {
         );
 
         // Get historical data from database for newly accessible groups
-        if (newAccessibleGroups.size > 0) {
+        if (Object.keys(newAccessibleGroups).length > 0) {
             this.db
                 .getDocsPerGroup(socket.data.userId, {
                     userAccess: newAccessibleGroups,

--- a/cms/src/db/baseDatabase.ts
+++ b/cms/src/db/baseDatabase.ts
@@ -9,8 +9,8 @@ export class BaseDatabase extends Dexie {
         super("luminary-db");
 
         // Remember to increase the version number below if you change the schema
-        this.version(2).stores({
-            docs: "_id, type, parentId, updatedTimeUtc, slug",
+        this.version(3).stores({
+            docs: "_id, type, parentId, updatedTimeUtc, slug, language, docType",
             localChanges: "++id, reqId, docId, status",
         });
     }

--- a/cms/src/db/repositories/baseRepository.ts
+++ b/cms/src/db/repositories/baseRepository.ts
@@ -37,7 +37,7 @@ export class BaseRepository {
                 (group) =>
                     (group.type === DocType.Group ||
                         (group.type === DocType.Change && group.docType === DocType.Group)) &&
-                    group.acl &&
+                    group.acl! &&
                     !group.acl.some(
                         (acl) =>
                             acl.type === DocType.Group &&

--- a/cms/src/db/repositories/baseRepository.ts
+++ b/cms/src/db/repositories/baseRepository.ts
@@ -51,7 +51,8 @@ export class BaseRepository {
         return db.docs.filter(
             (doc) =>
                 doc.memberOf !== undefined &&
-                (doc.type === docType || (doc.type == DocType.Change && doc.docType == docType)) &&
+                (doc.type === docType ||
+                    (doc.type === DocType.Change && doc.docType === docType)) &&
                 !doc.memberOf.some((groupId) => groupIds.includes(groupId)),
         );
     }

--- a/cms/src/db/repositories/baseRepository.ts
+++ b/cms/src/db/repositories/baseRepository.ts
@@ -19,6 +19,43 @@ export class BaseRepository {
         return db.docs.where("parentId").equals(parentId);
     }
 
+    whereParentIds(parentIds: Uuid[]) {
+        return db.docs.where("parentId").anyOf(parentIds);
+    }
+
+    whereLanguageIds(languageIds: Uuid[]) {
+        return db.docs.where("language").anyOf(languageIds);
+    }
+
+    /**
+     * Return a list of documents and change documents of specified DocType that are NOT members of the given groupIds
+     */
+    whereNotMemberOf(groupIds: Array<Uuid>, docType: DocType) {
+        // Query groups and group changeDocs
+        if (docType === DocType.Group) {
+            return db.docs.filter(
+                (group) =>
+                    (group.type === DocType.Group ||
+                        (group.type === DocType.Change && group.docType === DocType.Group)) &&
+                    group.acl &&
+                    !group.acl.some(
+                        (acl) =>
+                            acl.type === DocType.Group &&
+                            groupIds.includes(acl.groupId) &&
+                            acl.permission.some((p) => p === "view"),
+                    ),
+            );
+        }
+
+        // Query other documents
+        return db.docs.filter(
+            (doc) =>
+                doc.memberOf !== undefined &&
+                (doc.type === docType || (doc.type == DocType.Change && doc.docType == docType)) &&
+                !doc.memberOf.some((groupId) => groupIds.includes(groupId)),
+        );
+    }
+
     protected fromBaseDto<T extends BaseDocument>(dto: BaseDocumentDto) {
         const domainObject = dto as unknown as T;
 

--- a/cms/src/stores/deleteRevokedDocs.spec.ts
+++ b/cms/src/stores/deleteRevokedDocs.spec.ts
@@ -1,0 +1,276 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach, afterEach, vi, afterAll } from "vitest";
+import { useSocketConnectionStore } from "./socketConnection";
+import { AclPermission, DocType } from "@/types";
+import { db } from "@/db/baseDatabase";
+import waitForExpect from "wait-for-expect";
+import { createPinia, setActivePinia } from "pinia";
+
+const socketMocks = vi.hoisted(() => ({
+    emit: vi.fn(),
+    on: vi.fn(),
+}));
+
+vi.mock("@/socket", () => ({
+    getSocket: () => socketMocks,
+    setSocket: () => socketMocks,
+}));
+
+// Invoke the callback for socket.on() only for the passed event
+function listenToSocketOnEvent(allowedEvent: string | string[], returnValue?: any) {
+    if (typeof allowedEvent == "string") {
+        allowedEvent = [allowedEvent];
+    }
+    socketMocks.on = vi.fn().mockImplementation((socketEvent, callback) => {
+        if (allowedEvent.includes(socketEvent)) {
+            callback(returnValue);
+        }
+    });
+}
+
+describe("deleteRevokedDocs", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    afterEach(async () => {
+        vi.clearAllMocks();
+        await db.docs.clear();
+    });
+
+    afterAll(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("removes documents with memberOf field when access to a group is revoked", async () => {
+        // Insert documents into the local database with memberOf set to 'group-private-users'
+        const docs = [
+            {
+                _id: "doc1",
+                type: DocType.Post, // Test Post documents
+                memberOf: ["group-private-users"],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc2",
+                type: DocType.Tag, // Test Tag documents
+                memberOf: ["group-private-users"],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc3",
+                type: DocType.Content, // Test Content documents
+                parentId: "doc1",
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc4",
+                type: DocType.Change, // Test change documents of type Post
+                memberOf: ["group-private-users"],
+                docType: DocType.Post,
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc5",
+                type: DocType.Change, // Test change documents of type Content
+                docType: DocType.Content,
+                parentId: "doc2",
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc6",
+                type: DocType.Post,
+                memberOf: ["group-private-users", "group-public-users"], // This document should not be removed as it is also a member of 'group-public-users'
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc7",
+                type: DocType.Content,
+                parentId: "doc6", // This document should not be removed as it's parent is also a member of 'group-public-users'
+                updatedTimeUtc: 0,
+            },
+        ];
+        await db.docs.bulkPut(docs);
+
+        // Simulate receiving an accessMap update that only gives access to 'group-public-users'
+        const accessMap = {
+            "group-public-users": {
+                [DocType.Post]: {
+                    view: true,
+                    assign: true,
+                },
+            },
+        };
+
+        const store = useSocketConnectionStore();
+        listenToSocketOnEvent("accessMap", accessMap);
+        store.bindEvents();
+
+        await waitForExpect(async () => {
+            const remainingDocs = await db.docs.toArray();
+            expect(remainingDocs).toHaveLength(2);
+            expect(remainingDocs.find((doc) => doc._id === "doc6")).toBeDefined();
+            expect(remainingDocs.find((doc) => doc._id === "doc7")).toBeDefined();
+        });
+    });
+
+    it("removes content documents when access to the language document is revoked", async () => {
+        // Insert documents into the local database with memberOf set to 'group-private-users'
+        const docs = [
+            {
+                _id: "doc1",
+                type: DocType.Post, // Parent document - will not be removed as it is a member of 'group-public-users'
+                memberOf: ["group-public-users"],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc2",
+                type: DocType.Tag, // Parent document - will not be removed as it is a member of 'group-public-users'
+                memberOf: ["group-public-users"],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "doc3",
+                type: DocType.Content, // Test Content documents for Posts - should be removed as access to the language is revoked
+                parentId: "doc1",
+                updatedTimeUtc: 0,
+                language: "lang1",
+            },
+            {
+                _id: "doc4",
+                type: DocType.Content, // Test Content documents for Tags - should be removed as access to the language is revoked
+                parentId: "doc2",
+                updatedTimeUtc: 0,
+                language: "lang1",
+            },
+            {
+                _id: "doc5",
+                type: DocType.Content, // Test Content documents for Posts - should NOT be removed as access to the language is not revoked
+                parentId: "doc1",
+                updatedTimeUtc: 0,
+                language: "lang2",
+            },
+            {
+                _id: "doc6",
+                type: DocType.Change, // Test content Change docs - should be removed as access to the language is revoked
+                parentId: "doc1",
+                updatedTimeUtc: 0,
+                language: "lang1",
+            },
+            {
+                _id: "doc7",
+                type: DocType.Change, // Test content Change docs - should NOT be removed as access to the language NOT revoked
+                parentId: "doc1",
+                updatedTimeUtc: 0,
+                language: "lang2",
+            },
+            {
+                _id: "lang1",
+                type: DocType.Language, // Test Language document - will be removed as it is not a member of 'group-public-users'
+                memberOf: ["group-private-users"],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "lang2",
+                type: DocType.Language, // Test Language document - will not be removed as it is a member of 'group-public-users'
+                memberOf: ["group-public-users"],
+                updatedTimeUtc: 0,
+            },
+        ];
+        await db.docs.bulkPut(docs);
+
+        // Simulate receiving an accessMap update that only gives access to 'group-public-users'
+        const accessMap = {
+            "group-public-users": {
+                [DocType.Post]: {
+                    view: true,
+                    assign: true,
+                },
+                [DocType.Tag]: {
+                    view: true,
+                },
+                [DocType.Language]: {
+                    view: true,
+                },
+            },
+        };
+
+        const store = useSocketConnectionStore();
+        listenToSocketOnEvent("accessMap", accessMap);
+        store.bindEvents();
+
+        await waitForExpect(async () => {
+            const remainingDocs = await db.docs.toArray();
+            expect(remainingDocs).toHaveLength(5);
+            expect(remainingDocs.find((doc) => doc._id === "doc1")).toBeDefined();
+            expect(remainingDocs.find((doc) => doc._id === "doc2")).toBeDefined();
+            expect(remainingDocs.find((doc) => doc._id === "doc5")).toBeDefined();
+            expect(remainingDocs.find((doc) => doc._id === "doc7")).toBeDefined();
+            expect(remainingDocs.find((doc) => doc._id === "lang2")).toBeDefined();
+        });
+    });
+
+    it("removes documents with acl field when access to a group is revoked", async () => {
+        // Insert documents into the local database with memberOf set to 'group-private-users'
+        const docs = [
+            {
+                _id: "group1", // Should be removed as it is not a member of 'group-public-users'
+                type: DocType.Group,
+                acl: [
+                    {
+                        type: DocType.Group,
+                        groupId: "group-private-users",
+                        permission: [AclPermission.View],
+                    },
+                ],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "group2", // Should be kept as it is a member of 'group-public-users'
+                type: DocType.Group,
+                acl: [
+                    {
+                        type: DocType.Group,
+                        groupId: "group-public-users",
+                        permission: [AclPermission.View],
+                    },
+                ],
+                updatedTimeUtc: 0,
+            },
+            {
+                _id: "group3", // Should be removed as it is not a member of 'group-public-users'
+                type: DocType.Change,
+                docType: DocType.Group,
+                acl: [
+                    {
+                        type: DocType.Group,
+                        groupId: "group-private-users",
+                        permission: [AclPermission.View],
+                    },
+                ],
+                updatedTimeUtc: 0,
+            },
+        ];
+        await db.docs.bulkPut(docs);
+
+        // Simulate receiving an accessMap update that only gives access to 'group-public-users'
+        const accessMap = {
+            "group-public-users": {
+                [DocType.Group]: {
+                    view: true,
+                    assign: true,
+                },
+            },
+        };
+
+        const store = useSocketConnectionStore();
+        listenToSocketOnEvent("accessMap", accessMap);
+        store.bindEvents();
+
+        await waitForExpect(async () => {
+            const remainingDocs = await db.docs.toArray();
+            expect(remainingDocs).toHaveLength(1);
+            expect(remainingDocs.find((doc) => doc._id === "group2")).toBeDefined();
+        });
+    });
+});

--- a/cms/src/stores/deleteRevokedDocs.spec.ts
+++ b/cms/src/stores/deleteRevokedDocs.spec.ts
@@ -43,7 +43,6 @@ describe("deleteRevokedDocs", () => {
     });
 
     it("removes documents with memberOf field when access to a group is revoked", async () => {
-        // Insert documents into the local database with memberOf set to 'group-private-users'
         const docs = [
             {
                 _id: "doc1",
@@ -115,7 +114,6 @@ describe("deleteRevokedDocs", () => {
     });
 
     it("removes content documents when access to the language document is revoked", async () => {
-        // Insert documents into the local database with memberOf set to 'group-private-users'
         const docs = [
             {
                 _id: "doc1",
@@ -211,7 +209,6 @@ describe("deleteRevokedDocs", () => {
     });
 
     it("removes documents with acl field when access to a group is revoked", async () => {
-        // Insert documents into the local database with memberOf set to 'group-private-users'
         const docs = [
             {
                 _id: "group1", // Should be removed as it is not a member of 'group-public-users'

--- a/cms/src/stores/socketConnection.spec.ts
+++ b/cms/src/stores/socketConnection.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi, afterAll } from "vitest";
-import { useSocketConnectionStore } from "./socketConnection";
+import { useSocketConnectionStore, accessMapToGroups } from "./socketConnection";
 import { setActivePinia, createPinia } from "pinia";
 import { mockEnglishContentDto, mockPostDto } from "@/tests/mockData";
-import { type ChangeReqAckDto, AckStatus } from "@/types";
+import { type ChangeReqAckDto, AckStatus, type AccessMap, DocType, AclPermission } from "@/types";
 import { useLocalChangeStore } from "./localChanges";
 import { flushPromises } from "@vue/test-utils";
 
@@ -84,6 +84,7 @@ describe("socketConnection", () => {
         expect(socketMocks.emit).toHaveBeenCalledWith("clientDataReq", {
             version: Number.parseInt(lastUpdatedTime),
             cms: true,
+            accessMap: JSON.parse(localStorage.getItem("accessMap")!),
         });
     });
 
@@ -135,5 +136,20 @@ describe("socketConnection", () => {
         store.bindEvents();
 
         expect(handleAckSpy).toHaveBeenCalledWith(ack);
+    });
+
+    it("can convert an access map to groups per docType for a given permission", () => {
+        const accessMap: AccessMap = {
+            group1: {
+                [DocType.Post]: {
+                    view: true,
+                    assign: true,
+                },
+            },
+        };
+
+        const groups = accessMapToGroups(accessMap, AclPermission.View);
+
+        expect(groups[DocType.Post]).toEqual(["group1"]);
     });
 });

--- a/cms/src/stores/socketConnection.spec.ts
+++ b/cms/src/stores/socketConnection.spec.ts
@@ -15,7 +15,7 @@ vi.mock("@/socket", () => ({
     getSocket: () => socketMocks,
 }));
 
-// Invoke the callback for socket.on() only for the passed even
+// Invoke the callback for socket.on() only for the passed event
 function listenToSocketOnEvent(allowedEvent: string | string[], returnValue?: any) {
     if (typeof allowedEvent == "string") {
         allowedEvent = [allowedEvent];

--- a/cms/src/stores/socketConnection.ts
+++ b/cms/src/stores/socketConnection.ts
@@ -1,9 +1,18 @@
 import { defineStore } from "pinia";
 import { getSocket } from "@/socket";
-import { type ApiDataResponseDto, type ChangeReqAckDto } from "@/types";
+import {
+    DocType,
+    type ApiDataResponseDto,
+    type ChangeReqAckDto,
+    AclPermission,
+    type Uuid,
+    type AccessMap,
+    type DocGroupAccess,
+} from "@/types";
 import { db } from "@/db/baseDatabase";
 import { ref } from "vue";
 import { useLocalChangeStore } from "./localChanges";
+import { BaseRepository } from "@/db/repositories/baseRepository";
 
 export const useSocketConnectionStore = defineStore("socketConnection", () => {
     const isConnected = ref(false);
@@ -22,6 +31,7 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
             socket.emit("clientDataReq", {
                 version: syncVersion,
                 cms: true,
+                accessMap: JSON.parse(localStorage.getItem("accessMap")),
             });
         });
 
@@ -39,7 +49,68 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
 
             await localChangeStore.handleAck(ack);
         });
+
+        socket.on("accessMap", (accessMap: AccessMap) => {
+            // Delete revoked documents
+            // TODO: Only delete documents if the accessMap changed
+            const baseRepository = new BaseRepository();
+            const groupsPerDocType = accessMapToGroups(accessMap, AclPermission.View);
+
+            Object.values(DocType)
+                .filter((t) => !(t == DocType.Change || t == DocType.Content))
+                .forEach(async (docType) => {
+                    let groups = groupsPerDocType[docType as DocType];
+                    if (groups === undefined) groups = [];
+
+                    const revokedDocs = baseRepository.whereNotMemberOf(groups, docType as DocType);
+
+                    // Delete associated Post and Tag content documents
+                    if (docType === DocType.Post || docType === DocType.Tag) {
+                        const revokedParents = await revokedDocs.toArray();
+                        const revokedParentIds = revokedParents.map((p) => p._id);
+                        await baseRepository.whereParentIds(revokedParentIds).delete();
+                    }
+
+                    // Delete associated Language content documents
+                    if (docType === DocType.Language) {
+                        const revokedLanguages = await revokedDocs.toArray();
+                        const revokedlanguageIds = revokedLanguages.map((l) => l._id);
+                        await baseRepository.whereLanguageIds(revokedlanguageIds).delete();
+                    }
+
+                    await revokedDocs.delete();
+
+                    // TODO: Delete revoked groups
+                });
+
+            // Store the updated access map
+            localStorage.setItem("accessMap", JSON.stringify(accessMap));
+        });
     };
 
     return { isConnected, bindEvents };
 });
+
+/**
+ * Convert an access map to a list of accessible groups per document type for a given permission
+ */
+function accessMapToGroups(accessMap: AccessMap, permission: AclPermission): DocGroupAccess {
+    const groups: DocGroupAccess = {};
+
+    Object.keys(accessMap).forEach((groupId: Uuid) => {
+        Object.keys(accessMap[groupId as Uuid]).forEach((docType) => {
+            const docTypePermissions = accessMap[groupId as Uuid][docType as DocType];
+
+            if (!docTypePermissions) return;
+            Object.keys(docTypePermissions)
+                .filter((p) => p === permission)
+                .forEach((_permission) => {
+                    if (docTypePermissions[_permission as AclPermission]) {
+                        if (!groups[docType as DocType]) groups[docType as DocType] = [];
+                        groups[docType as DocType]?.push(groupId as Uuid);
+                    }
+                });
+        });
+    });
+    return groups;
+}

--- a/cms/src/stores/socketConnection.ts
+++ b/cms/src/stores/socketConnection.ts
@@ -31,7 +31,7 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
             socket.emit("clientDataReq", {
                 version: syncVersion,
                 cms: true,
-                accessMap: JSON.parse(localStorage.getItem("accessMap")),
+                accessMap: JSON.parse(localStorage.getItem("accessMap")!),
             });
         });
 
@@ -52,7 +52,8 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
 
         socket.on("accessMap", (accessMap: AccessMap) => {
             // Delete revoked documents
-            // TODO: Only delete documents if the accessMap changed
+
+            // TODO: Only delete documents if the accessMap changed for improved performance
             const baseRepository = new BaseRepository();
             const groupsPerDocType = accessMapToGroups(accessMap, AclPermission.View);
 
@@ -79,8 +80,6 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
                     }
 
                     await revokedDocs.delete();
-
-                    // TODO: Delete revoked groups
                 });
 
             // Store the updated access map
@@ -94,7 +93,7 @@ export const useSocketConnectionStore = defineStore("socketConnection", () => {
 /**
  * Convert an access map to a list of accessible groups per document type for a given permission
  */
-function accessMapToGroups(accessMap: AccessMap, permission: AclPermission): DocGroupAccess {
+export function accessMapToGroups(accessMap: AccessMap, permission: AclPermission): DocGroupAccess {
     const groups: DocGroupAccess = {};
 
     Object.keys(accessMap).forEach((groupId: Uuid) => {

--- a/cms/src/types/dto.ts
+++ b/cms/src/types/dto.ts
@@ -16,6 +16,7 @@ export type BaseDocumentDto = {
     _id: string;
     type: DocType;
     updatedTimeUtc: number;
+    memberOf?: Uuid[];
 };
 
 export type ContentBaseDto = BaseDocumentDto & {
@@ -77,3 +78,19 @@ export type ChangeReqAckDto = {
     message?: string;
     doc?: any;
 };
+
+export enum AclPermission {
+    View = "view",
+    Assign = "assign",
+    Edit = "edit",
+    Translate = "translate",
+    Publish = "publish",
+    Delete = "delete",
+}
+
+// export type AccessMap = Map<Uuid, Map<DocType, Map<AclPermission, boolean>>>;
+export type AccessMap = {
+    [a: Uuid]: { [b in DocType]?: { [c in AclPermission]?: boolean | undefined } };
+};
+
+export type DocGroupAccess = { [a in DocType]?: Uuid[] };

--- a/cms/src/types/dto.ts
+++ b/cms/src/types/dto.ts
@@ -22,7 +22,7 @@ export type BaseDocumentDto = {
 };
 
 export type GroupAclEntryDto = {
-    type: DocType.Group;
+    type: DocType;
     groupId: Uuid;
     permission: AclPermission[];
 };

--- a/cms/src/types/dto.ts
+++ b/cms/src/types/dto.ts
@@ -17,6 +17,14 @@ export type BaseDocumentDto = {
     type: DocType;
     updatedTimeUtc: number;
     memberOf?: Uuid[];
+    docType?: DocType;
+    acl?: GroupAclEntryDto[];
+};
+
+export type GroupAclEntryDto = {
+    type: DocType.Group;
+    groupId: Uuid;
+    permission: AclPermission[];
 };
 
 export type ContentBaseDto = BaseDocumentDto & {

--- a/cms/src/types/dto.ts
+++ b/cms/src/types/dto.ts
@@ -96,9 +96,8 @@ export enum AclPermission {
     Delete = "delete",
 }
 
-// export type AccessMap = Map<Uuid, Map<DocType, Map<AclPermission, boolean>>>;
 export type AccessMap = {
-    [a: Uuid]: { [b in DocType]?: { [c in AclPermission]?: boolean | undefined } };
+    [T: Uuid]: { [U in DocType]?: { [V in AclPermission]?: boolean | undefined } };
 };
 
 export type DocGroupAccess = { [a in DocType]?: Uuid[] };


### PR DESCRIPTION
- Remove revoked documents from the CMS IndexedDB upon receipt of an access map