### PR TITLE
Show notification when saving the content form & purging local cache

### DIFF
--- a/cms/src/App.vue
+++ b/cms/src/App.vue
@@ -11,6 +11,7 @@ import { useSocketConnectionStore } from "@/stores/socketConnection";
 import { useLocalChangeStore } from "@/stores/localChanges";
 import { getSocket, initSocket } from "@/socket";
 import MobileSideBar from "./components/navigation/MobileSideBar.vue";
+import NotificationManager from "./components/notifications/NotificationManager.vue";
 
 const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 const { appName } = useGlobalConfigStore();
@@ -77,4 +78,8 @@ const sidebarOpen = ref(false);
             <div class="flex items-center gap-2 text-lg"><LoadingSpinner /> Loading...</div>
         </div>
     </div>
+
+    <Teleport to="body">
+        <NotificationManager />
+    </Teleport>
 </template>

--- a/cms/src/components/notifications/LNotification.spec.ts
+++ b/cms/src/components/notifications/LNotification.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import LNotification from "./LNotification.vue";
+
+describe("LNotification", () => {
+    it("renders the title and description", () => {
+        const wrapper = mount(LNotification, {
+            props: { notification: { title: "Important News", description: "Read this." } },
+        });
+
+        expect(wrapper.text()).toContain("Important News");
+        expect(wrapper.text()).toContain("Read this.");
+    });
+
+    it("can be closed", async () => {
+        const wrapper = mount(LNotification, {
+            props: { notification: { title: "Important News", description: "Read this." } },
+        });
+
+        await wrapper.find("button").trigger("click");
+
+        expect(wrapper.findComponent(LNotification).isVisible()).toBe(false);
+    });
+});

--- a/cms/src/components/notifications/LNotification.vue
+++ b/cms/src/components/notifications/LNotification.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/vue/24/outline";
+import { XMarkIcon } from "@heroicons/vue/20/solid";
+import type { Notification } from "@/types";
+
+type Props = {
+    notification: Notification;
+};
+
+defineProps<Props>();
+
+const show = ref(true);
+</script>
+
+<template>
+    <div
+        v-if="show"
+        class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+    >
+        <div class="p-4">
+            <div class="flex items-start">
+                <div class="flex-shrink-0">
+                    <CheckCircleIcon
+                        class="h-6 w-6 text-green-400"
+                        aria-hidden="true"
+                        v-if="notification.state == 'success'"
+                    />
+                    <ExclamationCircleIcon
+                        class="h-6 w-6 text-red-400"
+                        aria-hidden="true"
+                        v-if="notification.state == 'error'"
+                    />
+                </div>
+                <div class="ml-3 w-0 flex-1 pt-0.5">
+                    <p class="text-sm font-medium text-gray-900">{{ notification.title }}</p>
+                    <p class="mt-1 text-sm text-gray-500">
+                        {{ notification.description }}
+                    </p>
+                </div>
+                <div class="ml-4 flex flex-shrink-0">
+                    <button
+                        type="button"
+                        @click="show = false"
+                        class="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                    >
+                        <span class="sr-only">Close</span>
+                        <XMarkIcon class="h-5 w-5" aria-hidden="true" />
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/cms/src/components/notifications/NotificationManager.spec.ts
+++ b/cms/src/components/notifications/NotificationManager.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import NotificationManager from "./NotificationManager.vue";
+import { createTestingPinia } from "@pinia/testing";
+import { setActivePinia } from "pinia";
+import { useNotificationStore } from "@/stores/notification";
+
+describe("NotificationManager", () => {
+    beforeEach(() => {
+        setActivePinia(createTestingPinia());
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders all notifications from the store", () => {
+        const notificationStore = useNotificationStore();
+        notificationStore.notifications = [{ title: "First" }, { title: "Second" }];
+        const wrapper = mount(NotificationManager);
+
+        expect(wrapper.text()).toContain("First");
+        expect(wrapper.text()).toContain("Second");
+    });
+});

--- a/cms/src/components/notifications/NotificationManager.vue
+++ b/cms/src/components/notifications/NotificationManager.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import LNotification from "./LNotification.vue";
+import { useNotificationStore } from "@/stores/notification";
+import { storeToRefs } from "pinia";
+
+const { notifications } = storeToRefs(useNotificationStore());
+</script>
+
+<template>
+    <div
+        aria-live="assertive"
+        class="pointer-events-none fixed inset-0 top-12 flex items-end px-4 py-6 sm:items-start sm:p-6"
+    >
+        <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+            <TransitionGroup
+                enter-active-class="transform ease-out duration-300 transition"
+                enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+                enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
+                leave-active-class="transition ease-in duration-100"
+                leave-from-class="opacity-100"
+                leave-to-class="opacity-0"
+            >
+                <LNotification
+                    v-for="notification in notifications"
+                    :key="notification.id"
+                    :notification
+                />
+            </TransitionGroup>
+        </div>
+    </div>
+</template>

--- a/cms/src/stores/notification.spec.ts
+++ b/cms/src/stores/notification.spec.ts
@@ -1,0 +1,41 @@
+import "fake-indexeddb/auto";
+import { describe, it, beforeEach, afterEach, vi, expect } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useNotificationStore } from "./notification";
+import waitForExpect from "wait-for-expect";
+
+describe("notification store", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("can add a notification", async () => {
+        const store = useNotificationStore();
+
+        store.addNotification({
+            title: "Test",
+        });
+
+        await waitForExpect(() => {
+            expect(store.notifications.length).toBe(1);
+        });
+    });
+
+    it("automatically deletes the previous notification", async () => {
+        const store = useNotificationStore();
+        store.notifications = [{ title: "Previous" }];
+
+        store.addNotification({
+            title: "New",
+        });
+
+        await waitForExpect(() => {
+            expect(store.notifications.length).toBe(1);
+            expect(store.notifications[0].title).toBe("New");
+        });
+    });
+});

--- a/cms/src/stores/notification.ts
+++ b/cms/src/stores/notification.ts
@@ -21,7 +21,7 @@ export const useNotificationStore = defineStore("notification", () => {
 
         setTimeout(() => {
             notifications.value = notifications.value.filter((n) => n.id != notificationId);
-        }, 1500);
+        }, 2000);
     };
 
     return { notifications, addNotification };

--- a/cms/src/stores/notification.ts
+++ b/cms/src/stores/notification.ts
@@ -1,0 +1,28 @@
+import { defineStore } from "pinia";
+import { type Notification } from "@/types";
+import { ref } from "vue";
+
+export const useNotificationStore = defineStore("notification", () => {
+    const id = ref(0);
+
+    const notifications = ref<Notification[]>([]);
+
+    const addNotification = (notification: Notification) => {
+        const notificationId = id.value++;
+
+        notifications.value = [];
+
+        setTimeout(() => {
+            notifications.value.push({
+                ...notification,
+                id: notificationId,
+            });
+        }, 100);
+
+        setTimeout(() => {
+            notifications.value = notifications.value.filter((n) => n.id != notificationId);
+        }, 1500);
+    };
+
+    return { notifications, addNotification };
+});

--- a/cms/src/stores/socketConnection.spec.ts
+++ b/cms/src/stores/socketConnection.spec.ts
@@ -88,6 +88,20 @@ describe("socketConnection", () => {
         });
     });
 
+    it("can reload the client data", async () => {
+        const store = useSocketConnectionStore();
+
+        store.bindEvents();
+        store.reloadClientData();
+
+        await flushPromises();
+
+        expect(socketMocks.emit).toHaveBeenCalledTimes(2); // First time on connect
+        expect(socketMocks.emit).toHaveBeenCalledWith("clientDataReq", {
+            cms: true,
+        });
+    });
+
     it("sets the state after disconnecting", () => {
         const store = useSocketConnectionStore();
         listenToSocketOnEvent("disconnect");

--- a/cms/src/types/cms.ts
+++ b/cms/src/types/cms.ts
@@ -120,3 +120,10 @@ export type LocalChange = {
     id: number;
     doc: BaseDocumentDto;
 };
+
+export type Notification = {
+    id?: number;
+    title: string;
+    description?: string;
+    state?: "success" | "error" | "info";
+};


### PR DESCRIPTION
Show success or error notification (+ add generic way of adding notifications).

Currently the previous notification will first be cleared before a new one is added to prevent the screen from being flooded with them.
