### PR TITLE
Include sourcemaps in build so Sentry can access them

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from "node:url";
-
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
@@ -17,5 +16,6 @@ export default defineConfig({
     },
     build: {
         target: "es2015",
+        sourcemap: true,
     },
 });

--- a/cms/vite.config.ts
+++ b/cms/vite.config.ts
@@ -15,4 +15,7 @@ export default defineConfig({
         port: 4175,
         strictPort: true,
     },
+    build: {
+        sourcemap: true,
+    },
 });


### PR DESCRIPTION
Opted to not use their plugin to upload the sourcemaps to their servers for now.

This does mean that the sourcemaps will be available to anyone but since our code is open source that doesn't seem to be a problem.
