### PR TITLE
Add 'muted' variant for button, to be used for icon buttons

### DIFF
--- a/cms/src/components/button/LButton.vue
+++ b/cms/src/components/button/LButton.vue
@@ -49,7 +49,7 @@ const buttonClasses = cva({
         {
             variant: "muted",
             size: "base",
-            class: "-mx-3 -py-2",
+            class: "-mx-3 -my-2",
         },
         {
             variant: "muted",

--- a/cms/src/components/button/LButton.vue
+++ b/cms/src/components/button/LButton.vue
@@ -13,6 +13,7 @@ const buttonClasses = cva({
                 "bg-white ring-1 shadow-sm text-zinc-900 ring-zinc-300 hover:bg-zinc-50 active:bg-zinc-100/70 disabled:bg-zinc-100 disabled:text-zinc-500",
             tertiary:
                 "bg-transparent text-zinc-900 hover:text-zinc-950 hover:bg-zinc-100 active:bg-zinc-200 disabled:text-zinc-500 disabled:hover:bg-transparent",
+            muted: "bg-transparent text-zinc-600 hover:text-zinc-700 active:text-zinc-800 hover:bg-zinc-100 active:bg-zinc-200 disabled:text-zinc-400 disabled:hover:bg-transparent",
         },
         size: {
             sm: "px-2 py-1.5",
@@ -39,6 +40,21 @@ const buttonClasses = cva({
             variant: "tertiary",
             context: "danger",
             class: "hover:text-red-600 active:text-red-700",
+        },
+        {
+            variant: "muted",
+            size: "sm",
+            class: "-mx-2 -my-1.5",
+        },
+        {
+            variant: "muted",
+            size: "base",
+            class: "-mx-3 -py-2",
+        },
+        {
+            variant: "muted",
+            size: "lg",
+            class: "-mx-3.5 -my-2.5",
         },
     ],
 });
@@ -68,6 +84,7 @@ const iconVariants = {
     primary: "text-zinc-100 group-hover:text-zinc-50 group-active:text-white",
     secondary: "text-zinc-800/80 group-hover:text-zinc-900/80 group-active:text-zinc-900/80",
     tertiary: "text-zinc-800/80 group-hover:text-zinc-900/80 group-active:text-zinc-900/80",
+    muted: "",
 };
 </script>
 

--- a/cms/src/components/groups/GroupEditor.vue
+++ b/cms/src/components/groups/GroupEditor.vue
@@ -410,7 +410,7 @@ const saveChanges = async () => {
                     </LBadge>
                     <LButton
                         v-if="groups && groups.length > 0 && open && !isDirty"
-                        variant="tertiary"
+                        variant="muted"
                         size="sm"
                         title="Duplicate"
                         :icon="DocumentDuplicateIcon"

--- a/cms/src/pages/internal/ComponentSandbox.vue
+++ b/cms/src/pages/internal/ComponentSandbox.vue
@@ -5,7 +5,12 @@ import LButton from "@/components/button/LButton.vue";
 import LInput from "@/components/forms/LInput.vue";
 import LTextarea from "@/components/forms/LTextarea.vue";
 import LSelect from "@/components/forms/LSelect.vue";
-import { EnvelopeIcon, PencilSquareIcon, PlusIcon } from "@heroicons/vue/20/solid";
+import {
+    DocumentDuplicateIcon,
+    EnvelopeIcon,
+    PencilSquareIcon,
+    PlusIcon,
+} from "@heroicons/vue/20/solid";
 import LCard from "@/components/common/LCard.vue";
 import LBadge from "@/components/common/LBadge.vue";
 import LTable from "@/components/common/LTable.vue";
@@ -288,6 +293,14 @@ const items = [
                     <LButton variant="primary" :icon="PencilSquareIcon">Edit</LButton>
                     <LButton variant="tertiary" :icon="PencilSquareIcon">Edit</LButton>
                     <LButton variant="tertiary" :icon="PencilSquareIcon"></LButton>
+                </div>
+                <div class="mt-6 space-x-4">
+                    <LButton size="sm">Save as draft</LButton>
+                    <LButton size="base">Save as draft</LButton>
+                    <LButton size="lg">Save as draft</LButton>
+                    <LButton variant="muted" :icon="DocumentDuplicateIcon" size="sm"></LButton>
+                    <LButton variant="muted" :icon="DocumentDuplicateIcon"></LButton>
+                    <LButton variant="muted" :icon="DocumentDuplicateIcon" size="lg"></LButton>
                 </div>
             </LCard>
         </div>


### PR DESCRIPTION
It also removes the padding by adding a negative margin (so there's still a background on hover), which makes it more suitable.

I was thinking if this should perhaps be a separate button, like `MutedIconButton` because it's intended to be specific, but I thought this could also make sense because you can take advantage of any other options like `danger`.