### PR TITLE
Update CMS:ContentOverview sort/filter/search user-interface

### DIFF
--- a/cms/src/components/BasePage.vue
+++ b/cms/src/components/BasePage.vue
@@ -11,12 +11,14 @@ type Props = {
     backLinkLocation?: RouteLocationRaw;
     backLinkText?: string;
     backLinkParams?: Record<string, string | undefined>;
+    isFullWidth?: boolean;
 };
 
 withDefaults(defineProps<Props>(), {
     loading: false,
     centered: false,
     backLinkText: "Back",
+    isFullWidth: false,
 });
 </script>
 
@@ -26,7 +28,7 @@ withDefaults(defineProps<Props>(), {
         enter-from-class="opacity-0"
         enter-to-class="opacity-100"
     >
-        <div v-if="!loading" class="mx-auto max-w-7xl">
+        <div v-if="!loading" :class="isFullWidth ? 'mx-0 w-full' : 'mx-auto max-w-7xl'">
             <RouterLink
                 v-if="backLinkLocation"
                 :to="backLinkLocation"

--- a/cms/src/components/content/ContentOverview.spec.ts
+++ b/cms/src/components/content/ContentOverview.spec.ts
@@ -136,7 +136,7 @@ describe("ContentOverview.vue", () => {
         await waitForExpect(() => {
             const contentTable = wrapper.findComponent(ContentTable);
 
-            expect(contentTable.props('queryOptions')).toMatchObject({ search: 'post 1'});
+            expect(contentTable.props("queryOptions")).toMatchObject({ search: "post 1" });
         });
     });
 
@@ -195,22 +195,22 @@ describe("ContentOverview.vue", () => {
             const contentTable = wrapper.findComponent(ContentTable);
 
             await sortOptionTitle.trigger("input");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderBy: 'title' });
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderBy: "title" });
 
             await sortOptionExpiryDate.trigger("input");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderBy: 'expiryDate' });
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderBy: "expiryDate" });
 
             await sortOptionPublishDate.trigger("input");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderBy: 'publishDate' });
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderBy: "publishDate" });
 
             await sortOptionLastUpdated.trigger("input");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderBy: 'updatedTimeUtc' });
-        
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderBy: "updatedTimeUtc" });
+
             await sortOptionAscending.trigger("click");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderDirection: 'asc' });
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderDirection: "asc" });
 
             await sortOptionDescending.trigger("click");
-            expect(contentTable.props('queryOptions')).toMatchObject({ orderDirection: 'desc' });
+            expect(contentTable.props("queryOptions")).toMatchObject({ orderDirection: "desc" });
         });
     });
 
@@ -249,16 +249,6 @@ describe("ContentOverview.vue", () => {
         });
 
         await waitForExpect(async () => {
-            const showFilterOptionsBtn = wrapper.find('[data-test="show-filter-options-btn"]');
-            expect(showFilterOptionsBtn.exists()).toBe(true);
-            await showFilterOptionsBtn.trigger("click");
-
-            const filterOptions = wrapper.find('[data-test="filter-options"]');
-            expect(filterOptions.exists()).toBe(true);
-
-            const filterInputLabels = wrapper.findAll('[data-test="filter-label"]');
-            expect(filterInputLabels.length).toBe(2);
-
             const filterInputSelects = wrapper.findAll('[data-test="filter-select"]');
             expect(filterInputSelects.length).toBe(2);
         });
@@ -274,34 +264,31 @@ describe("ContentOverview.vue", () => {
             },
         });
 
-        const showFilterOptionsBtn = wrapper.find('[data-test="show-filter-options-btn"]');
-        await showFilterOptionsBtn.trigger("click");
-
         const filterInputSelects = wrapper.findAll('[data-test="filter-select"]');
 
         await waitForExpect(async () => {
             const contentTable = wrapper.findComponent(ContentTable);
 
             await filterInputSelects[0].setValue("translated");
-            expect(contentTable.props('queryOptions').translationStatus).toBe("translated");
+            expect(contentTable.props("queryOptions").translationStatus).toBe("translated");
 
             await filterInputSelects[0].setValue("untranslated");
-            expect(contentTable.props('queryOptions').translationStatus).toBe("untranslated");
+            expect(contentTable.props("queryOptions").translationStatus).toBe("untranslated");
 
             await filterInputSelects[0].setValue("all");
-            expect(contentTable.props('queryOptions').translationStatus).toBe("all");
-            
+            expect(contentTable.props("queryOptions").translationStatus).toBe("all");
+
             await filterInputSelects[1].setValue("published");
-            expect(contentTable.props('queryOptions').publishStatus).toBe("published");
+            expect(contentTable.props("queryOptions").publishStatus).toBe("published");
 
             await filterInputSelects[1].setValue("scheduled");
-            expect(contentTable.props('queryOptions').publishStatus).toBe("scheduled");
+            expect(contentTable.props("queryOptions").publishStatus).toBe("scheduled");
 
             await filterInputSelects[1].setValue("expired");
-            expect(contentTable.props('queryOptions').publishStatus).toBe("expired");
+            expect(contentTable.props("queryOptions").publishStatus).toBe("expired");
 
             await filterInputSelects[1].setValue("draft");
-            expect(contentTable.props('queryOptions').publishStatus).toBe("draft");
+            expect(contentTable.props("queryOptions").publishStatus).toBe("draft");
         });
     });
 

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -172,11 +172,6 @@ onClickOutside(sortOptionsAsRef, () => {
     <BasePage :title="`${capitaliseFirstLetter(titleType)} overview`">
         <template #actions>
             <div class="flex gap-4">
-                <LButton
-                    data-test="show-filter-options-btn"
-                    @click="showFilterOptions = !showFilterOptions"
-                    :icon="FunnelIcon"
-                ></LButton>
                 <LSelect
                     v-model="selectedLanguage"
                     :options="languageOptions"
@@ -263,6 +258,11 @@ onClickOutside(sortOptionsAsRef, () => {
 
             <div>
                 <div class="relative flex h-full gap-1">
+                    <LButton
+                        data-test="show-filter-options-btn"
+                        @click="showFilterOptions = !showFilterOptions"
+                        :icon="FunnelIcon"
+                    ></LButton>
                     <LButton @click="() => (showSortOptions = true)" data-test="sort-toggle-btn">
                         <ArrowsUpDownIcon class="h-full w-4" />
                     </LButton>

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -50,14 +50,14 @@ const queryOptions = ref<ContentOverviewQueryOptions>({
     languageId: "",
     parentType: props.docType,
     tagType: tagType,
-    translationStatus: "translated",
+    translationStatus: "all",
     orderBy: "updatedTimeUtc",
     orderDirection: "desc",
     pageSize: 20,
     pageIndex: 0,
     tags: [],
     search: "",
-    publishStatus: "published",
+    publishStatus: "all",
 });
 
 const queryKey = computed(() => JSON.stringify(queryOptions.value));
@@ -88,8 +88,6 @@ if (!Object.entries(TagType).some((t) => t[1] == tagTypeString)) tagTypeString =
 
 const titleType = tagTypeString ? tagTypeString : props.docType;
 router.currentRoute.value.meta.title = `${capitaliseFirstLetter(titleType)} overview`;
-
-const showFilterOptions = ref(false);
 
 const filterByTranslation = ref(queryOptions.value.translationStatus);
 const filterByTranslationOptions = [
@@ -169,7 +167,7 @@ onClickOutside(sortOptionsAsRef, () => {
 </script>
 
 <template>
-    <BasePage :title="`${capitaliseFirstLetter(titleType)} overview`">
+    <BasePage :is-full-width="true" :title="`${capitaliseFirstLetter(titleType)} overview`">
         <template #actions>
             <div class="flex gap-4">
                 <LSelect
@@ -219,11 +217,11 @@ onClickOutside(sortOptionsAsRef, () => {
             :buttonPermission="canCreateNew"
             data-test="no-content"
         /> -->
-        <div class="flex h-max w-full gap-2 rounded-t-md bg-white p-2 shadow-lg">
+        <div class="flex h-max w-full gap-1 rounded-t-md bg-white p-2 shadow-lg">
             <LInput
                 type="text"
                 :icon="MagnifyingGlassIcon"
-                class="flex-grow"
+                class="mt-[2px] flex-grow"
                 name="search"
                 placeholder="Search..."
                 data-test="search-input"

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -217,7 +217,7 @@ onClickOutside(sortOptionsAsRef, () => {
             :buttonPermission="canCreateNew"
             data-test="no-content"
         /> -->
-        <div class="flex h-max w-full gap-1 rounded-t-md bg-white p-2 shadow-lg">
+        <div class="flex h-max w-full gap-2 rounded-t-md bg-white p-2 shadow-lg">
             <LInput
                 type="text"
                 :icon="MagnifyingGlassIcon"

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -226,6 +226,7 @@ onClickOutside(sortOptionsAsRef, () => {
                 placeholder="Search..."
                 data-test="search-input"
                 v-model="searchTerm"
+                :full-height="true"
             />
 
             <div class="h-full">

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -217,18 +217,18 @@ onClickOutside(sortOptionsAsRef, () => {
             :buttonPermission="canCreateNew"
             data-test="no-content"
         /> -->
-        <div class="flex h-max w-full gap-2 rounded-t-md bg-white p-2 shadow-lg">
+        <div class="flex w-full gap-1 rounded-t-md bg-white p-2 shadow-lg">
             <LInput
                 type="text"
                 :icon="MagnifyingGlassIcon"
-                class="mt-[2px] flex-grow"
+                class="flex-grow"
                 name="search"
                 placeholder="Search..."
                 data-test="search-input"
                 v-model="searchTerm"
             />
 
-            <div>
+            <div class="h-full">
                 <div class="relative flex h-full gap-1">
                     <LSelect
                         data-test="filter-select"

--- a/cms/src/components/content/ContentOverview.vue
+++ b/cms/src/components/content/ContentOverview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import BasePage from "@/components/BasePage.vue";
 import LButton from "@/components/button/LButton.vue";
-import { PlusIcon, FunnelIcon } from "@heroicons/vue/20/solid";
+import { PlusIcon, LanguageIcon, CloudArrowUpIcon } from "@heroicons/vue/20/solid";
 import { RouterLink } from "vue-router";
 import {
     ArrowsUpDownIcon,
@@ -50,14 +50,14 @@ const queryOptions = ref<ContentOverviewQueryOptions>({
     languageId: "",
     parentType: props.docType,
     tagType: tagType,
-    translationStatus: "all",
+    translationStatus: "translated",
     orderBy: "updatedTimeUtc",
     orderDirection: "desc",
     pageSize: 20,
     pageIndex: 0,
     tags: [],
     search: "",
-    publishStatus: "all",
+    publishStatus: "published",
 });
 
 const queryKey = computed(() => JSON.stringify(queryOptions.value));
@@ -197,32 +197,6 @@ onClickOutside(sortOptionsAsRef, () => {
                 </LButton>
             </div>
         </template>
-        <div
-            data-test="filter-options"
-            class="my-2 h-max rounded-md bg-white p-4 shadow-md"
-            v-if="showFilterOptions"
-        >
-            <div class="flex gap-5">
-                <label class="inline-flex items-center gap-1 text-sm" data-test="filter-label"
-                    >Translation
-                    <LSelect
-                        data-test="filter-select"
-                        v-model="filterByTranslation"
-                        :options="filterByTranslationOptions"
-                    />
-                </label>
-
-                <label class="inline-flex items-center gap-1 text-sm" data-test="filter-label">
-                    Status
-                    <LSelect
-                        data-test="filter-select"
-                        v-model="filterByStatus"
-                        :options="filterByStatusOptions"
-                    />
-                </label>
-            </div>
-        </div>
-
         <!-- TODO: Move empty state to ContentTable as the ContentOverview does not anymore know if there are content documents or not -->
         <!-- <EmptyState
             v-if="!contentParents || contentParents.length == 0"
@@ -258,11 +232,18 @@ onClickOutside(sortOptionsAsRef, () => {
 
             <div>
                 <div class="relative flex h-full gap-1">
-                    <LButton
-                        data-test="show-filter-options-btn"
-                        @click="showFilterOptions = !showFilterOptions"
-                        :icon="FunnelIcon"
-                    ></LButton>
+                    <LSelect
+                        data-test="filter-select"
+                        v-model="filterByTranslation"
+                        :options="filterByTranslationOptions"
+                        :icon="LanguageIcon"
+                    />
+                    <LSelect
+                        data-test="filter-select"
+                        v-model="filterByStatus"
+                        :options="filterByStatusOptions"
+                        :icon="CloudArrowUpIcon"
+                    />
                     <LButton @click="() => (showSortOptions = true)" data-test="sort-toggle-btn">
                         <ArrowsUpDownIcon class="h-full w-4" />
                     </LButton>

--- a/cms/src/components/forms/LInput.vue
+++ b/cms/src/components/forms/LInput.vue
@@ -89,7 +89,7 @@ const { attrsWithoutStyles } = useAttrsWithoutStyles();
         <FormLabel v-if="label" :for="id" :required="required" class="mb-2">
             {{ label }}
         </FormLabel>
-        <div class="relative flex rounded-md shadow-sm">
+        <div class="relative flex h-full rounded-md shadow-sm">
             <div
                 v-if="icon"
                 class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"

--- a/cms/src/components/forms/LInput.vue
+++ b/cms/src/components/forms/LInput.vue
@@ -24,6 +24,7 @@ type Props = {
     required?: boolean;
     disabled?: boolean;
     icon?: Component | Function;
+    fullHeight?: boolean;
     leftAddOn?: string;
     rightAddOn?: string;
 };
@@ -33,6 +34,7 @@ const props = withDefaults(defineProps<Props>(), {
     size: "base",
     required: false,
     disabled: false,
+    fullHeight: false,
 });
 
 // Expose the focus method to parent components.
@@ -89,7 +91,7 @@ const { attrsWithoutStyles } = useAttrsWithoutStyles();
         <FormLabel v-if="label" :for="id" :required="required" class="mb-2">
             {{ label }}
         </FormLabel>
-        <div class="relative flex rounded-md shadow-sm">
+        <div class="relative flex rounded-md shadow-sm" :class="fullHeight ? 'h-full' : ''">
             <div
                 v-if="icon"
                 class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"

--- a/cms/src/components/forms/LInput.vue
+++ b/cms/src/components/forms/LInput.vue
@@ -89,7 +89,7 @@ const { attrsWithoutStyles } = useAttrsWithoutStyles();
         <FormLabel v-if="label" :for="id" :required="required" class="mb-2">
             {{ label }}
         </FormLabel>
-        <div class="relative flex h-full rounded-md shadow-sm">
+        <div class="relative flex rounded-md shadow-sm">
             <div
                 v-if="icon"
                 class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"

--- a/cms/src/components/forms/LSelect.vue
+++ b/cms/src/components/forms/LSelect.vue
@@ -61,8 +61,8 @@ const { attrsWithoutStyles } = useAttrsWithoutStyles();
             </div>
             <select
                 v-model="model"
-                class="block w-full justify-items-center rounded-md border-0 px-3 py-2 pl-10 pr-10 text-sm font-semibold text-zinc-900 shadow-sm ring-1 ring-inset hover:bg-zinc-50 focus:ring-2 disabled:bg-zinc-100 disabled:text-zinc-500 disabled:ring-zinc-200 sm:text-sm sm:leading-6"
-                :class="states[state]"
+                class="block h-full w-full justify-items-center rounded-md border-0 text-sm font-semibold text-zinc-900 shadow-sm ring-1 ring-inset hover:bg-zinc-50 focus:ring-2 disabled:bg-zinc-100 disabled:text-zinc-500 disabled:ring-zinc-200 sm:text-sm sm:leading-6"
+                :class="[states[state], icon ? 'px-3 py-2 pl-10 pr-10' : '']"
                 :id="id"
                 :disabled="disabled"
                 :required="required"

--- a/cms/src/components/forms/LSelect.vue
+++ b/cms/src/components/forms/LSelect.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { type StyleValue } from "vue";
+import { type Component, type StyleValue } from "vue";
 import { useAttrsWithoutStyles } from "@/composables/attrsWithoutStyles";
 import { useId } from "@/util/useId";
 import FormLabel from "./FormLabel.vue";
@@ -20,6 +20,7 @@ type Props = {
     disabled?: boolean;
     label?: string;
     required?: boolean;
+    icon?: Component | Function;
 };
 
 withDefaults(defineProps<Props>(), {
@@ -46,25 +47,38 @@ const { attrsWithoutStyles } = useAttrsWithoutStyles();
         <FormLabel :for="id" class="block text-sm font-medium leading-6 text-zinc-900">
             {{ label }}
         </FormLabel>
-        <select
-            v-model="model"
-            class="block w-full justify-items-center rounded-md border-0 px-3 py-2 pr-10 text-sm font-semibold text-zinc-900 shadow-sm ring-1 ring-inset hover:bg-zinc-50 focus:ring-2 disabled:bg-zinc-100 disabled:text-zinc-500 disabled:ring-zinc-200 sm:text-sm sm:leading-6"
-            :class="states[state]"
-            :id="id"
-            :disabled="disabled"
-            :required="required"
-            v-bind="attrsWithoutStyles"
-        >
-            <option
-                v-for="(option, key) in options"
-                :key="key"
-                :value="option.value"
-                :disabled="option.disabled"
-                class="flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm text-zinc-700"
+        <div class="relative">
+            <div v-if="icon" class="absolute inset-y-0 left-0 flex items-center pl-3">
+                <component
+                    :is="icon"
+                    :class="{
+                        'text-zinc-400': state == 'default' && !disabled,
+                        'text-zinc-300': state == 'default' && disabled,
+                        'text-red-400': state == 'error',
+                    }"
+                    class="h-5 w-5"
+                />
+            </div>
+            <select
+                v-model="model"
+                class="block w-full justify-items-center rounded-md border-0 px-3 py-2 pl-10 pr-10 text-sm font-semibold text-zinc-900 shadow-sm ring-1 ring-inset hover:bg-zinc-50 focus:ring-2 disabled:bg-zinc-100 disabled:text-zinc-500 disabled:ring-zinc-200 sm:text-sm sm:leading-6"
+                :class="states[state]"
+                :id="id"
+                :disabled="disabled"
+                :required="required"
+                v-bind="attrsWithoutStyles"
             >
-                {{ option.label }}
-            </option>
-        </select>
+                <option
+                    class="flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm text-zinc-700"
+                    v-for="(option, key) in options"
+                    :key="key"
+                    :value="option.value"
+                    :disabled="option.disabled"
+                >
+                    {{ option.label }}
+                </option>
+            </select>
+        </div>
         <FormMessage v-if="$slots.default" :state="state" :id="`${id}-message`">
             <slot />
         </FormMessage>


### PR DESCRIPTION
This PR is to make the changes to the search/sort/search user-interface inside of ContentOverview, to make it look better and make it a better user experience.
Referencing updates from discussions on CMS: Add filtering/searching/sorting to content overview #288 
Todo:

- [x] Add tests for new look
- [x] Remove old tests that are no longer valid
- [x] Review new look