### PR TITLE
CMS: Review defineModel usage

### DIFF
--- a/cms/src/components/groups/EditAclByGroup.vue
+++ b/cms/src/components/groups/EditAclByGroup.vue
@@ -82,6 +82,8 @@ const duplicateGroup = (targetGroup: GroupDto) => {
                     </tr>
                 </thead>
                 <tbody>
+                    <!-- :aclEntry is a defineModel in EditAclEntry.
+                    Using "v-model:aclEntry" causes the error: "eslint: 'v-model' directives cannot update the iteration variable 'aclEntry' itself." -->
                     <EditAclEntry
                         v-for="aclEntry in group?.acl
                             .filter(

--- a/cms/src/components/groups/EditGroup.vue
+++ b/cms/src/components/groups/EditGroup.vue
@@ -458,7 +458,7 @@ const saveChanges = async () => {
                         <EditAclByGroup
                             v-for="assignedGroup in assignedGroups"
                             :key="assignedGroup._id"
-                            :group="editable"
+                            v-model:group="editable"
                             :assignedGroup="assignedGroup"
                             :originalGroup="group"
                             :availableGroups="availableGroups"


### PR DESCRIPTION
I have found 2 places where defineModel is not used exactly as the patterns given by the Vue documentation. I have commented a reason on why editAclEntry's model is not used with the same pattern. I have added the correct pattern to editAclByGroup, but not sure if this will cause the group permission mapper in the cms to stop working and not sure how to check this, I tried using the Vue-Devtools but things stayed the same. 