### PR TITLE
Add inline notifaction for too large file uploads

### DIFF
--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -16,8 +16,6 @@ import {
     type TagDto,
 } from "luminary-shared";
 
-const { addNotification } = useNotificationStore();
-
 type Props = {
     disabled: boolean;
 };

--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -16,7 +16,7 @@ import {
     type TagDto,
 } from "luminary-shared";
 
-const { notifications, addNotification } = useNotificationStore();
+const { addNotification } = useNotificationStore();
 
 type Props = {
     disabled: boolean;

--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -7,7 +7,6 @@ import {
     QuestionMarkCircleIcon,
 } from "@heroicons/vue/24/outline";
 import ImageEditorThumbnail from "./ImageEditorThumbnail.vue";
-import { useNotificationStore } from "@/stores/notification";
 import {
     type ImageUploadDto,
     type ImageFileCollectionDto,

--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -24,7 +24,6 @@ type Props = {
 defineProps<Props>();
 
 const parent = defineModel<PostDto | TagDto>("parent");
-maxUploadFileSize.value = 250000;
 const maxUploadFileSizeMb = computed(() => maxUploadFileSize.value / 1000000);
 
 // HTML element refs
@@ -50,11 +49,6 @@ const handleFiles = (files: FileList | null) => {
             const fileData = e.target!.result as ArrayBuffer;
 
             if (fileData.byteLength > maxUploadFileSize.value) {
-                addNotification({
-                    title: `Invalid image file size`,
-                    description: `Image file size is larger than the maximum allowed size of ${maxUploadFileSizeMb.value}MB`,
-                    state: "error",
-                });
                 failureMessage.value = `Image file size is larger than the maximum allowed size of ${maxUploadFileSizeMb.value}MB`;
                 return;
             }


### PR DESCRIPTION
The `maxFileUploadSize` has been **set to 0.25mb** as I saw that _in socketIo it defaults to 0_, not sure if that value should have a default value other than 0? When the user tries to upload an image that is too large, it displays an exclamationcircle, this can either be hovered on, or clicked to display the error message. As soon as the user uploads an image that is the correct size, it disappears.