### PR TITLE
Solve some security warnings using npm audit fix

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2358,10 +2358,11 @@
             }
         },
         "node_modules/@nestjs/core": {
-            "version": "10.4.4",
-            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.4.tgz",
-            "integrity": "sha512-y9tjmAzU6LTh1cC/lWrRsCcOd80khSR0qAHAqwY2svbW+AhsR/XCzgpZrAAKJrm/dDfjLCZKyxJSayeirGcW5Q==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.5.tgz",
+            "integrity": "sha512-wk0KJ+6tuidqAdeemsQ40BCp1BgMsSuSLG577aqXLxXYoa8FQYPrdxoSzd05znYLwJYM55fisZWb3FLF9HT2qw==",
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "@nuxtjs/opencollective": "0.3.2",
                 "fast-safe-stringify": "2.1.1",
@@ -2412,13 +2413,14 @@
             }
         },
         "node_modules/@nestjs/platform-express": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.3.tgz",
-            "integrity": "sha512-ss7gkofVm3eO+1P9iRhmGq6Xcjg+mIN3dWisKJZYelSV+msb0QpJmqChLvWjLkWtlqDnx915FKUk0IzCa0TVzw==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.5.tgz",
+            "integrity": "sha512-a629r8R8KC4skhdieQ0aIWH5vDBUFntWnWKFyDXQrll6/CllSchfWm87mWF39seaW6bXYtQtAEZY66JrngdrGA==",
+            "license": "MIT",
             "dependencies": {
                 "body-parser": "1.20.3",
                 "cors": "2.8.5",
-                "express": "4.21.0",
+                "express": "4.21.1",
                 "multer": "1.4.4-lts.1",
                 "tslib": "2.7.0"
             },
@@ -2437,12 +2439,13 @@
             "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         },
         "node_modules/@nestjs/platform-socket.io": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.3.1.tgz",
-            "integrity": "sha512-ClGIQyGre7D8XBkOAsT/imDaLWpEfQFELnhZcZiIRI5T/p9mfVFrhvzK4srSFivmUqIQbIFGT1doOTNrkSU59Q==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.4.5.tgz",
+            "integrity": "sha512-dHkHJQArhrpkX6qBdTW2ghuja3i3cCslwy4QHY6d46u+9UyANQlsNK9wt/lZnmXfCMaci8xAJvUpyODa6YtV7g==",
+            "license": "MIT",
             "dependencies": {
-                "socket.io": "4.7.4",
-                "tslib": "2.6.2"
+                "socket.io": "4.7.5",
+                "tslib": "2.7.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2453,6 +2456,12 @@
                 "@nestjs/websockets": "^10.0.0",
                 "rxjs": "^7.1.0"
             }
+        },
+        "node_modules/@nestjs/platform-socket.io/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
         },
         "node_modules/@nestjs/schematics": {
             "version": "10.1.0",
@@ -2471,12 +2480,13 @@
             }
         },
         "node_modules/@nestjs/testing": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.0.tgz",
-            "integrity": "sha512-8DM+bw1qASCvaEnoHUQhypCOf54+G5R21MeFBMvnSk5DtKaWVZuzDP2GjLeYCpTH19WeP6LrrjHv3rX2LKU02A==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.5.tgz",
+            "integrity": "sha512-3NhmztE+fK3MuuOZhXihvMIhxm0QuDM2BneHvM5A0oVLG+STsAeGBqbDr/Ef2qsvqH5HaqvfGbVJ4N1DQnZE5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tslib": "2.6.2"
+                "tslib": "2.7.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2497,20 +2507,28 @@
                 }
             }
         },
+        "node_modules/@nestjs/testing/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/@nestjs/websockets": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.3.1.tgz",
-            "integrity": "sha512-4GckGRWQ6Ce0YnIoAysQof5a+/TZruLjbD8YHzWSbhykX33EJbK4mKYWSiL3pEI6w0RhwlpMU1cW7cFxV/gyjQ==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.5.tgz",
+            "integrity": "sha512-LbL/HRLWQUBTUPY7swojOHdvokyVGINIiuP/VmRdhob4T751r+9i09z2RqRpP71psuom9mnRHYI1+vT2FABrAw==",
+            "license": "MIT",
             "dependencies": {
                 "iterare": "1.2.1",
                 "object-hash": "3.0.0",
-                "tslib": "2.6.2"
+                "tslib": "2.7.0"
             },
             "peerDependencies": {
                 "@nestjs/common": "^10.0.0",
                 "@nestjs/core": "^10.0.0",
                 "@nestjs/platform-socket.io": "^10.0.0",
-                "reflect-metadata": "^0.1.12",
+                "reflect-metadata": "^0.1.12 || ^0.2.0",
                 "rxjs": "^7.1.0"
             },
             "peerDependenciesMeta": {
@@ -2518,6 +2536,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@nestjs/websockets/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2698,7 +2722,8 @@
         "node_modules/@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "license": "MIT"
         },
         "node_modules/@types/cookiejar": {
             "version": "2.1.5",
@@ -2710,6 +2735,7 @@
             "version": "2.8.17",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
             "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -3300,6 +3326,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-types": "~2.1.34",
                 "negotiator": "0.6.3"
@@ -3485,7 +3512,8 @@
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+            "license": "MIT"
         },
         "node_modules/array-timsort": {
             "version": "1.0.3",
@@ -3689,6 +3717,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "license": "MIT",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
             }
@@ -3752,6 +3781,7 @@
             "version": "1.20.3",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
             "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -3775,6 +3805,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -3782,7 +3813,8 @@
         "node_modules/body-parser/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
@@ -3920,6 +3952,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4325,6 +4358,7 @@
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
             "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "5.2.1"
             },
@@ -4336,6 +4370,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4347,9 +4382,10 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4357,7 +4393,8 @@
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "license": "MIT"
         },
         "node_modules/cookiejar": {
             "version": "2.1.4",
@@ -4542,6 +4579,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4550,6 +4588,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -4676,7 +4715,8 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.629",
@@ -4710,6 +4750,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4718,6 +4759,7 @@
             "version": "6.5.5",
             "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
             "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
@@ -4759,6 +4801,7 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
             "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4822,7 +4865,8 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -5051,6 +5095,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5124,16 +5169,17 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+            "version": "4.21.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.6.0",
+                "cookie": "0.7.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -5168,6 +5214,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -5175,12 +5222,14 @@
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/express/node_modules/path-to-regexp": {
             "version": "0.1.10",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+            "license": "MIT"
         },
         "node_modules/external-editor": {
             "version": "3.1.0",
@@ -5339,6 +5388,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
             "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "encodeurl": "~2.0.0",
@@ -5356,6 +5406,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -5363,7 +5414,8 @@
         "node_modules/finalhandler/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -5589,6 +5641,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5597,6 +5650,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5916,6 +5970,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -6065,6 +6120,7 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -7392,6 +7448,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
             "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -7449,6 +7506,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -7611,6 +7669,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -7730,6 +7789,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -7898,6 +7958,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8153,6 +8214,7 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
             "dependencies": {
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
@@ -8255,6 +8317,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -8263,6 +8326,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
             "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -8579,6 +8643,7 @@
             "version": "0.19.0",
             "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
             "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -8602,6 +8667,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -8609,12 +8675,14 @@
         "node_modules/send/node_modules/debug/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/send/node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8622,7 +8690,8 @@
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
@@ -8637,6 +8706,7 @@
             "version": "1.16.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
             "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
@@ -8666,7 +8736,8 @@
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/sharp": {
             "version": "0.33.3",
@@ -8787,9 +8858,10 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.4.tgz",
-            "integrity": "sha512-DcotgfP1Zg9iP/dH9zvAQcWrE0TtbMVwXmlV4T4mqsvY+gw+LqUGPfx2AoVyRk0FLME+GQhufDMyacFmw7ksqw==",
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+            "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
@@ -8807,6 +8879,7 @@
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
             "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "~4.3.4",
                 "ws": "~8.17.1"
@@ -8914,6 +8987,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -9374,6 +9448,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
@@ -9667,6 +9742,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -9731,6 +9807,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
             }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -60,6 +60,48 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
+        "../shared": {
+            "name": "luminary-shared",
+            "version": "0.0.3",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@vueuse/core": "^10.11.0",
+                "@vueuse/rxjs": "^10.7.2",
+                "dexie": "^3.2.7",
+                "luxon": "^3.4.4",
+                "rxjs": "^7.8.1",
+                "socket.io-client": "^4.7.5",
+                "uuid": "^9.0.1",
+                "vue": "^3.3.11"
+            },
+            "devDependencies": {
+                "@rushstack/eslint-patch": "^1.3.3",
+                "@tsconfig/node18": "^18.2.4",
+                "@types/jsdom": "^21.1.7",
+                "@types/luxon": "^3.4.2",
+                "@types/node": "^18.19.3",
+                "@types/rollup-plugin-auto-external": "^2.0.5",
+                "@types/uuid": "^9.0.8",
+                "@vitejs/plugin-vue": "^5.0.4",
+                "@vue/eslint-config-prettier": "^8.0.0",
+                "@vue/eslint-config-typescript": "^12.0.0",
+                "@vue/test-utils": "^2.4.6",
+                "@vue/tsconfig": "^0.5.0",
+                "eslint": "^8.49.0",
+                "eslint-plugin-vue": "^9.17.0",
+                "fake-indexeddb": "^6.0.0",
+                "jsdom": "^24.1.0",
+                "prettier": "^3.0.3",
+                "rollup-plugin-auto-external": "^2.0.0",
+                "socket.io": "^4.7.5",
+                "typescript": "~5.3.0",
+                "vite": "^5.2.0",
+                "vite-plugin-dts": "^3.9.1",
+                "vitest": "^1.6.0",
+                "vue-tsc": "^1.8.25",
+                "wait-for-expect": "^3.0.2"
+            }
+        },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -1368,83 +1410,89 @@
             "dev": true
         },
         "node_modules/@sentry-internal/feedback": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
-            "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+            "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry-internal/replay-canvas": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
-            "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+            "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/replay": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/replay": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry-internal/tracing": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
-            "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+            "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/browser": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
-            "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+            "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry-internal/feedback": "7.118.0",
-                "@sentry-internal/replay-canvas": "7.118.0",
-                "@sentry-internal/tracing": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/integrations": "7.118.0",
-                "@sentry/replay": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry-internal/feedback": "7.119.2",
+                "@sentry-internal/replay-canvas": "7.119.2",
+                "@sentry-internal/tracing": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/integrations": "7.119.2",
+                "@sentry/replay": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
-            "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+            "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/integrations": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
-            "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+            "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2",
                 "localforage": "^1.8.1"
             },
             "engines": {
@@ -1452,47 +1500,51 @@
             }
         },
         "node_modules/@sentry/replay": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
-            "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+            "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry-internal/tracing": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry-internal/tracing": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry/types": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
-            "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+            "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/utils": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
-            "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+            "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/types": "7.118.0"
+                "@sentry/types": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/vue": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.118.0.tgz",
-            "integrity": "sha512-k77NHzelR3oyDx6LFr0nvg+IKwGTjawaE36Xz2OuWivhJtqJyWKRqjDUhecsLTjZOx6zdoEsdwnRjjMF//xGMA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.119.2.tgz",
+            "integrity": "sha512-GwBMpi8jnfeg4LPKEvXpwdILqn7RylxQLjpEb5xz/FKwOSL2P0gU2ysAb3WFuelC6NgspLOUpjmTqGWRemD39w==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/browser": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
@@ -1506,12 +1558,6 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
             "dev": true
-        },
-        "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "license": "MIT"
         },
         "node_modules/@tailwindcss/typography": {
             "version": "0.5.13",
@@ -2564,60 +2610,6 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@vueuse/rxjs": {
-            "version": "10.11.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/rxjs/-/rxjs-10.11.1.tgz",
-            "integrity": "sha512-e0Bvw8fbe0u/p+/lrzgycStitjf6poPwEhS23Tlnw3cvDE0vjrSfmu2MyY5dpXen2+B+KO3clELJieZaip07lQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@vueuse/shared": "10.11.1",
-                "vue-demi": ">=0.14.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "rxjs": ">=6.0.0"
-            }
-        },
-        "node_modules/@vueuse/rxjs/node_modules/@vueuse/shared": {
-            "version": "10.11.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
-            "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
-            "license": "MIT",
-            "dependencies": {
-                "vue-demi": ">=0.14.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@vueuse/rxjs/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@vueuse/shared": {
             "version": "10.11.0",
             "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
@@ -3327,6 +3319,7 @@
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
             "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -3379,15 +3372,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/dexie": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
-            "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=6.0"
             }
         },
         "node_modules/didyoumean": {
@@ -3511,49 +3495,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
-        },
-        "node_modules/engine.io-client": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-            "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
-            "license": "MIT",
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1",
-                "xmlhttprequest-ssl": "~2.1.1"
-            }
-        },
-        "node_modules/engine.io-client/node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -4464,7 +4405,8 @@
         "node_modules/immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -4845,6 +4787,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
@@ -4898,6 +4841,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
             "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "lie": "3.1.1"
             }
@@ -4957,19 +4901,8 @@
             "dev": true
         },
         "node_modules/luminary-shared": {
-            "version": "0.0.3",
-            "resolved": "file:../shared",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@vueuse/core": "^10.11.0",
-                "@vueuse/rxjs": "^10.7.2",
-                "dexie": "^3.2.7",
-                "luxon": "^3.4.4",
-                "rxjs": "^7.8.1",
-                "socket.io-client": "^4.7.5",
-                "uuid": "^9.0.1",
-                "vue": "^3.3.11"
-            }
+            "resolved": "../shared",
+            "link": true
         },
         "node_modules/luxon": {
             "version": "3.4.4",
@@ -5065,10 +4998,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -5208,7 +5142,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/muggle-string": {
             "version": "0.3.1",
@@ -5652,9 +5587,10 @@
             "dev": true
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -5815,9 +5751,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.39",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-            "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+            "version": "8.4.47",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5832,10 +5768,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "picocolors": "^1.1.0",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -6639,15 +6576,6 @@
                 "individual": "^2.0.0"
             }
         },
-        "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
-            }
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6786,38 +6714,11 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
-        "node_modules/socket.io-client": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-            "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
-            "license": "MIT",
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.2",
-                "engine.io-client": "~6.6.1",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "license": "MIT",
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7382,19 +7283,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/video.js": {
             "version": "8.16.1",
             "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.16.1.tgz",
@@ -7459,14 +7347,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
-            "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
+            "version": "5.4.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
+            "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.39",
-                "rollup": "^4.13.0"
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -7485,6 +7374,7 @@
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",
+                "sass-embedded": "*",
                 "stylus": "*",
                 "sugarss": "*",
                 "terser": "^5.4.0"
@@ -7500,6 +7390,9 @@
                     "optional": true
                 },
                 "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
                     "optional": true
                 },
                 "stylus": {
@@ -7973,14 +7866,6 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
-        },
-        "node_modules/xmlhttprequest-ssl": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-            "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
         },
         "node_modules/yallist": {
             "version": "4.0.0",

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -61,6 +61,48 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
+        "../shared": {
+            "name": "luminary-shared",
+            "version": "0.0.3",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@vueuse/core": "^10.11.0",
+                "@vueuse/rxjs": "^10.7.2",
+                "dexie": "^3.2.7",
+                "luxon": "^3.4.4",
+                "rxjs": "^7.8.1",
+                "socket.io-client": "^4.7.5",
+                "uuid": "^9.0.1",
+                "vue": "^3.3.11"
+            },
+            "devDependencies": {
+                "@rushstack/eslint-patch": "^1.3.3",
+                "@tsconfig/node18": "^18.2.4",
+                "@types/jsdom": "^21.1.7",
+                "@types/luxon": "^3.4.2",
+                "@types/node": "^18.19.3",
+                "@types/rollup-plugin-auto-external": "^2.0.5",
+                "@types/uuid": "^9.0.8",
+                "@vitejs/plugin-vue": "^5.0.4",
+                "@vue/eslint-config-prettier": "^8.0.0",
+                "@vue/eslint-config-typescript": "^12.0.0",
+                "@vue/test-utils": "^2.4.6",
+                "@vue/tsconfig": "^0.5.0",
+                "eslint": "^8.49.0",
+                "eslint-plugin-vue": "^9.17.0",
+                "fake-indexeddb": "^6.0.0",
+                "jsdom": "^24.1.0",
+                "prettier": "^3.0.3",
+                "rollup-plugin-auto-external": "^2.0.0",
+                "socket.io": "^4.7.5",
+                "typescript": "~5.3.0",
+                "vite": "^5.2.0",
+                "vite-plugin-dts": "^3.9.1",
+                "vitest": "^1.6.0",
+                "vue-tsc": "^1.8.25",
+                "wait-for-expect": "^3.0.2"
+            }
+        },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -1080,83 +1122,89 @@
             "dev": true
         },
         "node_modules/@sentry-internal/feedback": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
-            "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+            "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry-internal/replay-canvas": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
-            "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+            "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/replay": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/replay": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry-internal/tracing": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
-            "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+            "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/browser": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
-            "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+            "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry-internal/feedback": "7.118.0",
-                "@sentry-internal/replay-canvas": "7.118.0",
-                "@sentry-internal/tracing": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/integrations": "7.118.0",
-                "@sentry/replay": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry-internal/feedback": "7.119.2",
+                "@sentry-internal/replay-canvas": "7.119.2",
+                "@sentry-internal/tracing": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/integrations": "7.119.2",
+                "@sentry/replay": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
-            "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+            "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/integrations": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
-            "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+            "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2",
                 "localforage": "^1.8.1"
             },
             "engines": {
@@ -1164,47 +1212,51 @@
             }
         },
         "node_modules/@sentry/replay": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
-            "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+            "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry-internal/tracing": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry-internal/tracing": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@sentry/types": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
-            "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+            "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/utils": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
-            "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+            "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/types": "7.118.0"
+                "@sentry/types": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/vue": {
-            "version": "7.118.0",
-            "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.118.0.tgz",
-            "integrity": "sha512-k77NHzelR3oyDx6LFr0nvg+IKwGTjawaE36Xz2OuWivhJtqJyWKRqjDUhecsLTjZOx6zdoEsdwnRjjMF//xGMA==",
+            "version": "7.119.2",
+            "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.119.2.tgz",
+            "integrity": "sha512-GwBMpi8jnfeg4LPKEvXpwdILqn7RylxQLjpEb5xz/FKwOSL2P0gU2ysAb3WFuelC6NgspLOUpjmTqGWRemD39w==",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "7.118.0",
-                "@sentry/core": "7.118.0",
-                "@sentry/types": "7.118.0",
-                "@sentry/utils": "7.118.0"
+                "@sentry/browser": "7.119.2",
+                "@sentry/core": "7.119.2",
+                "@sentry/types": "7.119.2",
+                "@sentry/utils": "7.119.2"
             },
             "engines": {
                 "node": ">=8"
@@ -2283,57 +2335,6 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@vueuse/rxjs": {
-            "version": "10.11.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/rxjs/-/rxjs-10.11.1.tgz",
-            "integrity": "sha512-e0Bvw8fbe0u/p+/lrzgycStitjf6poPwEhS23Tlnw3cvDE0vjrSfmu2MyY5dpXen2+B+KO3clELJieZaip07lQ==",
-            "dependencies": {
-                "@vueuse/shared": "10.11.1",
-                "vue-demi": ">=0.14.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "rxjs": ">=6.0.0"
-            }
-        },
-        "node_modules/@vueuse/rxjs/node_modules/@vueuse/shared": {
-            "version": "10.11.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
-            "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
-            "dependencies": {
-                "vue-demi": ">=0.14.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@vueuse/rxjs/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "hasInstallScript": true,
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@vueuse/shared": {
             "version": "10.11.0",
             "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
@@ -3036,14 +3037,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/dexie": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
-            "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
-            "engines": {
-                "node": ">=6.0"
             }
         },
         "node_modules/didyoumean": {
@@ -3943,7 +3936,8 @@
         "node_modules/immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -4268,6 +4262,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
@@ -4320,6 +4315,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
             "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "lie": "3.1.1"
             }
@@ -4389,19 +4385,8 @@
             "dev": true
         },
         "node_modules/luminary-shared": {
-            "version": "0.0.3",
-            "resolved": "file:../shared",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@vueuse/core": "^10.11.0",
-                "@vueuse/rxjs": "^10.7.2",
-                "dexie": "^3.2.7",
-                "luxon": "^3.4.4",
-                "rxjs": "^7.8.1",
-                "socket.io-client": "^4.7.5",
-                "uuid": "^9.0.1",
-                "vue": "^3.3.11"
-            }
+            "resolved": "../shared",
+            "link": true
         },
         "node_modules/luxon": {
             "version": "3.4.4",
@@ -4471,10 +4456,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -4934,9 +4920,10 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -5042,9 +5029,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.39",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-            "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+            "version": "8.4.47",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5059,10 +5046,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "picocolors": "^1.1.0",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -5796,14 +5784,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "dependencies": {
-                "tslib": "^2.1.0"
-            }
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5918,9 +5898,10 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6333,7 +6314,8 @@
         "node_modules/tslib": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -6462,18 +6444,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/vee-validate": {
             "version": "4.13.2",
             "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.13.2.tgz",
@@ -6498,14 +6468,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
-            "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
+            "version": "5.4.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
+            "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.39",
-                "rollup": "^4.13.0"
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -6524,6 +6495,7 @@
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",
+                "sass-embedded": "*",
                 "stylus": "*",
                 "sugarss": "*",
                 "terser": "^5.4.0"
@@ -6539,6 +6511,9 @@
                     "optional": true
                 },
                 "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
                     "optional": true
                 },
                 "stylus": {


### PR DESCRIPTION
This solves some of the open security warnings on all projects using `npm audit fix`. 

On both the app and CMS the only moderate warning is related to the `vue-tsc` package, of which we're using an older version. However, when I upgrade this from 1.8 to 2.1, it suddenly generates tons of type errors in the code, that don't actually seem to be correct. Not entirely sure what's going on here and that needs a bit more investigation.
