### PR TITLE
Change language icon

### DIFF
--- a/cms/src/components/languages/CreateOrEditLanguageModal.vue
+++ b/cms/src/components/languages/CreateOrEditLanguageModal.vue
@@ -101,7 +101,7 @@ const validateForm = () => {
         <div class="w-96 rounded-lg bg-white p-6 shadow-lg">
             <!-- Dynamic title based on mode -->
             <h2 class="mb-4 text-xl font-bold">
-                {{ isEditMode ? "Edit Language" : "Create New Language" }}
+                {{ isEditMode ? "Edit language" : "Create new language" }}
             </h2>
 
             <LInput

--- a/cms/src/components/languages/CreateOrEditLanguageModel.spec.ts
+++ b/cms/src/components/languages/CreateOrEditLanguageModel.spec.ts
@@ -41,7 +41,7 @@ describe("CreateOrEditLanguageModal.vue", () => {
             const inputLanguageName = wrapper.find("[name='languageName']")
                 .element as HTMLInputElement;
 
-            expect(wrapper.html()).toContain("Create New Language");
+            expect(wrapper.html()).toContain("Create new language");
             expect(inputLanguageName.value).toBe("");
 
             // check if the button has the right text
@@ -84,7 +84,7 @@ describe("CreateOrEditLanguageModal.vue", () => {
             const inputLanguageName = wrapper.find("[name='languageName']")
                 .element as HTMLInputElement;
 
-            expect(wrapper.html()).toContain("Edit Language");
+            expect(wrapper.html()).toContain("Edit language");
             expect(inputLanguageName.value).toBe("English");
 
             // check if the button has the right text

--- a/cms/src/components/languages/LanguageOverview.vue
+++ b/cms/src/components/languages/LanguageOverview.vue
@@ -45,7 +45,7 @@ const handleLanguageCreated = (newLanguage: LanguageDto) => {
                     @click="openCreateModal"
                     name="createLanguageBtn"
                 >
-                    Create Language
+                    Create language
                 </LButton>
             </div>
         </template>

--- a/cms/src/components/navigation/SideBar.vue
+++ b/cms/src/components/navigation/SideBar.vue
@@ -6,7 +6,7 @@ import {
     HomeIcon,
     ChevronRightIcon,
     RectangleStackIcon,
-    LanguageIcon,
+    GlobeEuropeAfricaIcon,
 } from "@heroicons/vue/20/solid";
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/vue";
 import { useGlobalConfigStore } from "@/stores/globalConfig";
@@ -52,7 +52,7 @@ const navigation = ref<NavigationEntry[]>([
     {
         name: "Languages",
         to: { name: "languages" },
-        icon: LanguageIcon,
+        icon: GlobeEuropeAfricaIcon,
         visible: hasAnyPermission(DocType.Language, AclPermission.View),
     },
 ]);


### PR DESCRIPTION
Change the icon to something that fits a bit better with the rest. Also changed the Title Case from the language pages (`New Language` => `New language`) - it's subtle, but it's the style we use everywhere else.

![image](https://github.com/user-attachments/assets/2d230a42-2b70-449d-8d84-5cd05553fe0a)
