### PR TITLE
Make layout changes to EditContent

### DIFF
--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -200,7 +200,7 @@ describe("EditContent.vue", () => {
         });
 
         await waitForExpect(() => {
-            expect(wrapper.html()).toContain("The content is not yet available in");
+            expect(wrapper.html()).toContain("Please select a language to start editing");
         });
     });
 

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -319,6 +319,32 @@ watch(selectedLanguage, () => {
             </div>
         </template>
         <div class="relative grid grid-cols-3 gap-8">
+            <!-- Sidebar -->
+            <div class="col-span-3 md:col-span-1" v-if="parent">
+                <div class="sticky top-20 space-y-6">
+                    <EditContentParentValidation
+                        :can-translate="canTranslate"
+                        :can-publish="canPublish"
+                        :can-edit="canEditParent"
+                        v-if="contentDocs"
+                        v-model:parent="parent"
+                        v-model:contentDocs="contentDocs"
+                        :languages="languages"
+                        :dirty="isDirty"
+                        :contentPrev="contentDocsPrev"
+                        :parentPrev="parentPrev"
+                        @updateIsValid="(val) => (isValid = val)"
+                    />
+
+                    <EditContentParent
+                        v-if="parent"
+                        :docType="props.docType"
+                        :language="selectedLanguage"
+                        v-model="parent"
+                        :disabled="!canEditParent"
+                    />
+                </div>
+            </div>
             <div class="col-span-3 md:col-span-2">
                 <EmptyState
                     v-if="!selectedContent"
@@ -352,32 +378,6 @@ watch(selectedLanguage, () => {
                     <EditContentVideo
                         v-model:content="selectedContent"
                         :disabled="!canTranslateOrPublish"
-                    />
-                </div>
-            </div>
-            <!-- Sidebar -->
-            <div class="col-span-3 md:col-span-1" v-if="parent">
-                <div class="sticky top-20 space-y-6">
-                    <EditContentParentValidation
-                        :can-translate="canTranslate"
-                        :can-publish="canPublish"
-                        :can-edit="canEditParent"
-                        v-if="contentDocs"
-                        v-model:parent="parent"
-                        v-model:contentDocs="contentDocs"
-                        :languages="languages"
-                        :dirty="isDirty"
-                        :contentPrev="contentDocsPrev"
-                        :parentPrev="parentPrev"
-                        @updateIsValid="(val) => (isValid = val)"
-                    />
-                    <EditContentPreview v-if="selectedContent" :content="selectedContent" />
-                    <EditContentParent
-                        v-if="parent"
-                        :docType="props.docType"
-                        :language="selectedLanguage"
-                        v-model="parent"
-                        :disabled="!canEditParent"
                     />
                 </div>
             </div>

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -318,10 +318,10 @@ watch(selectedLanguage, () => {
                 </div>
             </div>
         </template>
-        <div class="relative grid grid-cols-3 gap-8">
+        <div class="relative grid min-h-screen grid-cols-3 gap-8">
             <!-- Sidebar -->
-            <div class="col-span-3 md:col-span-1" v-if="parent">
-                <div class="sticky top-20 space-y-6">
+            <div class="scrollbar col-span-3 h-screen overflow-y-auto md:col-span-1" v-if="parent">
+                <div class="sticky top-0 space-y-6">
                     <EditContentParentValidation
                         :can-translate="canTranslate"
                         :can-publish="canPublish"
@@ -345,7 +345,7 @@ watch(selectedLanguage, () => {
                     />
                 </div>
             </div>
-            <div class="col-span-3 md:col-span-2">
+            <div class="scrollbar col-span-3 h-screen overflow-y-auto md:col-span-2">
                 <EmptyState
                     v-if="!selectedContent"
                     :icon="TagIcon"
@@ -385,3 +385,14 @@ watch(selectedLanguage, () => {
     </BasePage>
     <ConfirmBeforeLeavingModal :isDirty="isDirty" />
 </template>
+
+<style>
+.scrollbar::-webkit-scrollbar {
+    display: none; /* Hide scrollbar in Chrome, Safari */
+}
+
+.scrollbar {
+    -ms-overflow-style: none; /* Hide scrollbar in IE/Edge */
+    scrollbar-width: none; /* Hide scrollbar in Firefox */
+}
+</style>

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -26,7 +26,6 @@ import EditContentStatus from "@/components/content/EditContentStatus.vue";
 import EditContentBasic from "@/components/content/EditContentBasic.vue";
 import EditContentText from "@/components/content/EditContentText.vue";
 import EditContentVideo from "@/components/content/EditContentVideo.vue";
-import EditContentPreview from "@/components/content/EditContentPreview.vue";
 import EditContentParentValidation from "@/components/content/EditContentParentValidation.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";

--- a/cms/src/components/content/EditContentBasic.vue
+++ b/cms/src/components/content/EditContentBasic.vue
@@ -35,7 +35,11 @@ watch(
         const slugChanged = previousSlug != content.value.slug;
 
         // Only update the slug if the title or slug has changed
-        if (!titleChanged && !slugChanged) {
+        if (
+            !titleChanged &&
+            !slugChanged &&
+            ((content.value.title && content.value.slug) || !content.value.title)
+        ) {
             return;
         }
 
@@ -68,7 +72,7 @@ watch(
         previousTitle = content.value.title;
         previousSlug = content.value.slug;
     },
-    { deep: true },
+    { deep: true, immediate: true },
 );
 
 const validateSlug = async () => {

--- a/cms/src/components/content/EditContentParent.vue
+++ b/cms/src/components/content/EditContentParent.vue
@@ -46,7 +46,7 @@ const pinned = computed({
         v-if="parent"
     >
         <GroupSelector v-model:groups="parent.memberOf" :disabled="disabled" :docType="docType" />
-        <ImageEditor :disabled="disabled" v-model:parent="parent" class="mb-4" />
+        <ImageEditor :disabled="disabled" v-model:parent="parent" class="my-4" />
         <div
             v-if="docType == DocType.Tag && parent && (parent as TagDto).pinned != undefined"
             class="mb-6 flex items-center justify-between"

--- a/cms/src/components/content/EditContentParent.vue
+++ b/cms/src/components/content/EditContentParent.vue
@@ -45,6 +45,7 @@ const pinned = computed({
         collapsible
         v-if="parent"
     >
+        <GroupSelector v-model:groups="parent.memberOf" :disabled="disabled" :docType="docType" />
         <ImageEditor :disabled="disabled" v-model:parent="parent" class="mb-4" />
         <div
             v-if="docType == DocType.Tag && parent && (parent as TagDto).pinned != undefined"
@@ -59,13 +60,6 @@ const pinned = computed({
             <FormLabel>Show publish date</FormLabel>
             <LToggle v-model="parent.publishDateVisible" :disabled="disabled" />
         </div>
-
-        <GroupSelector
-            v-model:groups="parent.memberOf"
-            :disabled="disabled"
-            :docType="docType"
-            class="mt-6"
-        />
 
         <TagSelector
             v-model:parent="parent"

--- a/cms/src/components/content/EditContentParentValidation.spec.ts
+++ b/cms/src/components/content/EditContentParentValidation.spec.ts
@@ -51,6 +51,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canPublish: true,
                 canTranslate: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -82,6 +83,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: false,
                 canPublish: false,
                 canTranslate: false,
+                untranslatedLanguages: [],
             },
         });
 
@@ -113,6 +115,7 @@ describe("EditContentParentValidation.vue", () => {
                     canTranslateOrPublish: true,
                     canTranslate: true,
                     canPublish: true,
+                    untranslatedLanguages: [],
                 },
             });
 
@@ -143,6 +146,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canTranslate: true,
                 canPublish: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -171,6 +175,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canPublish: true,
                 canTranslate: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -195,6 +200,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canTranslate: true,
                 canPublish: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -219,6 +225,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canTranslate: true,
                 canPublish: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -243,6 +250,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canTranslate: true,
                 canPublish: true,
+                untranslatedLanguages: [],
             },
         });
 
@@ -267,6 +275,7 @@ describe("EditContentParentValidation.vue", () => {
                 canTranslateOrPublish: true,
                 canTranslate: true,
                 canPublish: true,
+                untranslatedLanguages: [],
             },
         });
 

--- a/cms/src/components/content/EditContentParentValidation.vue
+++ b/cms/src/components/content/EditContentParentValidation.vue
@@ -4,22 +4,13 @@ import {
     type ContentDto,
     type Uuid,
     type LanguageDto,
-    AclPermission,
-    DocType,
-    verifyAccess,
     PublishStatus,
-    db,
     type ContentParentDto,
-    type TagDto,
 } from "luminary-shared";
-import { computed, ref, watch, watchEffect } from "vue";
+import { ref, watch, watchEffect } from "vue";
 import { validate, type Validation } from "./ContentValidator";
-import { sortByName } from "@/util/sortByName";
 import LanguageSelector from "./LanguageSelector.vue";
 import { ExclamationCircleIcon, XCircleIcon } from "@heroicons/vue/20/solid";
-import { useRouter } from "vue-router";
-
-const router = useRouter();
 
 type Props = {
     languages: LanguageDto[];
@@ -29,54 +20,11 @@ type Props = {
     canEdit: boolean;
     canTranslate: boolean;
     canPublish: boolean;
+    untranslatedLanguages: LanguageDto[];
 };
-const props = defineProps<Props>();
+defineProps<Props>();
 const parent = defineModel<ContentParentDto>("parent");
 const contentDocs = defineModel<ContentDto[]>("contentDocs");
-
-const untranslatedLanguages = computed(() => {
-    if (!contentDocs.value) {
-        return [];
-    }
-
-    return props.languages
-        .filter(
-            (l) =>
-                !contentDocs.value?.find((c) => c.language == l._id) &&
-                verifyAccess(l.memberOf, DocType.Language, AclPermission.Translate),
-        )
-        .sort(sortByName);
-});
-
-const createTranslation = (language: LanguageDto) => {
-    const newContent: ContentDto = {
-        _id: db.uuid(),
-        type: DocType.Content,
-        updatedTimeUtc: Date.now(),
-        memberOf: [],
-        parentId: parent.value?._id as Uuid,
-        parentType: parent.value?.docType as DocType.Post | DocType.Tag,
-        language: language._id,
-        status: PublishStatus.Draft,
-        title: `Translation for ${language.name}`,
-        slug: "",
-        parentTags: [],
-    };
-    contentDocs.value?.push(newContent);
-
-    router.replace({
-        name: "edit",
-        params: {
-            docType: parent.value?.docType,
-            tagType:
-                parent.value?.docType == DocType.Tag
-                    ? (parent.value as unknown as TagDto).tagType
-                    : undefined,
-            id: parent.value?._id,
-            languageCode: language.languageCode,
-        },
-    });
-};
 
 // Overall validation checking
 const overallValidations = ref([] as Validation[]);
@@ -93,7 +41,10 @@ const setOverallValidation = (id: Uuid, isValid: boolean) => {
     overallIsValid.value = overallValidations.value.every((v) => v.isValid);
 };
 
-const emit = defineEmits(["updateIsValid"]);
+const emit = defineEmits<{
+    (e: "updateIsValid", value: boolean): void;
+    (e: "createTranslation", language: LanguageDto): void;
+}>();
 
 watchEffect(() => {
     emit("updateIsValid", overallIsValid.value);
@@ -180,20 +131,17 @@ watch(
                     permission</span
                 >
             </div>
-            <div v-if="!parentIsValid" class="mb-2 rounded-md bg-zinc-50 p-4 shadow">
-                <span class="text-sm"
-                    >Errors were found in your {{ parent?.type }}'s settings:</span
-                >
-                <div class="mt-1 flex flex-col gap-0.5">
+            <div v-if="!parentIsValid">
+                <div class="mb-1 mt-1 flex flex-col gap-0.5">
                     <div
                         v-for="validation in parentValidations.filter((v) => !v.isValid)"
                         :key="validation.id"
                         class="-mb-[1px] flex items-center gap-1"
                     >
-                        <p class="flex items-center gap-1">
-                            <XCircleIcon class="h-[18px] text-red-400" />
+                        <div class="flex items-center gap-2">
+                            <XCircleIcon class="h-[18px] w-[18px] min-w-[18px] text-red-400" />
                             <span class="text-xs text-zinc-700">{{ validation.message }}</span>
-                        </p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -213,7 +161,7 @@ watch(
                     :languages="untranslatedLanguages"
                     :parent="parent"
                     :content="contentDocs"
-                    @create-translation="createTranslation"
+                    @create-translation="(language) => emit('createTranslation', language)"
                 />
             </div>
         </div>

--- a/cms/src/components/content/EditContentParentValidation.vue
+++ b/cms/src/components/content/EditContentParentValidation.vue
@@ -10,12 +10,16 @@ import {
     PublishStatus,
     db,
     type ContentParentDto,
+    type TagDto,
 } from "luminary-shared";
 import { computed, ref, watch, watchEffect } from "vue";
 import { validate, type Validation } from "./ContentValidator";
 import { sortByName } from "@/util/sortByName";
 import LanguageSelector from "./LanguageSelector.vue";
 import { ExclamationCircleIcon, XCircleIcon } from "@heroicons/vue/20/solid";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
 
 type Props = {
     languages: LanguageDto[];
@@ -59,6 +63,19 @@ const createTranslation = (language: LanguageDto) => {
         parentTags: [],
     };
     contentDocs.value?.push(newContent);
+
+    router.replace({
+        name: "edit",
+        params: {
+            docType: parent.value?.docType,
+            tagType:
+                parent.value?.docType == DocType.Tag
+                    ? (parent.value as unknown as TagDto).tagType
+                    : undefined,
+            id: parent.value?._id,
+            languageCode: language.languageCode,
+        },
+    });
 };
 
 // Overall validation checking

--- a/cms/src/components/content/EditContentValidation.vue
+++ b/cms/src/components/content/EditContentValidation.vue
@@ -150,8 +150,8 @@ const ensureRedirect = () => window.open(liveUrl.value, "_blank");
             :class="[
                 'rounded-md p-4',
                 {
-                    'bg-white  shadow': isActive,
-                    'border bg-zinc-100 hover:bg-stone-100': !isActive,
+                    'cursor-default bg-white shadow': isActive,
+                    'border bg-white/25 hover:bg-white/50': !isActive,
                 },
             ]"
         >
@@ -197,7 +197,7 @@ const ensureRedirect = () => window.open(liveUrl.value, "_blank");
             </div>
 
             <div v-if="!isValid || isContentDirty" class="mt-2 flex flex-col gap-0.5">
-                <div class="flex items-center gap-1">
+                <div class="flex items-center gap-2">
                     <p>
                         <ExclamationCircleIcon class="h-4 w-4 text-yellow-400" />
                     </p>
@@ -206,7 +206,7 @@ const ensureRedirect = () => window.open(liveUrl.value, "_blank");
                 <div
                     v-for="validation in validations.filter((v) => !v.isValid)"
                     :key="validation.id"
-                    class="flex items-center gap-1"
+                    class="flex items-center gap-2"
                 >
                     <p>
                         <XCircleIcon class="h-4 w-4 text-red-400" />

--- a/cms/src/components/content/EditContentValidation.vue
+++ b/cms/src/components/content/EditContentValidation.vue
@@ -5,6 +5,7 @@ import {
     type LanguageDto,
     DocType,
     type TagDto,
+    isConnected,
 } from "luminary-shared";
 import { computed, ref, watch, type ComputedRef } from "vue";
 import { validate, type Validation } from "./ContentValidator";
@@ -126,7 +127,7 @@ const liveUrl = computed(() => {
     return url.toString();
 });
 
-const ensureRedirect = () => (window.location.href = liveUrl.value);
+const ensureRedirect = () => window.open(liveUrl.value, "_blank");
 </script>
 
 <template>
@@ -150,14 +151,32 @@ const ensureRedirect = () => (window.location.href = liveUrl.value);
                 'rounded-md p-4',
                 {
                     'bg-white  shadow': isActive,
-                    'border bg-zinc-50 hover:bg-stone-100': !isActive,
+                    'border bg-zinc-100 hover:bg-stone-100': !isActive,
                 },
             ]"
         >
             <div class="flex flex-col">
                 <span class="flex items-center justify-between text-sm text-zinc-900">
-                    {{ usedLanguage?.name }}
-
+                    <div class="flex h-8 w-full items-center justify-start">
+                        {{ usedLanguage?.name }}
+                        <LButton
+                            v-if="
+                                isConnected &&
+                                content &&
+                                content.status == PublishStatus.Published &&
+                                content.title
+                            "
+                            :icon="ArrowTopRightOnSquareIcon"
+                            iconRight
+                            class="-ml-2 font-extralight text-zinc-600/[55%] hover:bg-transparent active:bg-transparent"
+                            variant="tertiary"
+                            is="a"
+                            @click="ensureRedirect"
+                            :href="liveUrl"
+                            target="_blank"
+                            title="View live version"
+                        ></LButton>
+                    </div>
                     <div class="flex items-center gap-1">
                         <template v-if="statusChanged">
                             <LBadge
@@ -169,22 +188,7 @@ const ensureRedirect = () => (window.location.href = liveUrl.value);
                             </LBadge>
                             <ArrowRightIcon class="h-4 w-4 text-zinc-700" />
                         </template>
-                        <LButton
-                            v-if="
-                                content &&
-                                content.status == PublishStatus.Published &&
-                                content.title
-                            "
-                            :icon="ArrowTopRightOnSquareIcon"
-                            iconRight
-                            class="font-extralight text-zinc-100"
-                            variant="tertiary"
-                            is="a"
-                            @click="ensureRedirect"
-                            :href="liveUrl"
-                            target="_blank"
-                            >View live version</LButton
-                        >
+
                         <LBadge withIcon :variant="statusBadge(content).variant">
                             {{ statusBadge(content).title }}
                         </LBadge>

--- a/cms/src/components/content/EditContentValidation.vue
+++ b/cms/src/components/content/EditContentValidation.vue
@@ -13,6 +13,9 @@ import LBadge, { variants } from "../common/LBadge.vue";
 import { RouterLink } from "vue-router";
 import _ from "lodash";
 import { capitaliseFirstLetter } from "@/util/string";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/vue/20/solid";
+import { clientAppUrl } from "@/globalConfig";
+import LButton from "../button/LButton.vue";
 
 type Props = {
     languages: LanguageDto[];
@@ -113,6 +116,17 @@ watch(
     },
     { immediate: true, deep: true },
 );
+
+const liveUrl = computed(() => {
+    if (!content.value) return "";
+    const url = new URL(
+        content.value.slug,
+        clientAppUrl.value ? clientAppUrl.value : "http://localhost",
+    );
+    return url.toString();
+});
+
+const ensureRedirect = () => (window.location.href = liveUrl.value);
 </script>
 
 <template>
@@ -155,7 +169,22 @@ watch(
                             </LBadge>
                             <ArrowRightIcon class="h-4 w-4 text-zinc-700" />
                         </template>
-
+                        <LButton
+                            v-if="
+                                content &&
+                                content.status == PublishStatus.Published &&
+                                content.title
+                            "
+                            :icon="ArrowTopRightOnSquareIcon"
+                            iconRight
+                            class="font-extralight text-zinc-100"
+                            variant="tertiary"
+                            is="a"
+                            @click="ensureRedirect"
+                            :href="liveUrl"
+                            target="_blank"
+                            >View live version</LButton
+                        >
                         <LBadge withIcon :variant="statusBadge(content).variant">
                             {{ statusBadge(content).title }}
                         </LBadge>

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -33,7 +33,7 @@ async function Startup() {
     await initLuminaryShared({
         cms: true,
         docsIndex:
-            "type, parentId, updatedTimeUtc, language, [type+tagType], [type+docType], [type+language]",
+            "type, parentId, updatedTimeUtc, language, [type+tagType], [type+docType], [type+language], slug",
         apiUrl,
         token,
         docTypes: [


### PR DESCRIPTION
Moved the sidebar from the right to the left, following the principle that users should see important information first
Moved groupSelector on top of the LImage component to make it clearer to the user, maybe add some bottom margin to seperate them more?
Moved "view live version" inside of each translation in the validation container, but only if the post is publishable, and contains a title. 
When I first started using the CMS, I remember that I skimmed over it and didn't ever really used and actually forgot about that feature, so now users will be able to find it more easily and it gives more space for the EditParent component