### PR TITLE
fix: bug in EditLanguage

### DIFF
--- a/cms/src/components/languages/EditLanguage.vue
+++ b/cms/src/components/languages/EditLanguage.vue
@@ -79,6 +79,8 @@ const originalLoadedHandler = watch(original, () => {
     if (!original.value) return;
     editable.value = _.cloneDeep(original.value);
 
+    if (!editable.value.translations) editable.value.translations = {};
+
     // Transform the translations into an array of translationKeyValuePair objects
     translations.value = Object.entries(editable.value.translations)
         .map(([key, value]) => ({
@@ -196,6 +198,9 @@ const confirmDelete = () => {
 
 // Save the current JSON to the database
 const save = async () => {
+    // Update the original object to reflect the newly saved state
+    original.value = _.cloneDeep(editable.value);
+
     editable.value.updatedTimeUtc = Date.now();
     await db.upsert(editable.value);
 
@@ -204,6 +209,8 @@ const save = async () => {
         description: "Language updated successfully",
         state: "success",
     });
+
+    isDirty.value = false;
 };
 
 // Revert to the initial state

--- a/cms/src/components/languages/EditLanguage.vue
+++ b/cms/src/components/languages/EditLanguage.vue
@@ -209,8 +209,6 @@ const save = async () => {
         description: "Language updated successfully",
         state: "success",
     });
-
-    isDirty.value = false;
 };
 
 // Revert to the initial state

--- a/cms/src/components/languages/EditLanguage.vue
+++ b/cms/src/components/languages/EditLanguage.vue
@@ -41,6 +41,9 @@ const translations = ref<translationKeyValuePair[]>([]);
 const languages = db.whereTypeAsRef<LanguageDto[]>(DocType.Language, []);
 const isLocalChange = db.isLocalChangeAsRef(props.id);
 
+const original = useDexieLiveQuery(
+    () => db.docs.where("_id").equals(props.id).first() as unknown as Promise<LanguageDto>,
+);
 const editable = ref<LanguageDto>({
     _id: props.id,
     name: "New language",
@@ -51,11 +54,6 @@ const editable = ref<LanguageDto>({
     updatedTimeUtc: Date.now(),
     translations: {},
 });
-
-const original = useDexieLiveQuery(
-    () => db.docs.where("_id").equals(props.id).first() as unknown as Promise<LanguageDto>,
-);
-
 const isNew = computed(() => !original.value?._id);
 
 watch(
@@ -75,12 +73,6 @@ watch(
     },
     { deep: true, immediate: true },
 );
-
-watch(isNew, () => {
-    if (isNew.value) {
-        original.value = _.cloneDeep(editable.value);
-    }
-});
 
 // Clone the original language when it's loaded into the editable object
 const originalLoadedHandler = watch(original, () => {
@@ -210,6 +202,7 @@ const save = async () => {
     original.value = _.cloneDeep(editable.value);
 
     editable.value.updatedTimeUtc = Date.now();
+    await db.upsert(editable.value);
 
     useNotificationStore().addNotification({
         title: "Language updated",
@@ -218,8 +211,6 @@ const save = async () => {
     });
 
     isDirty.value = false;
-
-    await db.upsert(editable.value);
 };
 
 // Revert to the initial state


### PR DESCRIPTION
- [x] Ensure that the translation field is set on save
- [ ] Check isDirty checking (Need to click twice before `Unsaved changes` disapears.