### PR TITLE
Handle LImageProvider Errors

### DIFF
--- a/app/src/components/images/LImageProvider.vue
+++ b/app/src/components/images/LImageProvider.vue
@@ -73,6 +73,7 @@ const filteredFileCollections = computed(() => {
 
         // add the smallest image from collection.imageFiles to images if images is empty
         if (images.length == 0) {
+            if (collection.imageFiles.length == 0) return;
             images.push(collection.imageFiles.reduce((a, b) => (a.width < b.width ? a : b)));
         }
 


### PR DESCRIPTION
Array.reduce() requires and initial value, so it throws an error when there is not one. So now it will just return out of the function if there is no initial value to handle that error, otherwise the webpage breaks.