### PR TITLE
Fix Broken Redirects

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -48,6 +48,7 @@ async function Startup() {
                 syncPriority: 1,
                 skipWaitForLanguageSync: true,
             },
+            { type: DocType.Redirect, contentOnly: false, syncPriority: 3 },
         ],
     }).catch((err) => {
         console.error(err);


### PR DESCRIPTION
Redirects where broken because Redirect Document types where not synced to the client, there was already tests for this, they passed because we use mockdata, so the redirect documents will always be there in the mock test enviroment

Test can be found in SingleContent.spec.ts: Row 311 Col 5