### PR TITLE
Exclude expired content when content only flag is set in API

### DIFF
--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -589,6 +589,11 @@ export class DbService extends EventEmitter {
                             { type: { $in: [DocType.Content] } },
                             { memberOf: { $in: groups } },
                             { parentType: docType },
+                            {
+                                $expr: {
+                                    $lt: ["$publishDate", "$expiryDate"],
+                                },
+                            },
                             ...languageSelector,
                         ],
                     });


### PR DESCRIPTION
To ensure expired documents are not synced, we can use the content-only field and only include documents that are not expired. Not sure if I already did this in a previous PR that is in review?