### PR TITLE
Add screen reader text for language selection and profile menu items

### DIFF
--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -113,6 +113,9 @@ const removeFromSelected = (id: string) => {
                         class="flex w-full cursor-pointer items-center gap-1"
                         @click="removeFromSelected(language._id)"
                     >
+                        <span class="sr-only">
+                            Remove {{ language.name }} from selected languages
+                        </span>
                         <CheckCircleIcon
                             v-if="appLanguageIdsAsRef.includes(language._id)"
                             class="h-5 w-5 cursor-pointer text-yellow-500 hover:text-yellow-400"
@@ -155,10 +158,10 @@ const removeFromSelected = (id: string) => {
                 data-test="add-language-button"
                 @click="setLanguage(language._id)"
             >
+                <span class="sr-only">Add {{ language.name }} to selected languages</span>
                 <PlusCircleIcon
                     class="h-5 w-5 cursor-pointer text-zinc-500 hover:text-yellow-600 dark:text-slate-400 dark:hover:text-yellow-500"
                 ></PlusCircleIcon>
-
                 <div class="flex w-full justify-between">
                     <div class="flex w-full items-center gap-1">
                         <span class="text-sm">{{ language.name }}</span>

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -113,9 +113,6 @@ const removeFromSelected = (id: string) => {
                         class="flex w-full cursor-pointer items-center gap-1"
                         @click="removeFromSelected(language._id)"
                     >
-                        <span class="sr-only">
-                            Remove {{ language.name }} from selected languages
-                        </span>
                         <CheckCircleIcon
                             v-if="appLanguageIdsAsRef.includes(language._id)"
                             class="h-5 w-5 cursor-pointer text-yellow-500 hover:text-yellow-400"
@@ -124,7 +121,10 @@ const removeFromSelected = (id: string) => {
                                     ? 'cursor-auto text-zinc-400 hover:text-zinc-400 dark:text-slate-400 hover:dark:text-slate-400'
                                     : ''
                             "
-                        />
+                            ><span class="sr-only">
+                                Remove {{ language.name }} from selected languages
+                            </span></CheckCircleIcon
+                        >
                         <div class="flex w-full justify-between">
                             <div class="flex w-full items-center">
                                 <span class="text-sm">{{ language.name }}</span>
@@ -158,10 +158,11 @@ const removeFromSelected = (id: string) => {
                 data-test="add-language-button"
                 @click="setLanguage(language._id)"
             >
-                <span class="sr-only">Add {{ language.name }} to selected languages</span>
                 <PlusCircleIcon
                     class="h-5 w-5 cursor-pointer text-zinc-500 hover:text-yellow-600 dark:text-slate-400 dark:hover:text-yellow-500"
-                ></PlusCircleIcon>
+                >
+                    <span class="sr-only">Add {{ language.name }} to selected languages</span>
+                </PlusCircleIcon>
                 <div class="flex w-full justify-between">
                     <div class="flex w-full items-center gap-1">
                         <span class="text-sm">{{ language.name }}</span>

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -178,6 +178,7 @@ const removeFromSelected = (id: string) => {
                 class="w-full"
                 @click="emit('close')"
             >
+                <span class="sr-only">Close language selection modal</span>
                 {{ t("language.modal.close") }}
             </LButton>
         </template>

--- a/app/src/components/navigation/ProfileMenu.vue
+++ b/app/src/components/navigation/ProfileMenu.vue
@@ -195,7 +195,7 @@ const userNavigation = computed(() => {
                             ]"
                             @click="item.action"
                         >
-                            <span class="sr-only">{{ item.name }}</span>
+                            <span class="sr-only">Navigate to {{ item.name }} menu item</span>
                             <component
                                 :is="item.icon"
                                 class="h-5 w-5 flex-shrink-0 text-zinc-500 dark:text-slate-300"

--- a/app/src/components/navigation/ProfileMenu.vue
+++ b/app/src/components/navigation/ProfileMenu.vue
@@ -195,7 +195,13 @@ const userNavigation = computed(() => {
                             ]"
                             @click="item.action"
                         >
-                            <span class="sr-only">Navigate to {{ item.name }} menu item</span>
+                            <!-- This is for the multi-language suport ssg-prerendering
+                                Our i18n translations are too dynamic, so need something static that won't
+                                change for crawler.  
+                            -->
+                            <span v-if="item.language" class="sr-only"
+                                >Navigate to language modal</span
+                            >
                             <component
                                 :is="item.icon"
                                 class="h-5 w-5 flex-shrink-0 text-zinc-500 dark:text-slate-300"

--- a/app/src/components/navigation/ProfileMenu.vue
+++ b/app/src/components/navigation/ProfileMenu.vue
@@ -195,9 +195,9 @@ const userNavigation = computed(() => {
                             ]"
                             @click="item.action"
                         >
-                            <!-- This is for the multi-language suport ssg-prerendering
-                                Our i18n translations are too dynamic, so need something static that won't
-                                change for crawler.  
+                            <!--    This is for the multi-language suport ssg-prerendering
+                                    Our i18n translations are too dynamic, so need something static that won't
+                                    change for crawler.  
                             -->
                             <span v-if="item.language" class="sr-only"
                                 >Navigate to language modal</span

--- a/app/src/components/navigation/ProfileMenu.vue
+++ b/app/src/components/navigation/ProfileMenu.vue
@@ -195,6 +195,7 @@ const userNavigation = computed(() => {
                             ]"
                             @click="item.action"
                         >
+                            <span class="sr-only">{{ item.name }}</span>
                             <component
                                 :is="item.icon"
                                 class="h-5 w-5 flex-shrink-0 text-zinc-500 dark:text-slate-300"


### PR DESCRIPTION
Enhance accessibility by adding screen reader text for language selection and profile menu items. This also makes it easy for the static site generator to crawl the languages dynamically