### PR TITLE
Potential fix for code scanning alert no. 5: Client-side URL redirect

### DIFF
--- a/app/src/analytics/service-worker.js
+++ b/app/src/analytics/service-worker.js
@@ -1,4 +1,42 @@
-const MATOMO_SERVER = new URL(location.href).searchParams.get("matomo_server");
+// Define a whitelist of allowed Matomo server hosts (e.g., by hostname only, or full base URLs)
+const ALLOWED_MATOMO_SERVERS = [
+  "https://matomo.example.com",
+  // Add other allowed servers as needed
+];
+
+const matomoServerUrlRaw = new URL(location.href).searchParams.get("matomo_server");
+let MATOMO_SERVER = null;
+
+try {
+  if (matomoServerUrlRaw) {
+    // Normalize the provided server URL (strip trailing slashes, enforce HTTPS)
+    const url = new URL(matomoServerUrlRaw);
+    // Optionally enforce HTTPS only:
+    if (url.protocol !== "https:") {
+      throw new Error("Only HTTPS Matomo servers are allowed.");
+    }
+    // Check against allowed servers (by origin)
+    if (ALLOWED_MATOMO_SERVERS.includes(url.origin)) {
+      MATOMO_SERVER = url.origin;
+    } else {
+      throw new Error(`Matomo server "${url.origin}" is not whitelisted.`);
+    }
+  } else {
+    throw new Error("matomo_server query parameter is missing.");
+  }
+} catch (e) {
+  // Abort further script execution if invalid
+  // Optionally, you can log the error to a monitoring endpoint
+  console.error("[ServiceWorker] Invalid matomo_server provided:", e.message);
+  // Exit early and do not import scripts or initialize analytics
+  // In a service worker, return; essentially halts further execution
+  // If this code is at global scope, set a guard
+  // For this snippet, we return for the rest of this script scope
+  // (No further initialization will run)
+  // Optionally, you can self.unregister() here
+  // self.unregister && self.unregister();
+  throw e; // stops script execution
+}
 
 self.importScripts(`${MATOMO_SERVER}/offline-service-worker.js`);
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
Potential fix for [https://github.com/bccsa/luminary/security/code-scanning/5](https://github.com/bccsa/luminary/security/code-scanning/5)

The best way to address this problem is to ensure that only trusted, intended URLs can be used as the value for `MATOMO_SERVER`. The most secure approach is to maintain a whitelist of allowed URLs or hostnames, and only proceed to construct the script URL if the extracted value matches one of the allowed entries. In this specific scenario, a simple approach would be to define, in the service worker script, a list or set of allowed Matomo server hostnames or base URLs, only allowing import from one of those. If `matomo_server` does not match an entry (by exact string or hostname comparison), abort or throw an error, rather than blindly using whatever the user provides.

This change would be implemented in app/src/analytics/service-worker.js: extract the value, check if it is included in your set/list, and only then compose the script URL and call `importScripts()`. If the value is not valid, log an error or take other appropriate action.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
