### PR TITLE
fix the zoom on Image Modal in the app

### DIFF
--- a/app/src/components/images/ImageModal.vue
+++ b/app/src/components/images/ImageModal.vue
@@ -180,7 +180,7 @@ function onTouchEndWithDoubleTap(e: TouchEvent) {
     const touch = e.changedTouches[0];
     const distanceX = Math.abs(touch.clientX - swipeStartX);
 
-    if (distanceX > 3) {
+    if (distanceX > 10) {
         lastTap = 0;
         onTouchEnd(e);
         return;


### PR DESCRIPTION
These are also implemented in this ticket to fixed some bugs:
- A condition to make sure there is no finger touching the screen before to disabled the pinchzooming function to avoid a swipe after a zoom out
- A function that check to distinguish between a swipe and a tap to prevent an accidental zooming while swiping