### PR TITLE
APP - fix: Fix video player console error

### DIFF
--- a/app/src/components/content/VideoPlayer.css
+++ b/app/src/components/content/VideoPlayer.css
@@ -97,6 +97,7 @@
 .video-player .vjs-progress-control {
     @apply !absolute !bottom-0 !left-0 !pl-2 !pr-0;
     width: calc(100% - 40px) !important;
+    touch-action: none;
 }
 
 .video-player .vjs-live-control {
@@ -113,6 +114,7 @@
 
 .video-player .vjs-slider {
     @apply !rounded-full;
+    touch-action: none;
 }
 
 .video-player .vjs-slider-bar {


### PR DESCRIPTION
Added touch-action: none to .vjs-progress-control and .vjs-slider. This tells the browser these elements own their touch interactions, so it won't register passive listeners on them — allowing video.js's preventDefault() calls to work without the console errors.