### PR TITLE
feat: immediately trigger search query watch in SearchModal 

### DIFF
--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -461,7 +461,7 @@ watch(isSearchOpen, (open) => {
             }
         }
     });
-});
+}, { immediate: true });
 
 watch(results, (newResults) => {
     if (newResults.length === 0) {


### PR DESCRIPTION
This fixes a bug where you first had to route to some page before being able to open the searchModal