### PR TITLE
CMS: Keep auto-selected storage buckets in lock-step to prevent fake dirty state

### DIFF
--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -22,7 +22,7 @@
                 "luminary-shared": "file:../shared",
                 "luxon": "^3.4.4",
                 "pinia": "^2.1.7",
-                "rte-vue": "^1.1.6",
+                "rte-vue": "^1.1.11",
                 "socket.io-client": "^4.7.4",
                 "tailwind-scrollbar-hide": "^4.0.0",
                 "tailwindcss": "^3.4.17",
@@ -34,7 +34,6 @@
                 "@headlessui/vue": "^1.7.17",
                 "@heroicons/vue": "^2.1.5",
                 "@pinia/testing": "^0.1.3",
-                "@playwright/test": "^1.40.1",
                 "@rushstack/eslint-patch": "^1.3.3",
                 "@tailwindcss/typography": "^0.5.16",
                 "@tsconfig/node18": "^18.2.2",
@@ -1028,22 +1027,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/@playwright/test": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-            "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "playwright": "1.58.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@popperjs/core": {
@@ -2674,6 +2657,15 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.13",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/abbrev": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -2883,6 +2875,26 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/bidi-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2903,6 +2915,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "1.20.4",
@@ -3363,6 +3381,12 @@
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true
         },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "license": "MIT"
+        },
         "node_modules/crelt": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -3558,6 +3582,12 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/dingbat-to-unicode": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+            "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3599,6 +3629,15 @@
             },
             "funding": {
                 "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/duck": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+            "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+            "license": "BSD",
+            "dependencies": {
+                "underscore": "^1.13.1"
             }
         },
         "node_modules/dunder-proto": {
@@ -4847,8 +4886,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -4953,6 +4991,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -5164,6 +5208,27 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "license": "(MIT OR GPL-3.0-or-later)",
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/jszip/node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "immediate": "~3.0.5"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5307,6 +5372,17 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
+        "node_modules/lop": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+            "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "duck": "^0.1.12",
+                "option": "~0.2.1",
+                "underscore": "^1.13.1"
+            }
+        },
         "node_modules/loupe": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -5381,6 +5457,39 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mammoth": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+            "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.6",
+                "argparse": "~1.0.3",
+                "base64-js": "^1.5.1",
+                "bluebird": "~3.4.0",
+                "dingbat-to-unicode": "^1.0.1",
+                "jszip": "^3.7.1",
+                "lop": "^0.4.2",
+                "path-is-absolute": "^1.0.0",
+                "underscore": "^1.13.1",
+                "xmlbuilder": "^10.0.0"
+            },
+            "bin": {
+                "mammoth": "bin/mammoth"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/mammoth/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/markdown-it": {
@@ -5844,6 +5953,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/option": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+            "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5901,6 +6016,12 @@
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5953,7 +6074,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6102,53 +6222,6 @@
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
             "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
             "dev": true
-        },
-        "node_modules/playwright": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-            "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "playwright-core": "1.58.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
-            }
-        },
-        "node_modules/playwright-core": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-            "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "playwright-core": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/playwright/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/postcss": {
             "version": "8.5.4",
@@ -6443,6 +6516,12 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "license": "MIT"
         },
         "node_modules/prosemirror-changeset": {
             "version": "2.2.1",
@@ -6797,6 +6876,27 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6981,15 +7081,17 @@
             "dev": true
         },
         "node_modules/rte-vue": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/rte-vue/-/rte-vue-1.1.6.tgz",
-            "integrity": "sha512-ftaWFUSv4dutG+t83jUGIM1ZdR9zrdHFWa9Dav6JFb4mMrME2YnJSr+5E9KrKO1tQ7dPc1xDcKVeC+yNdqiImQ==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/rte-vue/-/rte-vue-1.1.11.tgz",
+            "integrity": "sha512-PmXNvbv+weA0Q+/8oYgPztxzxJAcLUVH7BzlK+c9QnoBCTET69u8d+sPOB1J29EA9Or8YkdHF+cxSinXmektXQ==",
             "license": "MIT",
             "dependencies": {
                 "@tiptap/core": "^2.5.0 || ^3.0.0",
                 "@tiptap/extension-link": "^2.5.0 || ^3.0.0",
                 "@tiptap/starter-kit": "^2.5.0 || ^3.0.0",
                 "@tiptap/vue-3": "^2.5.0 || ^3.0.0",
+                "jszip": "^3.10.1",
+                "mammoth": "^1.12.0",
                 "markdown-it": "^14.0.0",
                 "turndown": "^7.1.0"
             },
@@ -7159,6 +7261,12 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "license": "MIT"
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -7365,6 +7473,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/stackback": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7385,6 +7499,21 @@
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
             "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
             "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "5.1.2",
@@ -7942,6 +8071,12 @@
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
             "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
             "dev": true
+        },
+        "node_modules/underscore": {
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "5.26.5",
@@ -8576,6 +8711,15 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+            "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/xmlchars": {

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -22,7 +22,7 @@
                 "luminary-shared": "file:../shared",
                 "luxon": "^3.4.4",
                 "pinia": "^2.1.7",
-                "rte-vue": "^1.1.11",
+                "rte-vue": "^1.1.13",
                 "socket.io-client": "^4.7.4",
                 "tailwind-scrollbar-hide": "^4.0.0",
                 "tailwindcss": "^3.4.17",
@@ -7081,9 +7081,9 @@
             "dev": true
         },
         "node_modules/rte-vue": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/rte-vue/-/rte-vue-1.1.11.tgz",
-            "integrity": "sha512-PmXNvbv+weA0Q+/8oYgPztxzxJAcLUVH7BzlK+c9QnoBCTET69u8d+sPOB1J29EA9Or8YkdHF+cxSinXmektXQ==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/rte-vue/-/rte-vue-1.1.13.tgz",
+            "integrity": "sha512-EZk/C4Q9x0nGON8XJMvrA/zI6Uwl7JNN7J+3jcLDdzF2SnWOaQ75O3GoPFdPkH7mKHhiVRJC9S41Ey51nHfh1A==",
             "license": "MIT",
             "dependencies": {
                 "@tiptap/core": "^2.5.0 || ^3.0.0",

--- a/cms/package.json
+++ b/cms/package.json
@@ -32,7 +32,7 @@
         "luminary-shared": "file:../shared",
         "luxon": "^3.4.4",
         "pinia": "^2.1.7",
-        "rte-vue": "^1.1.6",
+        "rte-vue": "^1.1.11",
         "socket.io-client": "^4.7.4",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^3.4.17",

--- a/cms/package.json
+++ b/cms/package.json
@@ -32,7 +32,7 @@
         "luminary-shared": "file:../shared",
         "luxon": "^3.4.4",
         "pinia": "^2.1.7",
-        "rte-vue": "^1.1.11",
+        "rte-vue": "^1.1.13",
         "socket.io-client": "^4.7.4",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^3.4.17",

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1170,4 +1170,119 @@ describe("EditContent.vue", () => {
             });
         });
     });
+
+    describe("dirty state on load", () => {
+        // Regression tests for a bug where MediaEditor / ImageEditor auto-selected the
+        // single available storage bucket on mount and wrote it only to editableParent,
+        // which made the diff against existingParent flag a phantom dirty state every
+        // time a legacy doc (no bucket IDs persisted) was opened.
+
+        const loadWithoutUserEdits = async (postOverride: Partial<PostDto> = {}) => {
+            await db.docs.clear();
+            await db.localChanges.clear();
+
+            const legacyPost: PostDto = {
+                ...mockData.mockPostDto,
+                ...postOverride,
+            };
+            delete (legacyPost as Partial<PostDto>).mediaBucketId;
+            delete (legacyPost as Partial<PostDto>).imageBucketId;
+
+            await db.docs.bulkPut([legacyPost]);
+            await db.docs.bulkPut([
+                mockData.mockEnglishContentDto,
+                mockData.mockFrenchContentDto,
+                mockData.mockSwahiliContentDto,
+            ]);
+            await db.docs.bulkPut([
+                mockData.mockLanguageDtoEng,
+                mockData.mockLanguageDtoFra,
+                mockData.mockLanguageDtoSwa,
+            ]);
+
+            const wrapper = mount(EditContent, {
+                props: {
+                    docType: DocType.Post,
+                    id: legacyPost._id,
+                    languageCode: "eng",
+                    tagOrPostType: PostType.Blog,
+                },
+            });
+
+            await waitForExpect(() => {
+                expect(wrapper.find('input[name="title"]').exists()).toBe(true);
+            });
+            // Let storage-bucket live query resolve and any post-load watchers settle.
+            await wait(50);
+            return wrapper;
+        };
+
+        it("is not dirty on load when the post has no bucket IDs and a single media bucket is auto-selected", async () => {
+            await db.docs.bulkPut([mockData.mockStorageDtoWithEncryptedCredentials]);
+
+            const wrapper = await loadWithoutUserEdits();
+
+            // Revert action is only rendered while isDirty is true — its absence proves
+            // the dirty state stayed clean across the bucket auto-select watcher.
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        });
+
+        it("is not dirty on load when the post has no bucket IDs and a single image bucket is auto-selected", async () => {
+            await db.docs.bulkPut([mockData.mockStorageDto]);
+
+            const wrapper = await loadWithoutUserEdits();
+
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        });
+
+        it("is not dirty on load when both image and media buckets are auto-selected", async () => {
+            await db.docs.bulkPut([
+                mockData.mockStorageDto,
+                mockData.mockStorageDtoWithEncryptedCredentials,
+            ]);
+
+            const wrapper = await loadWithoutUserEdits();
+
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        });
+
+        it("is not dirty on load when no storage buckets exist", async () => {
+            const wrapper = await loadWithoutUserEdits();
+
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        });
+
+        it("is not dirty on load when the post already has bucket IDs persisted", async () => {
+            await db.docs.bulkPut([
+                mockData.mockStorageDto,
+                mockData.mockStorageDtoWithEncryptedCredentials,
+            ]);
+
+            const wrapper = await loadWithoutUserEdits({
+                imageBucketId: mockData.mockStorageDto._id,
+                mediaBucketId: mockData.mockStorageDtoWithEncryptedCredentials._id,
+            });
+
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        });
+
+        it("becomes dirty after a genuine user edit on a legacy post with auto-selected buckets", async () => {
+            await db.docs.bulkPut([
+                mockData.mockStorageDto,
+                mockData.mockStorageDtoWithEncryptedCredentials,
+            ]);
+
+            const wrapper = await loadWithoutUserEdits();
+
+            // Baseline must be clean before the edit — otherwise the next assertion
+            // could pass for the wrong reason.
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+
+            await wrapper.find('input[name="title"]').setValue("Edited title");
+
+            await waitForExpect(() => {
+                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(true);
+            });
+        });
+    });
 });

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1181,12 +1181,10 @@ describe("EditContent.vue", () => {
             await db.docs.clear();
             await db.localChanges.clear();
 
-            const legacyPost: PostDto = {
-                ...mockData.mockPostDto,
-                ...postOverride,
-            };
-            delete (legacyPost as Partial<PostDto>).mediaBucketId;
-            delete (legacyPost as Partial<PostDto>).imageBucketId;
+            const basePost: PostDto = { ...mockData.mockPostDto };
+            delete (basePost as Partial<PostDto>).mediaBucketId;
+            delete (basePost as Partial<PostDto>).imageBucketId;
+            const legacyPost: PostDto = { ...basePost, ...postOverride };
 
             await db.docs.bulkPut([legacyPost]);
             await db.docs.bulkPut([

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1264,23 +1264,29 @@ describe("EditContent.vue", () => {
             expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
         });
 
-        it("becomes dirty after a genuine user edit on a legacy post with auto-selected buckets", async () => {
-            await db.docs.bulkPut([
-                mockData.mockStorageDto,
-                mockData.mockStorageDtoWithEncryptedCredentials,
-            ]);
+        it(
+            "becomes dirty after a genuine user edit on a legacy post with auto-selected buckets",
+            async () => {
+                await db.docs.bulkPut([
+                    mockData.mockStorageDto,
+                    mockData.mockStorageDtoWithEncryptedCredentials,
+                ]);
 
-            const wrapper = await loadWithoutUserEdits();
+                const wrapper = await loadWithoutUserEdits();
 
-            // Baseline must be clean before the edit — otherwise the next assertion
-            // could pass for the wrong reason.
-            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+                // Baseline must be clean before the edit — otherwise the next assertion
+                // could pass for the wrong reason.
+                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
 
-            await wrapper.find('input[name="title"]').setValue("Edited title");
+                await wrapper.find('input[name="title"]').setValue("Edited title");
 
-            await waitForExpect(() => {
-                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(true);
-            });
-        });
+                await waitForExpect(() => {
+                    expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(
+                        true,
+                    );
+                });
+            },
+            15000,
+        );
     });
 });

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -268,18 +268,6 @@ const canDelete = computed(() => {
     return verifyAccess(editableParent.value.memberOf, props.docType, AclPermission.Delete, "all");
 });
 
-const diffKeys = (a: any, b: any) => {
-    const keys = new Set([...Object.keys(a || {}), ...Object.keys(b || {})]);
-    const diffs: Record<string, { editable: any; existing: any }> = {};
-    for (const k of keys) {
-        if (k === "updatedBy") continue;
-        if (!_.isEqual((a || {})[k], (b || {})[k])) {
-            diffs[k] = { editable: (a || {})[k], existing: (b || {})[k] };
-        }
-    }
-    return diffs;
-};
-
 const isDirty = computed(() => {
     const parentDirty = !_.isEqual(
         { ...editableParent.value, updatedBy: "" },
@@ -289,67 +277,8 @@ const isDirty = computed(() => {
         { ...editableContent.value, updatedBy: "" },
         { ...existingContent.value, updatedBy: "" },
     );
-    const dirty = parentDirty || contentDirty;
-    if (dirty) {
-        if (parentDirty) {
-            console.log(
-                "[EditContent] isDirty=true (parent)",
-                diffKeys(editableParent.value, existingParent.value),
-            );
-        }
-        if (contentDirty) {
-            const editArr = editableContent.value || [];
-            const existArr = existingContent.value || [];
-            const ids = new Set([
-                ...editArr.map((c) => c._id),
-                ...existArr.map((c) => c._id),
-            ]);
-            for (const id of ids) {
-                const e = editArr.find((c) => c._id === id);
-                const x = existArr.find((c) => c._id === id);
-                if (!_.isEqual(e, x)) {
-                    const diff =
-                        e && x ? diffKeys(e, x) : { editable: e, existing: x };
-                    console.log(
-                        "[EditContent] isDirty=true (content) doc " + id,
-                        JSON.parse(JSON.stringify(diff)),
-                    );
-                }
-            }
-        }
-    }
-    return dirty;
+    return parentDirty || contentDirty;
 });
-
-watch(
-    editableParent,
-    (val) => {
-        console.log("[EditContent] editableParent changed", _.cloneDeep(val));
-    },
-    { deep: true },
-);
-watch(
-    existingParent,
-    (val) => {
-        console.log("[EditContent] existingParent changed", _.cloneDeep(val));
-    },
-    { deep: true },
-);
-watch(
-    editableContent,
-    (val) => {
-        console.log("[EditContent] editableContent changed", _.cloneDeep(val));
-        console.trace("[EditContent] editableContent change stack");
-    },
-    { deep: true },
-);
-watch(
-    existingContent,
-    (val) => {
-        console.log("[EditContent] existingContent changed", _.cloneDeep(val));
-    },
-    { deep: true },
-);
 
 const isValid = ref(true);
 

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -48,7 +48,6 @@ import EditContentActionsWrapper from "./EditContentActionsWrapper.vue";
 import { TrashIcon } from "@heroicons/vue/24/outline";
 import LButton from "@/components/button/LButton.vue";
 import LDropdown from "../common/LDropdown.vue";
-import { storageSelection } from "@/composables/storageSelection";
 
 type Props = {
     id: Uuid;
@@ -149,34 +148,6 @@ const loadData = (id: string, isNew: boolean) => {
 };
 
 loadData(parentId, newDocument);
-
-// Keep auto-selected storage buckets in lock-step between editable and existing
-// so that MediaEditor/ImageEditor's auto-select-on-mount logic does not appear as
-// a user edit (spurious dirty state) when the loaded doc predates the feature or
-// only has one bucket configured.
-const { autoSelectMediaBucket, autoSelectImageBucket } = storageSelection();
-
-watch(
-    [autoSelectMediaBucket, autoSelectImageBucket, existingParent],
-    ([mediaBucketId, imageBucketId, existing]) => {
-        if (!existing) return;
-
-        if (mediaBucketId && !existing.mediaBucketId) {
-            existingParent.value = { ...existing, mediaBucketId };
-            if (editableParent.value && !editableParent.value.mediaBucketId) {
-                editableParent.value.mediaBucketId = mediaBucketId;
-            }
-        }
-
-        if (imageBucketId && !existingParent.value?.imageBucketId) {
-            existingParent.value = { ...existingParent.value!, imageBucketId };
-            if (editableParent.value && !editableParent.value.imageBucketId) {
-                editableParent.value.imageBucketId = imageBucketId;
-            }
-        }
-    },
-    { immediate: true },
-);
 
 watch(
     () => props.id,

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -268,16 +268,87 @@ const canDelete = computed(() => {
     return verifyAccess(editableParent.value.memberOf, props.docType, AclPermission.Delete, "all");
 });
 
-const isDirty = computed(
-    () =>
-        !_.isEqual(
-            { ...editableParent.value, updatedBy: "" },
-            { ...existingParent.value, updatedBy: "" },
-        ) ||
-        !_.isEqual(
-            { ...editableContent.value, updatedBy: "" },
-            { ...existingContent.value, updatedBy: "" },
-        ),
+const diffKeys = (a: any, b: any) => {
+    const keys = new Set([...Object.keys(a || {}), ...Object.keys(b || {})]);
+    const diffs: Record<string, { editable: any; existing: any }> = {};
+    for (const k of keys) {
+        if (k === "updatedBy") continue;
+        if (!_.isEqual((a || {})[k], (b || {})[k])) {
+            diffs[k] = { editable: (a || {})[k], existing: (b || {})[k] };
+        }
+    }
+    return diffs;
+};
+
+const isDirty = computed(() => {
+    const parentDirty = !_.isEqual(
+        { ...editableParent.value, updatedBy: "" },
+        { ...existingParent.value, updatedBy: "" },
+    );
+    const contentDirty = !_.isEqual(
+        { ...editableContent.value, updatedBy: "" },
+        { ...existingContent.value, updatedBy: "" },
+    );
+    const dirty = parentDirty || contentDirty;
+    if (dirty) {
+        if (parentDirty) {
+            console.log(
+                "[EditContent] isDirty=true (parent)",
+                diffKeys(editableParent.value, existingParent.value),
+            );
+        }
+        if (contentDirty) {
+            const editArr = editableContent.value || [];
+            const existArr = existingContent.value || [];
+            const ids = new Set([
+                ...editArr.map((c) => c._id),
+                ...existArr.map((c) => c._id),
+            ]);
+            for (const id of ids) {
+                const e = editArr.find((c) => c._id === id);
+                const x = existArr.find((c) => c._id === id);
+                if (!_.isEqual(e, x)) {
+                    const diff =
+                        e && x ? diffKeys(e, x) : { editable: e, existing: x };
+                    console.log(
+                        "[EditContent] isDirty=true (content) doc " + id,
+                        JSON.parse(JSON.stringify(diff)),
+                    );
+                }
+            }
+        }
+    }
+    return dirty;
+});
+
+watch(
+    editableParent,
+    (val) => {
+        console.log("[EditContent] editableParent changed", _.cloneDeep(val));
+    },
+    { deep: true },
+);
+watch(
+    existingParent,
+    (val) => {
+        console.log("[EditContent] existingParent changed", _.cloneDeep(val));
+    },
+    { deep: true },
+);
+watch(
+    editableContent,
+    (val) => {
+        console.log("[EditContent] editableContent changed", _.cloneDeep(val));
+        console.trace("[EditContent] editableContent change stack");
+    },
+    { deep: true },
+);
+watch(
+    existingContent,
+    (val) => {
+        console.log("[EditContent] existingContent changed", _.cloneDeep(val));
+    },
+    { deep: true },
 );
 
 const isValid = ref(true);

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -48,6 +48,7 @@ import EditContentActionsWrapper from "./EditContentActionsWrapper.vue";
 import { TrashIcon } from "@heroicons/vue/24/outline";
 import LButton from "@/components/button/LButton.vue";
 import LDropdown from "../common/LDropdown.vue";
+import { storageSelection } from "@/composables/storageSelection";
 
 type Props = {
     id: Uuid;
@@ -148,6 +149,34 @@ const loadData = (id: string, isNew: boolean) => {
 };
 
 loadData(parentId, newDocument);
+
+// Keep auto-selected storage buckets in lock-step between editable and existing
+// so that MediaEditor/ImageEditor's auto-select-on-mount logic does not appear as
+// a user edit (spurious dirty state) when the loaded doc predates the feature or
+// only has one bucket configured.
+const { autoSelectMediaBucket, autoSelectImageBucket } = storageSelection();
+
+watch(
+    [autoSelectMediaBucket, autoSelectImageBucket, existingParent],
+    ([mediaBucketId, imageBucketId, existing]) => {
+        if (!existing) return;
+
+        if (mediaBucketId && !existing.mediaBucketId) {
+            existingParent.value = { ...existing, mediaBucketId };
+            if (editableParent.value && !editableParent.value.mediaBucketId) {
+                editableParent.value.mediaBucketId = mediaBucketId;
+            }
+        }
+
+        if (imageBucketId && !existingParent.value?.imageBucketId) {
+            existingParent.value = { ...existingParent.value!, imageBucketId };
+            if (editableParent.value && !editableParent.value.imageBucketId) {
+                editableParent.value.imageBucketId = imageBucketId;
+            }
+        }
+    },
+    { immediate: true },
+);
 
 watch(
     () => props.id,

--- a/cms/src/components/images/ImageEditor.spec.ts
+++ b/cms/src/components/images/ImageEditor.spec.ts
@@ -277,18 +277,27 @@ describe("ImageEditor", () => {
         expect(wrapper.text()).toContain("file size is larger than the maximum");
     });
 
-    it("auto-selects bucket when only one is available", async () => {
+    it("does not mutate parent on mount when a single bucket is available, but persists on upload", async () => {
         const parent: ContentParentDto = {
             ...mockPostDto,
             imageBucketId: undefined,
             imageData: { fileCollections: [] },
         };
 
-        mount(ImageEditor, {
+        const wrapper = mount(ImageEditor, {
             props: { parent, disabled: false },
         });
 
-        // The watchEffect should auto-select the single available bucket
+        // Mount must not mutate the parent — otherwise legacy docs open as phantom-dirty.
+        expect(parent.imageBucketId).toBeUndefined();
+
+        // An actual upload is a real user edit and should persist the effective bucket.
+        const mockFile = new File(["x"], "img.jpg", { type: "image/jpeg" });
+        Object.defineProperty(mockFile, "size", { value: 1024 });
+        const fileList = { 0: mockFile, length: 1, item: (i: number) => (i === 0 ? mockFile : null) };
+        (wrapper.vm as any).handleFiles(fileList);
+        await wrapper.vm.$nextTick();
+
         expect(parent.imageBucketId).toBe("bucket-images");
     });
 });

--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -16,8 +16,6 @@ type Props = {
     disabled: boolean;
     /** The bucket ID where existing images are currently stored (before any migration) */
     existingImagesBucketId?: string;
-    /** When true, skip auto-selecting a bucket if only one is available */
-    noAutoSelectBucket?: boolean;
 };
 const props = defineProps<Props>();
 
@@ -55,8 +53,7 @@ const newUploadsBucketUrl = computed(() => {
     return bucketBaseUrl.value;
 });
 const bucketBaseUrl = computed(() => {
-    // If parent or imageBucketId is not set, pass null to getBucketById (it accepts string | null)
-    const bucketId = parent.value?.imageBucketId ?? null;
+    const bucketId = effectiveImageBucketId.value ?? null;
     const bucket = bucketSelection.getBucketById(bucketId);
     return bucket ? bucket.publicUrl : undefined;
 });
@@ -131,16 +128,6 @@ watchEffect(() => {
                 parent.value.imageBucketId = undefined;
             }
         }
-    }
-
-    // Auto-select if only one bucket available and none is selected
-    if (
-        !props.noAutoSelectBucket &&
-        bucketSelection.autoSelectImageBucket.value &&
-        !parent.value?.imageBucketId
-    ) {
-        parent.value!.imageBucketId = bucketSelection.autoSelectImageBucket.value;
-        emit("bucketSelected", bucketSelection.autoSelectImageBucket.value);
     }
 
     // Proactively show error messages for bucket configuration issues

--- a/cms/src/components/images/ImageEditor.vue
+++ b/cms/src/components/images/ImageEditor.vue
@@ -31,6 +31,15 @@ const maxUploadFileSizeMb = computed(() => maxUploadFileSize.value / 1000000);
 // Bucket selection (simplified approach using existing database data)
 const bucketSelection = storageSelection();
 
+// The bucket the editor should treat as "current". Falls back to the auto-selected
+// bucket when the parent has none persisted yet — so a single-bucket setup behaves
+// as if it's selected without mutating the parent (which would create a fake dirty
+// state on legacy docs). The parent is only written to when the user actually
+// uploads or picks a bucket.
+const effectiveImageBucketId = computed(
+    () => parent.value?.imageBucketId ?? bucketSelection.autoSelectImageBucket.value ?? undefined,
+);
+
 // Get separate URLs for existing vs new content
 // This ensures existing images continue to display from their original bucket
 // even when the user changes bucket selection, preventing fallback images
@@ -54,11 +63,11 @@ const bucketBaseUrl = computed(() => {
 
 // Get accepted file types based on selected bucket
 const acceptedmimeTypes = computed(() => {
-    if (!parent.value?.imageBucketId) {
+    if (!effectiveImageBucketId.value) {
         return "image/*"; // default to all images
     }
 
-    const bucket = bucketSelection.getBucketById(parent.value.imageBucketId);
+    const bucket = bucketSelection.getBucketById(effectiveImageBucketId.value);
     if (!bucket || !bucket.mimeTypes || bucket.mimeTypes.length === 0) {
         return "image/*"; // accept all images if no restrictions
     }
@@ -69,11 +78,11 @@ const acceptedmimeTypes = computed(() => {
 
 // Get file type description for user
 const fileTypeDescription = computed(() => {
-    if (!parent.value?.imageBucketId) {
+    if (!effectiveImageBucketId.value) {
         return "";
     }
 
-    const bucket = bucketSelection.getBucketById(parent.value.imageBucketId);
+    const bucket = bucketSelection.getBucketById(effectiveImageBucketId.value);
     if (!bucket || !bucket.mimeTypes || bucket.mimeTypes.length === 0) {
         return "All image types";
     }
@@ -141,11 +150,11 @@ watchEffect(() => {
         failureMessage.value =
             "No storage buckets configured. Please configure at least one S3 bucket in the Storage settings before uploading images.";
         showFailureMessage.value = true;
-    } else if (!parent.value?.imageBucketId && bucketSelection.imageBuckets.value.length > 1) {
+    } else if (!effectiveImageBucketId.value && bucketSelection.imageBuckets.value.length > 1) {
         // Multiple buckets available but none selected
         failureMessage.value = "Please select a storage bucket before uploading images.";
         showFailureMessage.value = true;
-    } else if (parent.value?.imageBucketId) {
+    } else if (effectiveImageBucketId.value) {
         // Bucket is selected, clear any bucket-related errors
         // Only clear if the current error is about bucket selection/configuration
         const bucketRelatedErrors = [
@@ -165,11 +174,17 @@ const handleFiles = (files: FileList | null) => {
 
     const fileArray = Array.from(files);
 
-    // Check if a bucket is selected
-    if (!parent.value?.imageBucketId) {
+    // Resolve the bucket the user is uploading to. Persist it on the parent now —
+    // the upload itself is a real user edit, so the resulting dirty state is
+    // legitimate. Until this point the parent was untouched.
+    if (!effectiveImageBucketId.value) {
         failureMessage.value = "Please select a storage bucket before uploading images.";
         showFailureMessage.value = true;
         return;
+    }
+    if (parent.value && !parent.value.imageBucketId) {
+        parent.value.imageBucketId = effectiveImageBucketId.value;
+        emit("bucketSelected", effectiveImageBucketId.value);
     }
 
     // Check if the currently selected bucket still exists in the database
@@ -178,7 +193,7 @@ const handleFiles = (files: FileList | null) => {
     );
 
     if (!currentBucketExists) {
-        parent.value.imageBucketId = undefined;
+        if (parent.value) parent.value.imageBucketId = undefined;
         failureMessage.value =
             "The selected storage bucket no longer exists. Please select another bucket.";
         showFailureMessage.value = true;

--- a/cms/src/components/media/MediaEditor.spec.ts
+++ b/cms/src/components/media/MediaEditor.spec.ts
@@ -276,12 +276,30 @@ describe("MediaEditor.vue", () => {
         expect(languageDialog?.props("open")).toBe(false);
     });
 
-    it("auto-selects bucket when only one is available", () => {
+    it("auto-selects the single available bucket without mutating parent on mount", async () => {
         parent.mediaBucketId = undefined;
 
-        mount(MediaEditor, {
+        const wrapper = mount(MediaEditor, {
             props: { parent, disabled: false },
         });
+
+        // Opening the editor must not write to the parent — that was the
+        // phantom-dirty bug. The auto-selection is resolved internally via
+        // effectiveMediaBucketId so the upload picker and validation behave
+        // as if the single bucket is selected.
+        expect(parent.mediaBucketId).toBeUndefined();
+        expect(wrapper.text()).not.toContain("Please select a storage bucket");
+
+        // A genuine upload action persists the auto-selected bucket onto the
+        // parent, so the file lands in the right place.
+        const mockFile = new File(["audio"], "test.mp3", { type: "audio/mp3" });
+        const fileList = {
+            0: mockFile,
+            length: 1,
+            item: (i: number) => (i === 0 ? mockFile : null),
+        };
+        (wrapper.vm as any).handleFiles(fileList);
+        await wrapper.vm.$nextTick();
 
         expect(parent.mediaBucketId).toBe("bucket-media");
     });

--- a/cms/src/components/media/MediaEditor.vue
+++ b/cms/src/components/media/MediaEditor.vue
@@ -36,13 +36,22 @@ const maxMediaUploadFileSizeMb = computed(() => maxMediaUploadFileSize.value / 1
 // Bucket selection (simplified approach using existing database data)
 const bucketSelection = storageSelection();
 
+// The bucket the editor should treat as "current". Falls back to the auto-selected
+// bucket when the parent has none persisted yet — so a single-bucket setup behaves
+// as if it's selected without mutating the parent (which would create a fake dirty
+// state on legacy docs). The parent is only written to when the user actually
+// uploads or picks a bucket.
+const effectiveMediaBucketId = computed(
+    () => parent.value?.mediaBucketId ?? bucketSelection.autoSelectMediaBucket.value ?? undefined,
+);
+
 // Get accepted file types based on selected bucket
 const acceptedMimeTypes = computed(() => {
-    if (!parent.value?.mediaBucketId) {
+    if (!effectiveMediaBucketId.value) {
         return "audio/*"; // default to common audio formats
     }
 
-    const bucket = bucketSelection.getBucketById(parent.value.mediaBucketId);
+    const bucket = bucketSelection.getBucketById(effectiveMediaBucketId.value);
     if (!bucket || !bucket.mimeTypes || bucket.mimeTypes.length === 0) {
         return "audio/*"; // default if no restrictions
     }
@@ -53,11 +62,11 @@ const acceptedMimeTypes = computed(() => {
 
 // Get file type description for user
 const fileTypeDescription = computed(() => {
-    if (!parent.value?.mediaBucketId) {
+    if (!effectiveMediaBucketId.value) {
         return "";
     }
 
-    const bucket = bucketSelection.getBucketById(parent.value.mediaBucketId);
+    const bucket = bucketSelection.getBucketById(effectiveMediaBucketId.value);
     if (!bucket || !bucket.mimeTypes || bucket.mimeTypes.length === 0) {
         return "All audio types";
     }
@@ -173,12 +182,6 @@ watchEffect(() => {
         }
     }
 
-    // Auto-select if only one bucket available and none is selected
-    if (bucketSelection.autoSelectMediaBucket.value && !parent.value?.mediaBucketId) {
-        parent.value!.mediaBucketId = bucketSelection.autoSelectMediaBucket.value;
-        emit("bucketSelected", bucketSelection.autoSelectMediaBucket.value);
-    }
-
     // Proactively show error messages for bucket configuration issues
     // This ensures users see the error immediately, not just when they try to upload
     if (!bucketSelection.hasMediaBuckets.value) {
@@ -186,11 +189,11 @@ watchEffect(() => {
         failureMessage.value =
             "No storage buckets configured. Please configure at least one S3 bucket in the Storage settings before uploading media.";
         showFailureMessage.value = true;
-    } else if (!parent.value?.mediaBucketId && bucketSelection.mediaBuckets.value.length > 1) {
+    } else if (!effectiveMediaBucketId.value && bucketSelection.mediaBuckets.value.length > 1) {
         // Multiple buckets available but none selected
         failureMessage.value = "Please select a storage bucket before uploading media.";
         showFailureMessage.value = true;
-    } else if (parent.value?.mediaBucketId) {
+    } else if (effectiveMediaBucketId.value) {
         // Bucket is selected, clear any bucket-related errors
         // Only clear if the current error is about bucket selection/configuration
         const bucketRelatedErrors = [
@@ -254,11 +257,17 @@ const handleFiles = (files: FileList | null) => {
     // Only process the first file
     const file = files[0];
 
-    // Check if a bucket is selected
-    if (!parent.value?.mediaBucketId) {
+    // Resolve the bucket the user is uploading to. Persist it on the parent now —
+    // the upload itself is a real user edit, so the resulting dirty state is
+    // legitimate. Until this point the parent was untouched.
+    if (!effectiveMediaBucketId.value) {
         failureMessage.value = "Please select a storage bucket before uploading media.";
         showFailureMessage.value = true;
         return;
+    }
+    if (parent.value && !parent.value.mediaBucketId) {
+        parent.value.mediaBucketId = effectiveMediaBucketId.value;
+        emit("bucketSelected", effectiveMediaBucketId.value);
     }
 
     // Check if the currently selected bucket still exists in the database
@@ -267,7 +276,7 @@ const handleFiles = (files: FileList | null) => {
     );
 
     if (!currentBucketExists) {
-        parent.value.mediaBucketId = undefined;
+        if (parent.value) parent.value.mediaBucketId = undefined;
         failureMessage.value =
             "The selected storage bucket no longer exists. Please select another bucket.";
         showFailureMessage.value = true;


### PR DESCRIPTION
MediaEditor and ImageEditor previously wrote the auto-selected storage
bucket onto the parent via a mount-time watchEffect, producing a phantom
dirty state on legacy docs (and on any doc with a single bucket
configured). This required a lock-step watcher in EditContent to keep
editableParent and existingParent in sync.

Introduce `effectiveMediaBucketId` / `effectiveImageBucketId` computed
refs that fall back to the auto-selected bucket for display and
validation without touching the parent. The parent is only written when
the user actually picks a bucket or uploads a file — at which point any
resulting dirty state is legitimate. The lock-step watcher in
EditContent is deleted.

