### PR TITLE
fix: prevent app modal from closing on drag-out from input

### DIFF
--- a/app/src/components/form/BaseModal.vue
+++ b/app/src/components/form/BaseModal.vue
@@ -7,19 +7,12 @@ const emit = defineEmits(["close"]);
 
 <template>
     <LTeleport v-if="isVisible">
-        <div class="relative z-[100]">
-            <div
-                class="fixed inset-0 bg-zinc-800 bg-opacity-50 backdrop-blur-sm dark:bg-slate-800 dark:bg-opacity-50"
-                @mousedown.self="emit('close')"
-                data-test="modal-backdrop"
-            ></div>
-            <div
-                class="fixed inset-0 flex items-center justify-center rounded-lg p-2"
-                @mousedown.self="emit('close')"
-                data-test="modal-container"
-            >
-                <slot />
-            </div>
+        <div
+            class="fixed inset-0 z-[100] flex items-center justify-center rounded-lg bg-zinc-800 bg-opacity-50 p-2 backdrop-blur-sm dark:bg-slate-800 dark:bg-opacity-50"
+            @mousedown.self="emit('close')"
+            data-test="modal-container"
+        >
+            <slot />
         </div>
     </LTeleport>
 </template>


### PR DESCRIPTION
Collapse BaseModal's backdrop and flex-centering wrapper into a single div so @mousedown.self reliably ignores events originating inside the modal content, matching the CMS LModal structure.

## Summary
- Collapse BaseModal's two sibling `fixed inset-0` divs into a single backdrop + flex-centering wrapper, mirroring the CMS LModal structure
- Fixes the modal closing when a user mousedowns on an input (or other modal content) and drags outside the modal bounds before releasing

## Test plan
- [x] Open any app modal containing an input, click inside the input, drag the cursor outside the modal, release — modal stays open
- [x] Click directly on the backdrop — modal closes
- [X] Existing LModal.spec.ts tests pass