### PR TITLE
Fix provider lock-in after aborted login; simplify auth modules

### DIFF
--- a/api/src/db/seedingDocs/lang-eng.json
+++ b/api/src/db/seedingDocs/lang-eng.json
@@ -121,6 +121,8 @@
         "openapp_warning.description": "We noticed you're in Telegram. Please click on Continue to see the content properly on the {appName} app.",
         "openapp_warning.button_continue": "Continue",
         "openapp_warning.button_cancel": "Cancel",
+        "auth.sign_in": "Sign in",
+        "auth.no_methods_available": "No authentication methods available. Please try again in a moment.",
         "singlecontent.listen": "Listen"
     }
 }

--- a/api/src/db/seedingDocs/lang-fra.json
+++ b/api/src/db/seedingDocs/lang-fra.json
@@ -121,6 +121,8 @@
         "openapp_warning.description": "Nous avons remarqué que vous êtes sur Telegram. Veuillez cliquer sur Continuer pour voir le contenu correctement dans l'application {appName}.",
         "openapp_warning.button_continue": "Continuer",
         "openapp_warning.button_cancel": "Annuler",
+        "auth.sign_in": "Se connecter",
+        "auth.no_methods_available": "Aucun méthode d'authentification disponible. Veuillez réessayer dans un moment.",
         "singlecontent.listen": "Écouter"
     }
 }

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -1,31 +1,186 @@
-import { describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
-import auth from "./auth";
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db, DocType, type AuthProviderDto } from "luminary-shared";
+
+import {
+    activeProviderId,
+    clearAuth0Cache,
+    openProviderModal,
+    refreshTokenSilently,
+    resolveActiveProvider,
+    showProviderSelectionModal,
+} from "./auth";
+
+const providerA: AuthProviderDto = {
+    _id: "provider-a",
+    type: DocType.AuthProvider,
+    updatedTimeUtc: 1704114000000,
+    memberOf: [],
+    label: "Acme",
+    domain: "acme.auth0.com",
+    clientId: "client-a",
+    audience: "https://api.acme.com",
+};
+
+const providerB: AuthProviderDto = {
+    _id: "provider-b",
+    type: DocType.AuthProvider,
+    updatedTimeUtc: 1704114000000,
+    memberOf: [],
+    label: "Beta",
+    domain: "beta.auth0.com",
+    clientId: "client-b",
+    audience: "https://api.beta.com",
+};
+
+/** Put the browser into a clean deterministic state before each test. */
+async function resetWorld() {
+    localStorage.clear();
+    sessionStorage.clear();
+    history.replaceState(null, "", "/");
+    activeProviderId.value = null;
+    showProviderSelectionModal.value = false;
+    await db.docs.clear();
+}
 
 describe("auth", () => {
-    describe("getToken", () => {
-        it("calls getAccessTokenSilently when isAuthenticated is true", async () => {
-            const getAccessTokenSilently = vi.fn().mockResolvedValue("token");
-            const oauth = {
-                isAuthenticated: ref(true),
-                getAccessTokenSilently,
-            };
+    beforeEach(resetWorld);
+    afterEach(resetWorld);
 
-            const token = await auth.getToken(oauth as any);
-            expect(getAccessTokenSilently).toHaveBeenCalledOnce();
-            expect(token).toBe("token");
+    describe("resolveActiveProvider", () => {
+        it("returns null when storage is empty", async () => {
+            await db.docs.bulkPut([providerA]);
+            expect(await resolveActiveProvider()).toBeNull();
         });
 
-        it("does not call getAccessTokenSilently when isAuthenticated is false", async () => {
-            const getAccessTokenSilently = vi.fn();
-            const oauth = {
-                isAuthenticated: ref(false),
-                getAccessTokenSilently,
-            };
+        it("resolves via the localStorage session cache (returning user)", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            // Auth0 SDK cache key format: @@auth0spajs@@::<clientId>::<audience>::<scope>
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: { access_token: "fake" } }),
+            );
 
-            const token = await auth.getToken(oauth as any);
-            expect(getAccessTokenSilently).not.toHaveBeenCalled();
-            expect(token).toBeUndefined();
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("returns null when a localStorage clientId has no matching provider in Dexie", async () => {
+            // Dexie has only providerA, cache key references an unknown clientId.
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::unknown-client::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("does NOT trust a stale PKCE txs key when URL has no code/state (bug fix)", async () => {
+            // Simulates an aborted login: user hit Back on the Auth0 page, the txs
+            // key remains in sessionStorage, URL no longer has ?code=&state=.
+            await db.docs.bulkPut([providerA]);
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerA.clientId}`,
+                JSON.stringify({ state: "s", code_verifier: "v" }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("trusts the PKCE txs key when we ARE on the OAuth callback URL", async () => {
+            // Legitimate mid-callback state: URL has code+state, txs key present.
+            await db.docs.bulkPut([providerA]);
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerA.clientId}`,
+                JSON.stringify({ state: "s", code_verifier: "v" }),
+            );
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("prefers the localStorage session cache over the sessionStorage txs key", async () => {
+            // User completed a login with A, then aborted an attempt to switch to B
+            // (B's txs key is stale). Even on a callback URL we should pick A because
+            // A has a confirmed completed session.
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerB.clientId}`,
+                JSON.stringify({ state: "s" }),
+            );
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("ignores malformed cache keys without a clientId segment", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem("@@auth0spajs@@::", JSON.stringify({}));
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+    });
+
+    describe("clearAuth0Cache", () => {
+        it("removes @@auth0spajs@@ keys from localStorage and a0.spajs. keys from sessionStorage", () => {
+            localStorage.setItem("@@auth0spajs@@::c1::aud::scope", "x");
+            localStorage.setItem("@@auth0spajs@@::c2::aud::scope", "y");
+            sessionStorage.setItem("a0.spajs.txs.c1", "z");
+            sessionStorage.setItem("a0.spajs.other", "w");
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem("@@auth0spajs@@::c1::aud::scope")).toBeNull();
+            expect(localStorage.getItem("@@auth0spajs@@::c2::aud::scope")).toBeNull();
+            expect(sessionStorage.getItem("a0.spajs.txs.c1")).toBeNull();
+            expect(sessionStorage.getItem("a0.spajs.other")).toBeNull();
+        });
+
+        it("leaves unrelated storage keys untouched", () => {
+            localStorage.setItem("unrelated-app-key", "keep");
+            sessionStorage.setItem("some-other-session-key", "keep");
+            localStorage.setItem("@@auth0spajs@@::c::a::s", "drop");
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem("unrelated-app-key")).toBe("keep");
+            expect(sessionStorage.getItem("some-other-session-key")).toBe("keep");
+            expect(localStorage.getItem("@@auth0spajs@@::c::a::s")).toBeNull();
+        });
+
+        it("resets activeProviderId to null", () => {
+            activeProviderId.value = "provider-a";
+            clearAuth0Cache();
+            expect(activeProviderId.value).toBeNull();
+        });
+    });
+
+    describe("openProviderModal", () => {
+        it("flips showProviderSelectionModal to true", () => {
+            expect(showProviderSelectionModal.value).toBe(false);
+            openProviderModal();
+            expect(showProviderSelectionModal.value).toBe(true);
+        });
+    });
+
+    describe("refreshTokenSilently", () => {
+        it("returns false when no Auth0 plugin has been installed yet", async () => {
+            // setupAuth hasn't run in this test context, so the module has no
+            // oauth handle. The socket connect_error handler relies on this
+            // being a safe `false` rather than a throw.
+            expect(await refreshTokenSilently()).toBe(false);
         });
     });
 });

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -1,61 +1,74 @@
 import { createAuth0 } from "@auth0/auth0-vue";
 import { createAuth0Client } from "@auth0/auth0-spa-js";
-import { type App, ref, watch } from "vue";
+import { type App, ref } from "vue";
 import type { Router } from "vue-router";
 import * as Sentry from "@sentry/vue";
 import { setCustomHeader, removeCustomHeader, getSocket } from "luminary-shared";
 import { db, DocType } from "luminary-shared";
 import type { AuthProviderDto } from "luminary-shared";
 
-/** Ref for the currently active OAuth provider document id (or null when unauthenticated). Used by shared HTTP to send x-auth-provider-id. */
+const AUTH0_CACHE_PREFIX = "@@auth0spajs@@::";
+const AUTH0_TX_PREFIX = "a0.spajs.";
+const AUTH0_TX_KEY_PREFIX = "a0.spajs.txs.";
+
+/** Currently active OAuth provider document id (or null when unauthenticated). */
 export const activeProviderId = ref<string | null>(null);
 
 /** When true, the provider selection modal should be shown. */
 export const showProviderSelectionModal = ref(false);
 
 /**
- * True once `setupAuth` has installed the Auth0 Vue plugin. Callers should
- * check this before calling `useAuth0()` to avoid the
- * `[Vue warn]: injection "Symbol($auth0)" not found` noise and the
- * `"Please ensure Auth0's Vue plugin is correctly installed"` throw.
+ * True once setupAuth has installed the Auth0 Vue plugin. Check before calling
+ * useAuth0() to avoid the `injection "Symbol($auth0)" not found` warning.
  */
 export const isAuthPluginInstalled = ref(false);
 
-/**
- * Extract client_id from Auth0's native storage footprint (read-only).
- * Checks localStorage (@@auth0spajs@@::*) for returning users, then the Auth0
- * SDK's in-flight transaction key in sessionStorage for the redirect callback.
- * Do not modify or rely on the OAuth state parameter; the SDK owns it for CSRF.
- */
-export function readAuth0NativeStorage(): { client_id: string } | null {
-    if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
+type Auth0Prompt = "none" | "login" | "consent" | "select_account";
+type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
 
-    for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (!key?.startsWith("@@auth0spajs@@::")) continue;
-        const parts = key.split("::");
-        if (parts.length >= 2 && parts[1]) return { client_id: parts[1] };
+function clearStoragePrefix(storage: Storage, prefix: string): void {
+    for (let i = storage.length - 1; i >= 0; i--) {
+        const key = storage.key(i);
+        if (key?.startsWith(prefix)) storage.removeItem(key);
     }
-
-    // Fall back to the Auth0 SDK's in-flight transaction marker for users
-    // mid-redirect: loginWithRedirect writes a0.spajs.txs.<clientId> into
-    // sessionStorage holding the PKCE code_verifier + state, and it stays
-    // there across the round-trip to Auth0 until handleRedirectCallback
-    // consumes it. So when we boot on the callback URL — before
-    // @@auth0spajs@@::* exists for a first-time login — this key tells us
-    // which provider's redirect we're returning from.
-    for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (!key?.startsWith("a0.spajs.txs.")) continue;
-        const clientId = key.slice("a0.spajs.txs.".length);
-        if (clientId) return { client_id: clientId };
-    }
-
-    return null;
 }
 
-/** Look up OAuthProvider doc by clientId in Dexie. */
-async function getProviderByClientId(clientId: string): Promise<AuthProviderDto | null> {
+function setProviderIdHeader(id: string | null): void {
+    activeProviderId.value = id;
+    if (id) setCustomHeader("x-auth-provider-id", id);
+    else removeCustomHeader("x-auth-provider-id");
+}
+
+/**
+ * Identify the current provider by reading Auth0's own storage footprint and
+ * looking it up in Dexie. Prefers the localStorage session cache; falls back
+ * to the PKCE transaction key in sessionStorage, but only while we're on the
+ * OAuth callback URL — without that gate, a stale txs key from an aborted
+ * login would impersonate a real session and lock the user out of re-picking.
+ */
+export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
+    if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
+
+    let clientId: string | null = null;
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (!key?.startsWith(AUTH0_CACHE_PREFIX)) continue;
+        clientId = key.slice(AUTH0_CACHE_PREFIX.length).split("::")[0] || null;
+        if (clientId) break;
+    }
+
+    if (!clientId) {
+        const params = new URLSearchParams(location.search);
+        if (!params.has("code") || !params.has("state")) return null;
+        for (let i = 0; i < sessionStorage.length; i++) {
+            const key = sessionStorage.key(i);
+            if (!key?.startsWith(AUTH0_TX_KEY_PREFIX)) continue;
+            clientId = key.slice(AUTH0_TX_KEY_PREFIX.length) || null;
+            if (clientId) break;
+        }
+        if (!clientId) return null;
+    }
+
     const doc = await db.docs
         .where("type")
         .equals(DocType.AuthProvider)
@@ -64,155 +77,93 @@ async function getProviderByClientId(clientId: string): Promise<AuthProviderDto 
     return (doc as AuthProviderDto) ?? null;
 }
 
-function buildAuth0Options(provider: Pick<AuthProviderDto, "domain" | "clientId" | "audience">) {
+function buildAuth0Options(p: ProviderConfig) {
     return {
-        domain: provider.domain,
-        clientId: provider.clientId,
+        domain: p.domain,
+        clientId: p.clientId,
         useRefreshTokens: true,
         useRefreshTokensFallback: true,
         cacheLocation: "localstorage" as const,
         authorizationParams: {
-            audience: provider.audience,
+            audience: p.audience,
             scope: "openid profile email offline_access",
             redirect_uri: window.location.origin,
         },
     };
 }
 
-export type AuthPlugin = Awaited<ReturnType<typeof setupAuth>>;
+// Module-level handle on the installed Auth0 plugin. Set by setupAuth, read by
+// refreshTokenSilently so the socket's connect_error handler can ask the SDK
+// for a fresh access token without a visible re-login.
+let installedOauth: ReturnType<typeof createAuth0> | null = null;
 
 /**
- * Setup Auth0: read the storage footprint, resolve the provider from Dexie, and
- * install createAuth0 only when a provider is found. With no provider the app
- * runs unauthenticated — consumers of useAuth0() must handle the undefined case.
+ * Setup Auth0: resolve the active provider, install createAuth0 if found, and
+ * finish any in-flight redirect callback. With no provider the app runs
+ * unauthenticated.
  */
-export async function setupAuth(app: App<Element>, router: Router) {
-    app.config.globalProperties.$auth = null;
+export async function setupAuth(app: App<Element>, router: Router): Promise<void> {
+    const provider = await resolveActiveProvider();
+    if (!provider) return;
 
-    const footprint = readAuth0NativeStorage();
-
-    const provider = footprint
-        ? await getProviderByClientId(footprint.client_id)
-        : null;
-    if (!provider) return undefined;
-
-    const oauth = createAuth0(buildAuth0Options(provider), {
-        skipRedirectCallback: true,
-    });
+    const oauth = createAuth0(buildAuth0Options(provider), { skipRedirectCallback: true });
+    app.use(oauth);
+    installedOauth = oauth;
     isAuthPluginInstalled.value = true;
+    setProviderIdHeader(provider._id);
 
-    async function handleRedirectCallbackIfPresent(): Promise<{ handled: boolean; url: URL }> {
-        const url = new URL(location.href);
-        if (!url.searchParams.has("code") || !url.searchParams.has("state"))
-            return { handled: false, url };
-        if (url.searchParams.has("error")) {
-            const err = url.searchParams.get("error");
-            console.error("Auth0 callback error:", err);
-            return { handled: false, url };
-        }
+    const url = new URL(location.href);
+    let handled = false;
+    if (url.searchParams.has("code") && url.searchParams.has("state")) {
         try {
             await oauth.handleRedirectCallback(location.href);
-            return { handled: true, url };
+            handled = true;
         } catch (e) {
             Sentry?.captureException(e);
-            return { handled: false, url };
         }
     }
 
-    app.use(oauth);
-
-    const { handled, url } = await handleRedirectCallbackIfPresent();
-
-    const effectiveProvider = handled
-        ? await (async () => {
-              const postFootprint = readAuth0NativeStorage();
-              return postFootprint
-                  ? await getProviderByClientId(postFootprint.client_id)
-                  : null;
-          })()
-        : provider;
-
-    if (effectiveProvider) {
-        activeProviderId.value = effectiveProvider._id;
-        setCustomHeader("x-auth-provider-id", effectiveProvider._id);
-    }
-
-    try {
-        const token = await oauth.getAccessTokenSilently();
-        if (token) {
-            setCustomHeader("Authorization", `Bearer ${token}`);
-            getSocket().setAuth(token, activeProviderId.value);
-            getSocket().reconnect();
-            startTokenRefresh(oauth);
-        }
-    } catch {
-        // The app has a valid unauthenticated state (public content), so swallow.
-    }
+    // Public unauthenticated state is valid for the app — failure here just
+    // means no token; proceed and let the socket connect unauthenticated.
+    await refreshTokenSilently();
 
     if (handled) {
-        const path = url.pathname + (url.hash || "");
-        router.replace(path || "/").catch(() => {});
+        router.replace(url.pathname + (url.hash || "") || "/").catch(() => {});
     }
-
-    await new Promise<void>((resolve) => {
-        if (!oauth.isLoading.value) {
-            resolve();
-            return;
-        }
-        const stop = watch(
-            () => oauth.isLoading.value,
-            (isLoading) => {
-                if (!isLoading) {
-                    stop();
-                    resolve();
-                }
-            },
-        );
-    });
-
-    return oauth;
 }
 
 /**
- * Trigger login with the given provider by creating a temporary Auth0 client and
- * calling loginWithRedirect(). On return, the app boot will use readAuth0NativeStorage()
- * to resolve the provider and complete the callback. Do not modify the OAuth state parameter.
+ * Ask Auth0 for a fresh access token via the refresh token, then push it to
+ * the Authorization header and the socket. Returns true on success. Call from
+ * the socket's connect_error handler before falling back to a visible
+ * re-login — this is what `useRefreshTokens: true` is for.
  */
-const AUTH0_PROMPT_VALUES = ["none", "login", "consent", "select_account"] as const;
-type Auth0Prompt = (typeof AUTH0_PROMPT_VALUES)[number];
+export async function refreshTokenSilently(): Promise<boolean> {
+    if (!installedOauth) return false;
+    try {
+        const token = await installedOauth.getAccessTokenSilently();
+        if (!token) return false;
+        setCustomHeader("Authorization", `Bearer ${token}`);
+        getSocket().setAuth(token, activeProviderId.value);
+        getSocket().reconnect();
+        return true;
+    } catch {
+        return false;
+    }
+}
 
+/**
+ * Trigger login with the given provider. Creates a temporary Auth0 client and
+ * calls loginWithRedirect. On return, setupAuth picks up the session.
+ */
 export async function loginWithProvider(
-    provider: AuthProviderDto,
+    provider: ProviderConfig,
     opts?: { prompt?: Auth0Prompt },
 ): Promise<void> {
-    const webOrigin = window.location.origin;
-
-    // Evict any in-flight Auth0 PKCE transactions from previously aborted
-    // login attempts (e.g. the user hit Back while on the Auth0 page). The
-    // Auth0 SDK persists each loginWithRedirect's { code_verifier, state }
-    // pair under a0.spajs.txs.<clientId> in sessionStorage so it can complete
-    // the code-for-token exchange on return, but it does not clean up pairs
-    // from aborted flows. If a stale pair is still present when the next
-    // callback fires, handleRedirectCallback picks it up first and the PKCE
-    // verifier won't match the fresh authorization code — the call fails
-    // silently and the user has to click login a second time.
-    // Only clears sessionStorage a0.spajs.* transaction keys; the localStorage
-    // @@auth0spajs@@::* keys holding completed sessions are untouched.
-    for (let i = sessionStorage.length - 1; i >= 0; i--) {
-        const key = sessionStorage.key(i);
-        if (key?.startsWith("a0.spajs.")) sessionStorage.removeItem(key);
-    }
-
-    const client = await createAuth0Client({
-        domain: provider.domain,
-        clientId: provider.clientId,
-        cacheLocation: "localstorage",
-        authorizationParams: {
-            audience: provider.audience,
-            scope: "openid profile email offline_access",
-            redirect_uri: webOrigin,
-        },
-    });
+    // Evict stale PKCE transactions from aborted attempts so the next
+    // callback matches the fresh code_verifier.
+    clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
+    const client = await createAuth0Client(buildAuth0Options(provider));
     await client.loginWithRedirect({
         authorizationParams: opts?.prompt ? { prompt: opts.prompt } : undefined,
     });
@@ -220,131 +171,26 @@ export async function loginWithProvider(
 
 /**
  * Clear Auth0 native cache keys, active provider id, and shared token.
- * Use when switching provider or logging out. Callers are responsible for
- * refreshing any downstream state (e.g. reconnecting the socket) afterwards.
+ * Use when switching provider or logging out.
  */
 export function clearAuth0Cache(): void {
-    activeProviderId.value = null;
+    setProviderIdHeader(null);
     removeCustomHeader("Authorization");
-    removeCustomHeader("x-auth-provider-id");
-
-    // NOTE: these storage key prefixes are specific to the Auth0 SPA SDK. If we
-    // add non-Auth0 OIDC providers, this cleanup will need to be made generic
-    // (or delegated to each provider adapter).
-    const keysToRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key?.startsWith("@@auth0spajs@@")) keysToRemove.push(key);
-    }
-    for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (key?.startsWith("a0.spajs.")) keysToRemove.push(key);
-    }
-    keysToRemove.forEach((k) => {
-        localStorage.removeItem(k);
-        sessionStorage.removeItem(k);
-    });
+    clearStoragePrefix(localStorage, AUTH0_CACHE_PREFIX);
+    clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
 }
 
-/** Open the provider selection modal (e.g. on apiAuthFailed). */
 export function openProviderModal(): void {
     showProviderSelectionModal.value = true;
 }
 
-/**
- * Resolve the auth provider the user most recently used by reading the Auth0
- * storage footprint and looking it up in Dexie. Call BEFORE clearAuth0Cache(),
- * otherwise the footprint will have been wiped.
- */
-export async function getLastSelectedProvider(): Promise<AuthProviderDto | null> {
-    const footprint = readAuth0NativeStorage();
-    if (!footprint?.client_id) return null;
-    try {
-        return await getProviderByClientId(footprint.client_id);
-    } catch (e) {
-        Sentry?.captureException(e);
-        return null;
-    }
-}
-
-// ── Proactive token refresh ─────────────────────────────────────────────────
-// Auth0 access tokens expire (typically 1 hour). We refresh every 5 minutes
-// so the socket and HTTP headers always carry a valid token.
-
-const TOKEN_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
-let tokenRefreshTimer: ReturnType<typeof setInterval> | null = null;
-
-export function startTokenRefresh(oauth: {
-    getAccessTokenSilently: () => Promise<string>;
-}): void {
-    stopTokenRefresh();
-    tokenRefreshTimer = setInterval(async () => {
-        try {
-            const token = await oauth.getAccessTokenSilently();
-            if (token) {
-                setCustomHeader("Authorization", `Bearer ${token}`);
-                getSocket().setAuth(token, activeProviderId.value);
-            }
-        } catch {
-            // Token refresh failed — the apiAuthFailed socket event will handle redirect
-        }
-    }, TOKEN_REFRESH_INTERVAL_MS);
-}
-
-export function stopTokenRefresh(): void {
-    if (tokenRefreshTimer) {
-        clearInterval(tokenRefreshTimer);
-        tokenRefreshTimer = null;
-    }
-}
-
-/**
- * Get a token from the oauth client if the user is authenticated.
- * Returns undefined if not authenticated.
- */
-export async function getToken(oauth: {
-    isAuthenticated: { value: boolean };
-    getAccessTokenSilently: () => Promise<string>;
-}): Promise<string | undefined> {
-    if (!oauth.isAuthenticated.value) return undefined;
-    return oauth.getAccessTokenSilently();
-}
-
-/**
- * Resolve active provider id from readAuth0NativeStorage() + Dexie and set activeProviderId.
- * Call after init() when db is ready, and after callback handling.
- */
-export async function resolveProviderId(): Promise<void> {
-    const footprint = readAuth0NativeStorage();
-    if (!footprint?.client_id) {
-        activeProviderId.value = null;
-        removeCustomHeader("x-auth-provider-id");
-        return;
-    }
-    try {
-        const provider = await getProviderByClientId(footprint.client_id);
-        if (provider) {
-            activeProviderId.value = provider._id;
-            setCustomHeader("x-auth-provider-id", provider._id);
-        } else {
-            activeProviderId.value = null;
-            removeCustomHeader("x-auth-provider-id");
-        }
-    } catch (e) {
-        Sentry?.captureException(e);
-        activeProviderId.value = null;
-        removeCustomHeader("x-auth-provider-id");
-    }
-}
-
 export default {
     setupAuth,
-    resolveProviderId,
     openProviderModal,
     clearAuth0Cache,
-    readAuth0NativeStorage,
     activeProviderId,
     showProviderSelectionModal,
     loginWithProvider,
-    getToken,
+    resolveActiveProvider,
+    refreshTokenSilently,
 };

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -5,12 +5,11 @@ import App from "./App.vue";
 import router from "./router";
 import {
     setupAuth,
-    resolveProviderId,
     openProviderModal,
     clearAuth0Cache,
-    getLastSelectedProvider,
+    resolveActiveProvider,
     loginWithProvider,
-    stopTokenRefresh,
+    refreshTokenSilently,
 } from "@/auth";
 import { DocType, getSocket, init, warmMangoCaches } from "luminary-shared";
 import { loadPlugins } from "./util/pluginLoader";
@@ -80,8 +79,6 @@ async function Startup() {
         "connect_error",
         async (err: Error & { data?: { type?: string; reason?: string } }) => {
             if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-            Sentry?.captureMessage("API authentication failed");
-            stopTokenRefresh();
 
             const reason = err.data?.reason;
 
@@ -95,7 +92,14 @@ async function Startup() {
                 return;
             }
 
-            const lastProvider = await getLastSelectedProvider();
+            // Normal case: the access token expired. Ask the Auth0 SDK for a
+            // fresh one via the refresh token — no redirect needed.
+            if (await refreshTokenSilently()) return;
+
+            // The refresh token itself is gone or rejected — need a visible
+            // re-login.
+            Sentry?.captureMessage("API authentication failed; silent refresh failed");
+            const lastProvider = await resolveActiveProvider();
             clearAuth0Cache();
             socket.setAuth("", null);
             if (lastProvider) {
@@ -108,7 +112,6 @@ async function Startup() {
 
     await setupAuth(app, router);
     socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
-    await resolveProviderId();
 
     initAuthLangSync();
     await initLanguage();

--- a/cms/src/auth.spec.ts
+++ b/cms/src/auth.spec.ts
@@ -1,32 +1,177 @@
-import { describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
-import auth from "./auth";
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db, DocType, type AuthProviderDto } from "luminary-shared";
+
+import {
+    activeProviderId,
+    clearAuth0Cache,
+    openProviderModal,
+    refreshTokenSilently,
+    resolveActiveProvider,
+    showProviderSelectionModal,
+} from "./auth";
+
+const providerA: AuthProviderDto = {
+    _id: "provider-a",
+    type: DocType.AuthProvider,
+    updatedTimeUtc: 1704114000000,
+    memberOf: [],
+    label: "Acme",
+    domain: "acme.auth0.com",
+    clientId: "client-a",
+    audience: "https://api.acme.com",
+};
+
+const providerB: AuthProviderDto = {
+    _id: "provider-b",
+    type: DocType.AuthProvider,
+    updatedTimeUtc: 1704114000000,
+    memberOf: [],
+    label: "Beta",
+    domain: "beta.auth0.com",
+    clientId: "client-b",
+    audience: "https://api.beta.com",
+};
+
+async function resetWorld() {
+    localStorage.clear();
+    sessionStorage.clear();
+    history.replaceState(null, "", "/");
+    activeProviderId.value = null;
+    showProviderSelectionModal.value = false;
+    await db.docs.clear();
+}
 
 describe("auth", () => {
-    describe("getToken", () => {
-        it("calls getAccessTokenSilently when isAuthenticated is true", async () => {
-            const getAccessTokenSilently = vi.fn().mockResolvedValue("token");
-            const oauth = {
-                isAuthenticated: ref(true),
-                getAccessTokenSilently,
-            };
+    beforeEach(resetWorld);
+    afterEach(resetWorld);
 
-            const token = await auth.getToken(oauth as any);
-            expect(getAccessTokenSilently).toHaveBeenCalledOnce();
-            expect(token).toBe("token");
+    describe("resolveActiveProvider", () => {
+        it("returns null when storage is empty", async () => {
+            await db.docs.bulkPut([providerA]);
+            expect(await resolveActiveProvider()).toBeNull();
         });
 
-        it("does not call getAccessTokenSilently when isAuthenticated is false", async () => {
-            const getAccessTokenSilently = vi.fn();
-            const oauth = {
-                isAuthenticated: ref(false),
-                getAccessTokenSilently,
-            };
+        it("resolves via the localStorage session cache (returning user)", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: { access_token: "fake" } }),
+            );
 
-            const token = await auth.getToken(oauth as any);
-            expect(getAccessTokenSilently).not.toHaveBeenCalled();
-            expect(token).toBeUndefined();
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
         });
 
+        it("returns null when a localStorage clientId has no matching provider in Dexie", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::unknown-client::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("does NOT trust a stale PKCE txs key when URL has no code/state (bug fix)", async () => {
+            await db.docs.bulkPut([providerA]);
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerA.clientId}`,
+                JSON.stringify({ state: "s", code_verifier: "v" }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("trusts the PKCE txs key when we ARE on the OAuth callback URL", async () => {
+            await db.docs.bulkPut([providerA]);
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerA.clientId}`,
+                JSON.stringify({ state: "s", code_verifier: "v" }),
+            );
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("prefers the localStorage session cache over the sessionStorage txs key", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+            sessionStorage.setItem(
+                `a0.spajs.txs.${providerB.clientId}`,
+                JSON.stringify({ state: "s" }),
+            );
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("ignores malformed cache keys without a clientId segment", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem("@@auth0spajs@@::", JSON.stringify({}));
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::aud::scope`,
+                JSON.stringify({ body: {} }),
+            );
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+    });
+
+    describe("clearAuth0Cache", () => {
+        it("removes @@auth0spajs@@ keys from localStorage and a0.spajs. keys from sessionStorage", () => {
+            localStorage.setItem("@@auth0spajs@@::c1::aud::scope", "x");
+            localStorage.setItem("@@auth0spajs@@::c2::aud::scope", "y");
+            sessionStorage.setItem("a0.spajs.txs.c1", "z");
+            sessionStorage.setItem("a0.spajs.other", "w");
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem("@@auth0spajs@@::c1::aud::scope")).toBeNull();
+            expect(localStorage.getItem("@@auth0spajs@@::c2::aud::scope")).toBeNull();
+            expect(sessionStorage.getItem("a0.spajs.txs.c1")).toBeNull();
+            expect(sessionStorage.getItem("a0.spajs.other")).toBeNull();
+        });
+
+        it("leaves unrelated storage keys untouched", () => {
+            localStorage.setItem("unrelated-app-key", "keep");
+            sessionStorage.setItem("some-other-session-key", "keep");
+            localStorage.setItem("@@auth0spajs@@::c::a::s", "drop");
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem("unrelated-app-key")).toBe("keep");
+            expect(sessionStorage.getItem("some-other-session-key")).toBe("keep");
+            expect(localStorage.getItem("@@auth0spajs@@::c::a::s")).toBeNull();
+        });
+
+        it("resets activeProviderId to null", () => {
+            activeProviderId.value = "provider-a";
+            clearAuth0Cache();
+            expect(activeProviderId.value).toBeNull();
+        });
+    });
+
+    describe("openProviderModal", () => {
+        it("flips showProviderSelectionModal to true", () => {
+            expect(showProviderSelectionModal.value).toBe(false);
+            openProviderModal();
+            expect(showProviderSelectionModal.value).toBe(true);
+        });
+    });
+
+    describe("refreshTokenSilently", () => {
+        it("returns false when no Auth0 plugin has been installed yet", async () => {
+            // setupAuth hasn't run in this test context, so the module has no
+            // oauth handle. The socket connect_error handler relies on this
+            // being a safe `false` rather than a throw.
+            expect(await refreshTokenSilently()).toBe(false);
+        });
     });
 });

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -1,89 +1,77 @@
 import { createAuth0 } from "@auth0/auth0-vue";
 import { createAuth0Client } from "@auth0/auth0-spa-js";
-import { type App, ref, watch } from "vue";
+import { type App, ref } from "vue";
 import * as Sentry from "@sentry/vue";
 import { setCustomHeader, removeCustomHeader, getSocket } from "luminary-shared";
 import { db, DocType } from "luminary-shared";
 import type { AuthProviderDto } from "luminary-shared";
 
-/**
- * Check if auth bypass mode is enabled (for development and E2E testing)
- */
+const AUTH0_CACHE_PREFIX = "@@auth0spajs@@::";
+const AUTH0_TX_PREFIX = "a0.spajs.";
+const AUTH0_TX_KEY_PREFIX = "a0.spajs.txs.";
+
+/** Development / E2E testing bypass. */
 export const isAuthBypassed = import.meta.env.VITE_AUTH_BYPASS === "true";
 
-/** Ref for the currently active OAuth provider document id (or null when unauthenticated). Used by shared HTTP to send x-auth-provider-id. */
+/** Currently active OAuth provider document id (or null when unauthenticated). */
 export const activeProviderId = ref<string | null>(null);
 
 /** When true, the provider selection modal should be shown. */
 export const showProviderSelectionModal = ref(false);
 
 /**
- * True once `setupAuth` has installed the Auth0 Vue plugin (or a mock in bypass
- * mode). Callers should check this before calling `useAuth0()` to avoid the
- * `[Vue warn]: injection "Symbol($auth0)" not found` noise and the
- * `"Please ensure Auth0's Vue plugin is correctly installed"` throw.
+ * True once setupAuth has installed the Auth0 Vue plugin (or bypassed auth).
+ * Check before calling useAuth0() to avoid the
+ * `injection "Symbol($auth0)" not found` warning.
  */
 export const isAuthPluginInstalled = ref(false);
 
-/**
- * Mock auth plugin for bypass mode
- */
-function createMockAuth() {
-    return {
-        isAuthenticated: ref(true),
-        isLoading: ref(false),
-        user: ref({
-            name: "E2E Test User",
-            email: "e2e@test.local",
-            sub: "e2e-test-user",
-        }),
-        idTokenClaims: ref(null),
-        error: ref(null),
-        loginWithRedirect: async () => {},
-        loginWithPopup: async () => {},
-        logout: async () => {},
-        getAccessTokenSilently: async () => "mock-token-for-e2e-testing",
-        getAccessTokenWithPopup: async () => "mock-token-for-e2e-testing",
-        checkSession: async () => {},
-        handleRedirectCallback: async () => ({ appState: {} }),
-        install: () => {},
-    } as any;
+type Auth0Prompt = "none" | "login" | "consent" | "select_account";
+type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
+
+function clearStoragePrefix(storage: Storage, prefix: string): void {
+    for (let i = storage.length - 1; i >= 0; i--) {
+        const key = storage.key(i);
+        if (key?.startsWith(prefix)) storage.removeItem(key);
+    }
+}
+
+function setProviderIdHeader(id: string | null): void {
+    activeProviderId.value = id;
+    if (id) setCustomHeader("x-auth-provider-id", id);
+    else removeCustomHeader("x-auth-provider-id");
 }
 
 /**
- * Extract client_id from Auth0's native storage footprint (read-only).
- * Checks localStorage (@@auth0spajs@@::*) for returning users, then the Auth0
- * SDK's in-flight transaction key in sessionStorage for the redirect callback.
+ * Identify the current provider by reading Auth0's own storage footprint and
+ * looking it up in Dexie. Prefers the localStorage session cache; falls back
+ * to the PKCE transaction key in sessionStorage, but only while we're on the
+ * OAuth callback URL — without that gate, a stale txs key from an aborted
+ * login would impersonate a real session and lock the user out of re-picking.
  */
-export function readAuth0NativeStorage(): { client_id: string } | null {
+export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
     if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
 
+    let clientId: string | null = null;
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
-        if (!key?.startsWith("@@auth0spajs@@::")) continue;
-        const parts = key.split("::");
-        if (parts.length >= 2 && parts[1]) return { client_id: parts[1] };
+        if (!key?.startsWith(AUTH0_CACHE_PREFIX)) continue;
+        clientId = key.slice(AUTH0_CACHE_PREFIX.length).split("::")[0] || null;
+        if (clientId) break;
     }
 
-    // Fall back to the Auth0 SDK's in-flight transaction marker for users
-    // mid-redirect: loginWithRedirect writes a0.spajs.txs.<clientId> into
-    // sessionStorage holding the PKCE code_verifier + state, and it stays
-    // there across the round-trip to Auth0 until handleRedirectCallback
-    // consumes it. So when we boot on the callback URL — before
-    // @@auth0spajs@@::* exists for a first-time login — this key tells us
-    // which provider's redirect we're returning from.
-    for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (!key?.startsWith("a0.spajs.txs.")) continue;
-        const clientId = key.slice("a0.spajs.txs.".length);
-        if (clientId) return { client_id: clientId };
+    if (!clientId) {
+        const params = new URLSearchParams(location.search);
+        if (!params.has("code") || !params.has("state")) return null;
+        for (let i = 0; i < sessionStorage.length; i++) {
+            const key = sessionStorage.key(i);
+            if (!key?.startsWith(AUTH0_TX_KEY_PREFIX)) continue;
+            clientId = key.slice(AUTH0_TX_KEY_PREFIX.length) || null;
+            if (clientId) break;
+        }
+        if (!clientId) return null;
     }
 
-    return null;
-}
-
-/** Look up AuthProvider doc by clientId in Dexie. */
-async function getProviderByClientId(clientId: string): Promise<AuthProviderDto | null> {
     const doc = await db.docs
         .where("type")
         .equals(DocType.AuthProvider)
@@ -92,156 +80,105 @@ async function getProviderByClientId(clientId: string): Promise<AuthProviderDto 
     return (doc as AuthProviderDto) ?? null;
 }
 
-function buildAuth0Options(provider: Pick<AuthProviderDto, "domain" | "clientId" | "audience">) {
+function buildAuth0Options(p: ProviderConfig) {
     return {
-        domain: provider.domain,
-        clientId: provider.clientId,
+        domain: p.domain,
+        clientId: p.clientId,
         useRefreshTokens: true,
         useRefreshTokensFallback: true,
         cacheLocation: "localstorage" as const,
         authorizationParams: {
-            audience: provider.audience,
+            audience: p.audience,
             scope: "openid profile email offline_access",
             redirect_uri: window.location.origin,
         },
     };
 }
 
-export type AuthPlugin = Awaited<ReturnType<typeof setupAuth>>;
+// Module-level handle on the installed Auth0 plugin. Set by setupAuth, read by
+// refreshTokenSilently so the socket's connect_error handler can ask the SDK
+// for a fresh access token without a visible re-login.
+let installedOauth: ReturnType<typeof createAuth0> | null = null;
 
 /**
- * Setup Auth0: read the storage footprint, resolve the provider from Dexie, and
- * install createAuth0 only when a provider is found. With no provider the app
- * runs unauthenticated — consumers of useAuth0() must handle the undefined case.
- * In bypass mode, returns a mock auth plugin.
+ * Setup Auth0: resolve the active provider, install createAuth0 if found, and
+ * finish any in-flight redirect callback. In bypass mode, shortcircuit with a
+ * mock token so E2E tests can run without real Auth0.
  */
-export async function setupAuth(app: App<Element>) {
+export async function setupAuth(app: App<Element>): Promise<void> {
     if (isAuthBypassed) {
         console.warn(
             "⚠️ Auth bypass mode enabled - this should only be used for development/E2E testing",
         );
-        const mockAuth = createMockAuth();
-        app.config.globalProperties.$auth = mockAuth;
         setCustomHeader("Authorization", "Bearer mock-token-for-e2e-testing");
         isAuthPluginInstalled.value = true;
-        return mockAuth;
+        return;
     }
 
-    app.config.globalProperties.$auth = null;
+    const provider = await resolveActiveProvider();
+    if (!provider) return;
 
-    const footprint = readAuth0NativeStorage();
-
-    const provider = footprint ? await getProviderByClientId(footprint.client_id) : null;
-    if (!provider) return undefined;
-
-    const oauth = createAuth0(buildAuth0Options(provider), {
-        skipRedirectCallback: true,
-    });
+    const oauth = createAuth0(buildAuth0Options(provider), { skipRedirectCallback: true });
+    app.use(oauth);
+    installedOauth = oauth;
     isAuthPluginInstalled.value = true;
+    setProviderIdHeader(provider._id);
 
-    async function handleRedirectCallbackIfPresent(): Promise<{ handled: boolean; url: URL }> {
-        const url = new URL(location.href);
-        if (!url.searchParams.has("code") || !url.searchParams.has("state"))
-            return { handled: false, url };
-        if (url.searchParams.has("error")) {
-            const err = url.searchParams.get("error");
-            console.error("Auth0 callback error:", err);
-            return { handled: false, url };
-        }
+    const url = new URL(location.href);
+    let handled = false;
+    if (url.searchParams.has("code") && url.searchParams.has("state")) {
         try {
             await oauth.handleRedirectCallback(location.href);
-            return { handled: true, url };
+            handled = true;
         } catch (e) {
             Sentry?.captureException(e);
-            return { handled: false, url };
         }
     }
 
-    app.use(oauth);
-
-    const { handled, url } = await handleRedirectCallbackIfPresent();
-
-    const effectiveProvider = handled
-        ? await (async () => {
-              const postFootprint = readAuth0NativeStorage();
-              return postFootprint ? await getProviderByClientId(postFootprint.client_id) : null;
-          })()
-        : provider;
-
-    if (effectiveProvider) {
-        activeProviderId.value = effectiveProvider._id;
-        setCustomHeader("x-auth-provider-id", effectiveProvider._id);
-    }
-
-    try {
-        const token = await oauth.getAccessTokenSilently();
-        if (token) {
-            setCustomHeader("Authorization", `Bearer ${token}`);
-            getSocket().setAuth(token, activeProviderId.value);
-            getSocket().reconnect();
-            startTokenRefresh(oauth);
-        }
-    } catch {
-        // The CMS has no unauthenticated state — on token failure (e.g. expired
-        // refresh token) for the returning-user path, reset and prompt re-login.
-        if (!handled) {
-            activeProviderId.value = null;
-            openProviderModal();
-        }
+    const ok = await refreshTokenSilently();
+    if (!ok && !handled) {
+        // CMS has no unauthenticated state — returning-user with an expired
+        // refresh token gets prompted to re-login via the provider modal.
+        setProviderIdHeader(null);
+        openProviderModal();
     }
 
     if (handled) {
-        const path = url.pathname + (url.hash || "") || "/";
-        history.replaceState(history.state, "", path);
+        history.replaceState(history.state, "", url.pathname + (url.hash || "") || "/");
     }
-
-    await new Promise<void>((resolve) => {
-        if (!oauth.isLoading.value) {
-            resolve();
-            return;
-        }
-        const stop = watch(
-            () => oauth.isLoading.value,
-            (isLoading) => {
-                if (!isLoading) {
-                    stop();
-                    resolve();
-                }
-            },
-        );
-    });
-
-    return oauth;
 }
 
 /**
- * Trigger login with the given provider by creating a temporary Auth0 client and
- * calling loginWithRedirect(). On return, the app boot will use readAuth0NativeStorage()
- * to resolve the provider and complete the callback.
+ * Ask Auth0 for a fresh access token via the refresh token, then push it to
+ * the Authorization header and the socket. Returns true on success. Call from
+ * the socket's connect_error handler before falling back to a visible
+ * re-login — this is what `useRefreshTokens: true` is for.
  */
-const AUTH0_PROMPT_VALUES = ["none", "login", "consent", "select_account"] as const;
-type Auth0Prompt = (typeof AUTH0_PROMPT_VALUES)[number];
+export async function refreshTokenSilently(): Promise<boolean> {
+    if (!installedOauth) return false;
+    try {
+        const token = await installedOauth.getAccessTokenSilently();
+        if (!token) return false;
+        setCustomHeader("Authorization", `Bearer ${token}`);
+        getSocket().setAuth(token, activeProviderId.value);
+        getSocket().reconnect();
+        return true;
+    } catch {
+        return false;
+    }
+}
 
+/**
+ * Trigger login with the given provider. Creates a temporary Auth0 client and
+ * calls loginWithRedirect. On return, setupAuth picks up the session.
+ */
 export async function loginWithProvider(
-    provider: AuthProviderDto,
+    provider: ProviderConfig,
     opts?: { prompt?: Auth0Prompt },
 ): Promise<void> {
-    // Evict any in-flight Auth0 PKCE transactions from previously aborted
-    // login attempts (e.g. the user hit Back while on the Auth0 page). The
-    // Auth0 SDK persists each loginWithRedirect's { code_verifier, state }
-    // pair under a0.spajs.txs.<clientId> in sessionStorage so it can complete
-    // the code-for-token exchange on return, but it does not clean up pairs
-    // from aborted flows. If a stale pair is still present when the next
-    // callback fires, handleRedirectCallback picks it up first and the PKCE
-    // verifier won't match the fresh authorization code — the call fails
-    // silently and the user has to click login a second time.
-    // Only clears sessionStorage a0.spajs.* transaction keys; the localStorage
-    // @@auth0spajs@@::* keys holding completed sessions are untouched.
-    for (let i = sessionStorage.length - 1; i >= 0; i--) {
-        const key = sessionStorage.key(i);
-        if (key?.startsWith("a0.spajs.")) sessionStorage.removeItem(key);
-    }
-
+    // Evict stale PKCE transactions from aborted attempts so the next
+    // callback matches the fresh code_verifier.
+    clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
     const client = await createAuth0Client(buildAuth0Options(provider));
     await client.loginWithRedirect({
         authorizationParams: opts?.prompt ? { prompt: opts.prompt } : undefined,
@@ -250,128 +187,28 @@ export async function loginWithProvider(
 
 /**
  * Clear Auth0 native cache keys, active provider id, and shared token.
- * Use when switching provider or logging out. Callers are responsible for
- * refreshing any downstream state (e.g. reconnecting the socket) afterwards.
+ * Use when switching provider or logging out.
  */
 export function clearAuth0Cache(): void {
-    activeProviderId.value = null;
+    setProviderIdHeader(null);
     removeCustomHeader("Authorization");
-    removeCustomHeader("x-auth-provider-id");
-
-    // NOTE: these storage key prefixes are specific to the Auth0 SPA SDK. If we
-    // add non-Auth0 OIDC providers, this cleanup will need to be made generic
-    // (or delegated to each provider adapter).
-    const keysToRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key?.startsWith("@@auth0spajs@@")) keysToRemove.push(key);
-    }
-    for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (key?.startsWith("a0.spajs.")) keysToRemove.push(key);
-    }
-    keysToRemove.forEach((k) => {
-        localStorage.removeItem(k);
-        sessionStorage.removeItem(k);
-    });
+    clearStoragePrefix(localStorage, AUTH0_CACHE_PREFIX);
+    clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
 }
 
-/** Open the provider selection modal (e.g. on apiAuthFailed). */
 export function openProviderModal(): void {
     showProviderSelectionModal.value = true;
 }
 
-/**
- * Resolve the auth provider the user most recently used by reading the Auth0
- * storage footprint and looking it up in Dexie. Call BEFORE clearAuth0Cache(),
- * otherwise the footprint will have been wiped.
- */
-export async function getLastSelectedProvider(): Promise<AuthProviderDto | null> {
-    const footprint = readAuth0NativeStorage();
-    if (!footprint?.client_id) return null;
-    try {
-        return await getProviderByClientId(footprint.client_id);
-    } catch (e) {
-        Sentry?.captureException(e);
-        return null;
-    }
-}
-
-/**
- * Resolve active provider id from readAuth0NativeStorage() + Dexie and set activeProviderId.
- * Call after init() when db is ready.
- */
-export async function resolveProviderId(): Promise<void> {
-    const footprint = readAuth0NativeStorage();
-    if (!footprint?.client_id) {
-        activeProviderId.value = null;
-        removeCustomHeader("x-auth-provider-id");
-        return;
-    }
-    try {
-        const provider = await getProviderByClientId(footprint.client_id);
-        if (provider) {
-            activeProviderId.value = provider._id;
-            setCustomHeader("x-auth-provider-id", provider._id);
-        } else {
-            activeProviderId.value = null;
-            removeCustomHeader("x-auth-provider-id");
-        }
-    } catch (e) {
-        Sentry?.captureException(e);
-        activeProviderId.value = null;
-        removeCustomHeader("x-auth-provider-id");
-    }
-}
-
-// ── Proactive token refresh ─────────────────────────────────────────────────
-// Auth0 access tokens expire (typically 1 hour). We refresh every 5 minutes
-// so the socket and HTTP headers always carry a valid token.
-
-const TOKEN_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
-let tokenRefreshTimer: ReturnType<typeof setInterval> | null = null;
-
-export function startTokenRefresh(oauth: { getAccessTokenSilently: () => Promise<string> }): void {
-    stopTokenRefresh();
-    tokenRefreshTimer = setInterval(async () => {
-        try {
-            const token = await oauth.getAccessTokenSilently();
-            if (token) {
-                setCustomHeader("Authorization", `Bearer ${token}`);
-                getSocket().setAuth(token, activeProviderId.value);
-            }
-        } catch {
-            // Token refresh failed — the apiAuthFailed socket event will handle redirect
-        }
-    }, TOKEN_REFRESH_INTERVAL_MS);
-}
-
-export function stopTokenRefresh(): void {
-    if (tokenRefreshTimer) {
-        clearInterval(tokenRefreshTimer);
-        tokenRefreshTimer = null;
-    }
-}
-
-export async function getToken(oauth: {
-    isAuthenticated: { value: boolean };
-    getAccessTokenSilently: () => Promise<string>;
-}): Promise<string | undefined> {
-    if (!oauth.isAuthenticated.value) return undefined;
-    return oauth.getAccessTokenSilently();
-}
-
 export default {
     setupAuth,
-    resolveProviderId,
     openProviderModal,
     clearAuth0Cache,
-    readAuth0NativeStorage,
     activeProviderId,
     showProviderSelectionModal,
     isAuthPluginInstalled,
     loginWithProvider,
-    getLastSelectedProvider,
+    resolveActiveProvider,
+    refreshTokenSilently,
     isAuthBypassed,
-    getToken,
 };

--- a/cms/src/components/users/CreateOrEditUser.vue
+++ b/cms/src/components/users/CreateOrEditUser.vue
@@ -84,7 +84,7 @@ const authProviders = useDexieLiveQuery(
 const providerOptions = computed(() => [
     { label: "Choose a provider this user belongs to", value: "" },
     ...authProviders.value.map((p) => ({
-        label: p.label ? `${p.label} — ${p.domain}` : p.domain,
+        label: p.label || "Unnamed provider",
         value: p._id,
     })),
 ]);

--- a/cms/src/components/users/UserDisplayCard.vue
+++ b/cms/src/components/users/UserDisplayCard.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 import DisplayCard from "@/components/common/DisplayCard.vue";
-import { db, type UserDto, type GroupDto, DocType } from "luminary-shared";
+import {
+    db,
+    type UserDto,
+    type GroupDto,
+    type AuthProviderDto,
+    DocType,
+} from "luminary-shared";
 import LBadge from "@/components/common/LBadge.vue";
 import { DateTime } from "luxon";
 import { UserGroupIcon, KeyIcon } from "@heroicons/vue/24/outline";
 import { computed } from "vue";
-import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import { breakpointsTailwind, useBreakpoints } from "@vueuse/core";
 
 type Props = {
     usersDoc: UserDto;
@@ -14,14 +20,15 @@ const props = defineProps<Props>();
 const isLocalChanges = db.isLocalChangeAsRef(props.usersDoc._id);
 
 const groups = db.whereTypeAsRef<GroupDto[]>(DocType.Group);
+const authProviders = db.whereTypeAsRef<AuthProviderDto[]>(DocType.AuthProvider);
 
 const emit = defineEmits<{ (e: "edit", id: string): void }>();
 const showEditModal = defineModel<boolean>();
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
-const smallerThanSm = breakpoints.smaller('sm');
+const smallerThanSm = breakpoints.smaller("sm");
 
-function editModalVisible () {
+function editModalVisible() {
     showEditModal.value = true;
     emit("edit", props.usersDoc._id);
 }
@@ -29,6 +36,10 @@ function editModalVisible () {
 const userGroups = computed(() => {
     return groups.value?.filter((g) => props.usersDoc.memberOf.includes(g._id)) || [];
 });
+
+const userProvider = computed(() =>
+    authProviders.value?.find((p) => p._id === props.usersDoc.providerId),
+);
 </script>
 
 <template>
@@ -48,7 +59,7 @@ const userGroups = computed(() => {
                     >
                     <div
                         v-if="usersDoc.lastLogin"
-                            class="flex items-center gap-1 text-xs text-zinc-400"
+                        class="flex items-center gap-1 text-xs text-zinc-400"
                     >
                         <KeyIcon class="h-4 w-4 text-zinc-400 max-sm:h-3 max-sm:w-3" />
                         <span title="Last logged in" class="whitespace-nowrap">
@@ -62,27 +73,63 @@ const userGroups = computed(() => {
                                     )
                             }}
                         </span>
-                </div>
-                <div v-else class="text-xs text-zinc-400 whitespace-nowrap">Has not logged in yet</div>
+                    </div>
+                    <div v-else class="whitespace-nowrap text-xs text-zinc-400">
+                        Has not logged in yet
+                    </div>
                 </div>
             </template>
             <template #content>
                 <div class="flex justify-between pb-1 min-[1500px]:pt-0">
                     <div>
-                        <span class="text-xs text-zinc-500 sm:text-sm">{{
-                            usersDoc.email
-                        }}</span>
+                        <span class="text-xs text-zinc-500 sm:text-sm">{{ usersDoc.email }}</span>
                     </div>
-                    
                 </div>
             </template>
 
             <template #mobileFooter>
-                <div class="flex flex-1 items-center gap-1">
-                    <div>
+                <div class="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+                    <LBadge
+                        v-if="userProvider"
+                        type="default"
+                        variant="default"
+                        :icon="KeyIcon"
+                        withIcon
+                    >
+                        {{ userProvider.label || userProvider.domain }}
+                    </LBadge>
+                    <div class="flex items-center gap-1">
                         <UserGroupIcon class="h-4 w-4 text-zinc-400" />
+                        <div class="flex flex-wrap gap-1">
+                            <LBadge
+                                v-for="group in userGroups"
+                                :key="group._id"
+                                type="default"
+                                variant="blue"
+                            >
+                                {{ group.name }}
+                            </LBadge>
+                            <span v-if="userGroups.length === 0" class="text-xs text-zinc-400">
+                                No groups
+                            </span>
+                        </div>
                     </div>
-                    <div class="flex flex-wrap gap-1">
+                </div>
+            </template>
+
+            <template #desktopFooter>
+                <div class="flex w-full flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+                    <LBadge
+                        v-if="userProvider"
+                        type="default"
+                        variant="default"
+                        :icon="KeyIcon"
+                        withIcon
+                    >
+                        {{ userProvider.label || userProvider.domain }}
+                    </LBadge>
+                    <div class="flex flex-1 flex-wrap items-center gap-1">
+                        <UserGroupIcon class="h-4 w-4 text-zinc-400" />
                         <LBadge
                             v-for="group in userGroups"
                             :key="group._id"
@@ -95,23 +142,6 @@ const userGroups = computed(() => {
                             No groups
                         </span>
                     </div>
-                </div>
-            </template>
-
-            <template #desktopFooter>
-                <div class="flex w-full flex-1 flex-wrap items-center gap-1">
-                    <UserGroupIcon class="h-4 w-4 text-zinc-400" />
-                    <LBadge
-                        v-for="group in userGroups"
-                        :key="group._id"
-                        type="default"
-                        variant="blue"
-                    >
-                        {{ group.name }}
-                    </LBadge>
-                    <span v-if="userGroups.length === 0" class="text-xs text-zinc-400">
-                        No groups
-                    </span>
                 </div>
             </template>
         </DisplayCard>

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -6,7 +6,7 @@ import App from "./App.vue";
 import router from "./router";
 import { DocType, getSocket, init } from "luminary-shared";
 import { apiUrl, initLanguage } from "@/globalConfig";
-import auth, { isAuthBypassed, stopTokenRefresh } from "./auth";
+import auth, { isAuthBypassed } from "./auth";
 import { useNotificationStore } from "./stores/notification";
 import { changeReqWarnings, changeReqErrors } from "luminary-shared";
 import { initAuthLangSync, initSync } from "./sync";
@@ -96,8 +96,6 @@ async function Startup() {
             "connect_error",
             async (err: Error & { data?: { type?: string; reason?: string } }) => {
                 if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-                Sentry.captureMessage("API authentication failed");
-                stopTokenRefresh();
 
                 const reason = err.data?.reason;
 
@@ -111,7 +109,14 @@ async function Startup() {
                     return;
                 }
 
-                const lastProvider = await auth.getLastSelectedProvider();
+                // Normal case: the access token expired. Ask the Auth0 SDK for
+                // a fresh one via the refresh token — no redirect needed.
+                if (await auth.refreshTokenSilently()) return;
+
+                // The refresh token itself is gone or rejected — need a
+                // visible re-login.
+                Sentry.captureMessage("API authentication failed; silent refresh failed");
+                const lastProvider = await auth.resolveActiveProvider();
                 auth.clearAuth0Cache();
                 socket.setAuth("", null);
                 if (lastProvider) {
@@ -124,7 +129,6 @@ async function Startup() {
     }
 
     await auth.setupAuth(app);
-    await auth.resolveProviderId();
     socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
 
     // Show notification if a change request was rejected or accepted but has warnings


### PR DESCRIPTION
Was not really happy with the state of the auth.ts files for the cms and app. So just a last simplification and it also solves a bug. 