### PR TITLE
feat(auth-provider): add sortIndex to order providers in selection modals

### DIFF
--- a/api/src/dto/AuthProviderDto.ts
+++ b/api/src/dto/AuthProviderDto.ts
@@ -84,6 +84,12 @@ export class AuthProviderDto extends _contentBaseDto {
     @Expose()
     public iconOpacity?: number;
 
+    /** Sort index used to order providers in selection UIs (ascending from 0) */
+    @IsNumber()
+    @IsOptional()
+    @Expose()
+    public sortIndex?: number;
+
     /** Storage bucket ID for the provider icon image */
     @IsString()
     @IsOptional()

--- a/app/src/components/authProvider/AuthProviderSelectionModal.vue
+++ b/app/src/components/authProvider/AuthProviderSelectionModal.vue
@@ -20,7 +20,11 @@ const allProviders = useDexieLiveQuery(
     { initialValue: [] as AuthProviderDto[] },
 );
 
-const providers = computed(() => allProviders.value ?? []);
+const providers = computed(() =>
+    [...(allProviders.value ?? [])].sort(
+        (a, b) => (a.sortIndex ?? Number.POSITIVE_INFINITY) - (b.sortIndex ?? Number.POSITIVE_INFINITY),
+    ),
+);
 
 const hasIcon = (provider: AuthProviderDto) =>
     provider.imageData?.fileCollections?.some((fc) => fc.imageFiles?.length > 0) ?? false;

--- a/app/src/components/authProvider/AuthProviderSelectionModal.vue
+++ b/app/src/components/authProvider/AuthProviderSelectionModal.vue
@@ -20,11 +20,7 @@ const allProviders = useDexieLiveQuery(
         const list = await mangoToDexie<AuthProviderDto>(db.docs, {
             selector: { type: DocType.AuthProvider },
         });
-        return list.sort(
-            (a, b) =>
-                (a.sortIndex ?? Number.POSITIVE_INFINITY) -
-                (b.sortIndex ?? Number.POSITIVE_INFINITY),
-        );
+        return list.sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0));
     },
     { initialValue: [] as AuthProviderDto[] },
 );

--- a/app/src/components/authProvider/AuthProviderSelectionModal.vue
+++ b/app/src/components/authProvider/AuthProviderSelectionModal.vue
@@ -16,15 +16,20 @@ import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 const isVisible = defineModel<boolean>("isVisible");
 const allProviders = useDexieLiveQuery(
-    () => mangoToDexie<AuthProviderDto>(db.docs, { selector: { type: DocType.AuthProvider } }),
+    async () => {
+        const list = await mangoToDexie<AuthProviderDto>(db.docs, {
+            selector: { type: DocType.AuthProvider },
+        });
+        return list.sort(
+            (a, b) =>
+                (a.sortIndex ?? Number.POSITIVE_INFINITY) -
+                (b.sortIndex ?? Number.POSITIVE_INFINITY),
+        );
+    },
     { initialValue: [] as AuthProviderDto[] },
 );
 
-const providers = computed(() =>
-    [...(allProviders.value ?? [])].sort(
-        (a, b) => (a.sortIndex ?? Number.POSITIVE_INFINITY) - (b.sortIndex ?? Number.POSITIVE_INFINITY),
-    ),
-);
+const providers = computed(() => allProviders.value ?? []);
 
 const hasIcon = (provider: AuthProviderDto) =>
     provider.imageData?.fileCollections?.some((fc) => fc.imageFiles?.length > 0) ?? false;

--- a/cms/src/components/authProvider/FormModal.vue
+++ b/cms/src/components/authProvider/FormModal.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from "vue";
 import LModal from "../modals/LModal.vue";
 import LDialog from "../common/LDialog.vue";
 import LCombobox from "../forms/LCombobox.vue";
+import LInput from "../forms/LInput.vue";
 import FormErrors from "./FormErrors.vue";
 import AuthConfig from "./AuthConfig.vue";
 import LabelAndType from "./LabelAndType.vue";
@@ -220,6 +221,35 @@ const handleRevert = () => {
                 <FormErrors :errors="errors ?? []" :validations="providerValidations" />
 
                 <LabelAndType v-model:provider="provider" :disabled="isDisabled" />
+
+                <div class="rounded-md border border-zinc-200 bg-white p-2">
+                    <label
+                        for="provider-sort-index"
+                        class="mb-1 block text-xs font-medium text-gray-700"
+                    >
+                        Sort Index
+                    </label>
+                    <LInput
+                        id="provider-sort-index"
+                        name="providerSortIndex"
+                        type="number"
+                        min="1"
+                        :model-value="provider.sortIndex != null ? String(provider.sortIndex) : ''"
+                        placeholder="1"
+                        :disabled="isDisabled"
+                        @update:model-value="
+                            (v) => {
+                                if (!provider) return;
+                                const trimmed = (v ?? '').trim();
+                                provider.sortIndex =
+                                    trimmed === '' ? undefined : Number(trimmed);
+                            }
+                        "
+                    />
+                    <p class="mt-1 text-[11px] text-zinc-500">
+                        Lower values appear first in the provider selection list (starting at 1).
+                    </p>
+                </div>
 
                 <div class="rounded-md border border-zinc-200 bg-white p-2">
                     <LCombobox

--- a/cms/src/components/authProvider/FormModal.vue
+++ b/cms/src/components/authProvider/FormModal.vue
@@ -1,3 +1,8 @@
+feat(auth-provider): add sortIndex to order providers in selection modals Adds an optional sortIndex
+field to AuthProviderDto so auth providers can be displayed in a deterministic, user-controlled
+order. The app and CMS selection modals apply the sort inside their live query (ascending; providers
+without a value fall to the end), and the CMS FormModal exposes a number input for editing it. New
+providers default to sortIndex 1.
 <script setup lang="ts">
 import { type AuthProviderDto, type GroupDto } from "luminary-shared";
 import { computed, ref, watch } from "vue";
@@ -241,13 +246,12 @@ const handleRevert = () => {
                             (v) => {
                                 if (!provider) return;
                                 const trimmed = (v ?? '').trim();
-                                provider.sortIndex =
-                                    trimmed === '' ? undefined : Number(trimmed);
+                                provider.sortIndex = trimmed === '' ? undefined : Number(trimmed);
                             }
                         "
                     />
                     <p class="mt-1 text-[11px] text-zinc-500">
-                        Lower values appear first in the provider selection list (starting at 1).
+                        Lower values appear first in the provider selection list.
                     </p>
                 </div>
 
@@ -261,10 +265,7 @@ const handleRevert = () => {
                         :disabled="isDisabled"
                         data-test="groupSelector"
                     />
-                    <p
-                        v-if="memberOfError"
-                        class="mt-1 text-[11px] font-medium text-red-600"
-                    >
+                    <p v-if="memberOfError" class="mt-1 text-[11px] font-medium text-red-600">
                         {{ memberOfError }}
                     </p>
                 </div>

--- a/cms/src/components/authProvider/SelectionModal.vue
+++ b/cms/src/components/authProvider/SelectionModal.vue
@@ -16,15 +16,20 @@ const isVisible = defineModel<boolean>("isVisible");
 const storage = storageSelection();
 
 const allProviders = useDexieLiveQuery(
-    () => mangoToDexie<AuthProviderDto>(db.docs, { selector: { type: DocType.AuthProvider } }),
+    async () => {
+        const list = await mangoToDexie<AuthProviderDto>(db.docs, {
+            selector: { type: DocType.AuthProvider },
+        });
+        return list.sort(
+            (a, b) =>
+                (a.sortIndex ?? Number.POSITIVE_INFINITY) -
+                (b.sortIndex ?? Number.POSITIVE_INFINITY),
+        );
+    },
     { initialValue: [] as AuthProviderDto[] },
 );
 
-const providers = computed(() =>
-    [...(allProviders.value ?? [])].sort(
-        (a, b) => (a.sortIndex ?? Number.POSITIVE_INFINITY) - (b.sortIndex ?? Number.POSITIVE_INFINITY),
-    ),
-);
+const providers = computed(() => allProviders.value ?? []);
 
 const hasIcon = (provider: AuthProviderDto) =>
     provider.imageData?.fileCollections?.some((fc) => fc.imageFiles?.length > 0) ?? false;

--- a/cms/src/components/authProvider/SelectionModal.vue
+++ b/cms/src/components/authProvider/SelectionModal.vue
@@ -20,7 +20,11 @@ const allProviders = useDexieLiveQuery(
     { initialValue: [] as AuthProviderDto[] },
 );
 
-const providers = computed(() => allProviders.value ?? []);
+const providers = computed(() =>
+    [...(allProviders.value ?? [])].sort(
+        (a, b) => (a.sortIndex ?? Number.POSITIVE_INFINITY) - (b.sortIndex ?? Number.POSITIVE_INFINITY),
+    ),
+);
 
 const hasIcon = (provider: AuthProviderDto) =>
     provider.imageData?.fileCollections?.some((fc) => fc.imageFiles?.length > 0) ?? false;

--- a/cms/src/components/authProvider/SelectionModal.vue
+++ b/cms/src/components/authProvider/SelectionModal.vue
@@ -20,11 +20,7 @@ const allProviders = useDexieLiveQuery(
         const list = await mangoToDexie<AuthProviderDto>(db.docs, {
             selector: { type: DocType.AuthProvider },
         });
-        return list.sort(
-            (a, b) =>
-                (a.sortIndex ?? Number.POSITIVE_INFINITY) -
-                (b.sortIndex ?? Number.POSITIVE_INFINITY),
-        );
+        return list.sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0));
     },
     { initialValue: [] as AuthProviderDto[] },
 );

--- a/cms/src/composables/useAuthProviders.ts
+++ b/cms/src/composables/useAuthProviders.ts
@@ -134,6 +134,7 @@ export function useAuthProviders() {
             domain: "",
             clientId: "",
             audience: "",
+            sortIndex: 1,
         };
         providers.value.push(newProvider);
 

--- a/shared/src/types/dto.ts
+++ b/shared/src/types/dto.ts
@@ -268,6 +268,7 @@ export type AuthProviderDto = BaseDocumentDto & {
     backgroundColor?: string;
     textColor?: string;
     iconOpacity?: number;
+    sortIndex?: number;
     imageBucketId?: Uuid;
     imageData?: ImageDto;
 };


### PR DESCRIPTION
Adds an optional sortIndex field to AuthProviderDto so auth providers can be displayed in a deterministic, user-controlled order. The app and CMS selection modals now sort ascending by sortIndex (providers without a value fall to the end), and the CMS FormModal exposes a number input for editing it. New providers default to sortIndex 1.