### PR TITLE
fix(sync): preserve blockEnd in mergeVertical when chunks share blockStart

### DIFF
--- a/shared/src/rest/sync2/merge.ts
+++ b/shared/src/rest/sync2/merge.ts
@@ -30,7 +30,7 @@ export function mergeVertical(options: SyncBaseOptions) {
             current.blockEnd =
                 next.blockStart === 0 && next.blockEnd === 0
                     ? current.blockEnd
-                    : next.blockEnd;
+                    : Math.min(current.blockEnd, next.blockEnd);
             current.eof = next.eof;
 
             // Remove next chunk from syncList
@@ -53,8 +53,7 @@ export function mergeVertical(options: SyncBaseOptions) {
     // eof is true only when ALL remaining chunks have reached eof.
     // This prevents prematurely stopping sync when a catch-up fetch (for new data)
     // reaches eof but older incomplete chunks still exist from an interrupted sync.
-    const eof =
-        filteredList.length > 0 ? filteredList.every((chunk) => chunk.eof === true) : false;
+    const eof = filteredList.length > 0 ? filteredList.every((chunk) => chunk.eof === true) : false;
 
     return { eof, blockStart, blockEnd };
 }

--- a/shared/src/rest/sync2/mergeVertical.spec.ts
+++ b/shared/src/rest/sync2/mergeVertical.spec.ts
@@ -894,4 +894,37 @@ describe("mergeVertical", () => {
         expect(result.blockStart).toBe(7000);
         expect(result.blockEnd).toBe(5000);
     });
+
+    it("should preserve blockEnd=0 when a boundary-overlap chunk is pushed on top of a fully-synced chunk", () => {
+        // Regression: syncBatch's syncTolerance overlap on an incremental sync can return a
+        // duplicate doc at the existing entry's blockStart. That pushes a new chunk with
+        // blockStart=T, blockEnd=T-syncTolerance. When mergeVertical adopts next.blockEnd
+        // unconditionally, it clobbers the existing blockEnd=0 — leaving a 1s-range entry
+        // that the initSync validation then discards, triggering a full resync on reload.
+        const T = 1_000_000;
+        const syncTolerance = 1000;
+        syncList.value = [
+            {
+                chunkType: "post",
+                memberOf: ["group1"],
+                blockStart: T,
+                blockEnd: 0,
+                eof: true,
+            },
+            {
+                chunkType: "post",
+                memberOf: ["group1"],
+                blockStart: T,
+                blockEnd: T - syncTolerance,
+                eof: true,
+            },
+        ];
+
+        mergeVertical({ type: DocType.Post, memberOf: ["group1"] });
+
+        expect(syncList.value).toHaveLength(1);
+        expect(syncList.value[0].blockStart).toBe(T);
+        expect(syncList.value[0].blockEnd).toBe(0);
+        expect(syncList.value[0].eof).toBe(true);
+    });
 });


### PR DESCRIPTION
mergeVertical was adopting next.blockEnd unconditionally, which is only correct when next has a strictly smaller blockStart than current. When an incremental sync's syncTolerance overlap returns a boundary doc that was already synced, syncBatch pushes a new chunk with the same blockStart as the existing fully-synced entry. The old merge logic then overwrote the existing blockEnd=0 with the new chunk's blockEnd=T-syncTolerance, producing a 1-second-range eof entry.

On next page reload, initSync's validation flagged the corrupt entry and wiped the entire syncList, causing a full resync of all data — observed as a full resync of public content on every login/logout.

Fix: use Math.min(current.blockEnd, next.blockEnd) to correctly compute the union of both chunks' ranges. No behavior change for strictly descending blockStart (the common case); mergeHorizontal already uses the same rule on line 104.

Adds a regression test that fails without the fix.