### PR TITLE
perf(fts): debounce corpus stats recompute during sync

### DIFF
--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -294,9 +294,11 @@ class Database extends Dexie {
         const nonDeleteDocs = docs.filter((doc) => doc.type !== DocType.DeleteCmd);
         const result = await this.docs.bulkPut(nonDeleteDocs);
 
-        // Update corpus stats if this batch contained ContentDtos
+        // Update corpus stats if this batch contained ContentDtos.
+        // Debounced so a burst of sync batches triggers a single full-corpus scan 10 s
+        // after sync quiets, rather than one O(n) scan per batch (O(n²) across sync).
         if (nonDeleteDocs.length > 0 && nonDeleteDocs[0].type === DocType.Content) {
-            await recomputeCorpusStats();
+            scheduleCorpusStatsRecompute();
         }
 
         return result;


### PR DESCRIPTION
`db.bulkPut` was calling `recomputeCorpusStats()` synchronously after every batch of Content docs, scanning the full Content doc set each time — O(n²) over a fresh sync. Switch to the existing `scheduleCorpusStatsRecompute()` debounce (10 s after last call) so stats are computed once after sync settles. Measured ~3× faster initial sync; no change to search behavior beyond brief staleness of BM25 `N`/`avgdl` during active sync.

1 doc, sum=0 831ms 33ms
2 docs, sum=0 750ms 41ms
100 docs, sum≈55k 980-1067ms 213-672ms
Total (~700 docs) ~7.9s ~2.4s

This is the result from using scheduleCorpusStatsRecompute instead of "await recomputeCorpusStats()" - this works because it debounces the full-corpus scan 10 seconds after sync quiets. I was able to get this comparison by using performance.now() in the bulkPut function for corpus stats. 