### PR TITLE
perf(fts): speed up sync writes and search query latency

### DIFF
--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -273,14 +273,27 @@ watch(
             resolvedDocs.value = new Map();
             return;
         }
-        const docIds = newResults.map((r) => r.docId);
-        const docs = await db.docs.where("_id").anyOf(docIds).toArray();
 
+        // FTS already loaded these docs during scoring — reuse via `result.doc` and
+        // only fall back to a DB lookup for results that arrive without one (e.g.
+        // test fixtures or older callers).
         const docMap = new Map<string, ContentDto>();
         const langIds = new Set<string>();
-        for (const doc of docs) {
-            docMap.set(doc._id, doc as ContentDto);
-            if ((doc as ContentDto).language) langIds.add((doc as ContentDto).language);
+        const missingIds: string[] = [];
+        for (const r of newResults) {
+            if (r.doc) {
+                docMap.set(r.doc._id, r.doc);
+                if (r.doc.language) langIds.add(r.doc.language);
+            } else {
+                missingIds.push(r.docId);
+            }
+        }
+        if (missingIds.length) {
+            const docs = await db.docs.where("_id").anyOf(missingIds).toArray();
+            for (const doc of docs) {
+                docMap.set(doc._id, doc as ContentDto);
+                if ((doc as ContentDto).language) langIds.add((doc as ContentDto).language);
+            }
         }
         resolvedDocs.value = docMap;
 

--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -274,9 +274,9 @@ watch(
             return;
         }
 
-        // FTS already loaded these docs during scoring — reuse via `result.doc` and
-        // only fall back to a DB lookup for results that arrive without one (e.g.
-        // test fixtures or older callers).
+        // FTS already loaded these docs during scoring — reuse via `result.doc`
+        // and only fall back to a DB lookup for results that arrive without
+        // one (e.g. test fixtures or older callers).
         const docMap = new Map<string, ContentDto>();
         const langIds = new Set<string>();
         const missingIds: string[] = [];

--- a/app/src/pages/HomePage.vue
+++ b/app/src/pages/HomePage.vue
@@ -2,6 +2,7 @@
 import IgnorePagePadding from "@/components/IgnorePagePadding.vue";
 import HomePagePinned from "@/components/HomePage/HomePagePinned.vue";
 import HomePageNewest from "@/components/HomePage/HomePageNewest.vue";
+import HomePageSearch from "@/components/HomePage/HomePageSearch.vue";
 import BasePage from "@/components/BasePage.vue";
 import ContinueWatching from "@/components/HomePage/ContinueWatching.vue";
 import ContinueListening from "@/components/HomePage/ContinueListening.vue";
@@ -10,6 +11,7 @@ import ContinueListening from "@/components/HomePage/ContinueListening.vue";
 <template>
     <BasePage>
         <IgnorePagePadding ignoreTop>
+            <HomePageSearch />
             <Suspense>
                 <HomePagePinned />
             </Suspense>

--- a/app/src/pages/HomePage.vue
+++ b/app/src/pages/HomePage.vue
@@ -2,7 +2,6 @@
 import IgnorePagePadding from "@/components/IgnorePagePadding.vue";
 import HomePagePinned from "@/components/HomePage/HomePagePinned.vue";
 import HomePageNewest from "@/components/HomePage/HomePageNewest.vue";
-import HomePageSearch from "@/components/HomePage/HomePageSearch.vue";
 import BasePage from "@/components/BasePage.vue";
 import ContinueWatching from "@/components/HomePage/ContinueWatching.vue";
 import ContinueListening from "@/components/HomePage/ContinueListening.vue";

--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -889,11 +889,10 @@ export async function initDatabase() {
         console.error("Database blocked");
     });
 
-    // Compute FTS corpus stats on startup.
-    // Uses setTimeout(0) to avoid Dexie PSD zone deadlocks during initialization.
-    setTimeout(() => {
-        scheduleCorpusStatsRecompute();
-    }, 0);
+    // Schedule a debounced FTS corpus stats recompute on startup. The persisted
+    // stats from the previous session are used until this fires (10 s later), so
+    // first searches aren't blocked by a full-corpus scan contending with IDB.
+    scheduleCorpusStatsRecompute();
 
     // Wait a little to give the app time to load before deleting expired content to help speed up the initial app loading time
     setTimeout(() => {

--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -16,6 +16,13 @@ import {
     Uuid,
 } from "../types";
 import { scheduleCorpusStatsRecompute } from "../fts/ftsIndexer";
+import {
+    ensureTrigramIndexBuilt,
+    installTrigramHooks,
+    type TrigramDb,
+    type TrigramPostingsRow,
+    type TrigramStatsRow,
+} from "../fts/trigramIndex";
 import { useObservable } from "@vueuse/rxjs";
 import type { Observable } from "rxjs";
 import { ref, type Ref, toRaw, watch } from "vue";
@@ -58,6 +65,15 @@ type dbIndex = {
     localChanges: string;
     queryCache: string;
     luminaryInternals: string;
+    trigramStats: string;
+    trigramPostings: string;
+    /**
+     * Legacy single-table inverted FTS index. Replaced by the split
+     * trigramStats/trigramPostings pair so common-trigram skipping doesn't pay
+     * the postings deserialization cost. Kept as `null` to drop the orphaned
+     * store on installs that already created it.
+     */
+    trigrams: string | null;
 };
 
 export type QueryOptions = {
@@ -119,11 +135,13 @@ export type UpsertOptions<T> = {
     localChangesOnly?: boolean;
 };
 
-class Database extends Dexie {
+class Database extends Dexie implements TrigramDb {
     docs!: Table<BaseDocumentDto>;
     localChanges!: Table<Partial<LocalChangeDto>>; // Partial because it includes id which is only set after saving
     queryCache!: Table<queryCacheDto<BaseDocumentDto>>;
     luminaryInternals!: Table<LuminaryInternals>;
+    trigramStats!: Table<TrigramStatsRow, string>;
+    trigramPostings!: Table<TrigramPostingsRow, string>;
 
     /**
      * Luminary Shared Database class
@@ -135,7 +153,7 @@ class Database extends Dexie {
         this.requestIndexDbPersistent();
 
         const index: string = concatIndex(
-            "_id,type,parentType,language,expiryDate,parentId,publishDate,[type+tagType],*fts",
+            "_id,type,parentType,language,expiryDate,parentId,publishDate,[type+tagType],[language+_id],*fts",
             docsIndex,
         ); // Concatenate and compact app specific indexed fields with shared library indexed fields
         const dbIndex: dbIndex = {
@@ -143,6 +161,9 @@ class Database extends Dexie {
             localChanges: "++id, reqId, docId, status",
             queryCache: "id",
             luminaryInternals: "id",
+            trigramStats: "trigram, df",
+            trigramPostings: "trigram",
+            trigrams: null,
         };
 
         const version: number = bumpDBVersion(
@@ -859,6 +880,8 @@ class Database extends Dexie {
             this.localChanges.clear(),
             this.queryCache.clear(),
             this.luminaryInternals.clear(),
+            this.trigramStats.clear(),
+            this.trigramPostings.clear(),
         ]);
     }
 }
@@ -868,6 +891,10 @@ export let db: Database;
 export async function initDatabase() {
     const _v: number = await getDbVersion();
     db = new Database(_v, config.docsIndex);
+
+    // Install trigram-index hooks before opening the DB so the first writes are
+    // captured. Hooks just queue changes; the batched flush runs on a debounce.
+    installTrigramHooks(db);
 
     // Open the database and wait for it to be ready
     await new Promise<void>((resolve) => {
@@ -893,6 +920,16 @@ export async function initDatabase() {
     // stats from the previous session are used until this fires (10 s later), so
     // first searches aren't blocked by a full-corpus scan contending with IDB.
     scheduleCorpusStatsRecompute();
+
+    // Build the trigram inverted index from existing docs if it's empty.
+    // Awaited here so ftsSearch can rely on a populated index without needing
+    // a fallback path. First run pays a one-time backfill cost; subsequent
+    // runs are a no-op since the table is already populated.
+    try {
+        await ensureTrigramIndexBuilt(db);
+    } catch (err) {
+        console.error("[trigramIndex] backfill failed", err);
+    }
 
     // Wait a little to give the app time to load before deleting expired content to help speed up the initial app loading time
     setTimeout(() => {

--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -21,7 +21,6 @@ import {
     installTrigramHooks,
     type TrigramDb,
     type TrigramPostingsRow,
-    type TrigramStatsRow,
 } from "../fts/trigramIndex";
 import { useObservable } from "@vueuse/rxjs";
 import type { Observable } from "rxjs";
@@ -65,15 +64,12 @@ type dbIndex = {
     localChanges: string;
     queryCache: string;
     luminaryInternals: string;
-    trigramStats: string;
-    trigramPostings: string;
     /**
-     * Legacy single-table inverted FTS index. Replaced by the split
-     * trigramStats/trigramPostings pair so common-trigram skipping doesn't pay
-     * the postings deserialization cost. Kept as `null` to drop the orphaned
-     * store on installs that already created it.
+     * Inverted FTS index — `{ trigram, postings: [docId, tf][] }`. Read by
+     * `ftsSearch` so per-trigram lookups don't queue behind sync's writes on
+     * `db.docs`. Maintained via debounced flush from a Dexie hook on `db.docs`.
      */
-    trigrams: string | null;
+    trigramPostings: string;
 };
 
 export type QueryOptions = {
@@ -140,7 +136,6 @@ class Database extends Dexie implements TrigramDb {
     localChanges!: Table<Partial<LocalChangeDto>>; // Partial because it includes id which is only set after saving
     queryCache!: Table<queryCacheDto<BaseDocumentDto>>;
     luminaryInternals!: Table<LuminaryInternals>;
-    trigramStats!: Table<TrigramStatsRow, string>;
     trigramPostings!: Table<TrigramPostingsRow, string>;
 
     /**
@@ -161,9 +156,7 @@ class Database extends Dexie implements TrigramDb {
             localChanges: "++id, reqId, docId, status",
             queryCache: "id",
             luminaryInternals: "id",
-            trigramStats: "trigram, df",
             trigramPostings: "trigram",
-            trigrams: null,
         };
 
         const version: number = bumpDBVersion(
@@ -880,7 +873,6 @@ class Database extends Dexie implements TrigramDb {
             this.localChanges.clear(),
             this.queryCache.clear(),
             this.luminaryInternals.clear(),
-            this.trigramStats.clear(),
             this.trigramPostings.clear(),
         ]);
     }
@@ -892,8 +884,9 @@ export async function initDatabase() {
     const _v: number = await getDbVersion();
     db = new Database(_v, config.docsIndex);
 
-    // Install trigram-index hooks before opening the DB so the first writes are
-    // captured. Hooks just queue changes; the batched flush runs on a debounce.
+    // Install trigram-index hooks before opening the DB so the first writes
+    // are captured. Hooks just queue changes; the batched flush runs on a
+    // 5 s quiescence debounce.
     installTrigramHooks(db);
 
     // Open the database and wait for it to be ready
@@ -921,15 +914,13 @@ export async function initDatabase() {
     // first searches aren't blocked by a full-corpus scan contending with IDB.
     scheduleCorpusStatsRecompute();
 
-    // Build the trigram inverted index from existing docs if it's empty.
-    // Awaited here so ftsSearch can rely on a populated index without needing
-    // a fallback path. First run pays a one-time backfill cost; subsequent
-    // runs are a no-op since the table is already populated.
-    try {
-        await ensureTrigramIndexBuilt(db);
-    } catch (err) {
+    // Build `trigramPostings` from existing fts arrays if empty. Run in the
+    // background so app startup isn't gated on the (one-time) backfill;
+    // searches before it commits will fall through to the multi-entry index
+    // fallback path in `ftsSearch`.
+    ensureTrigramIndexBuilt(db).catch((err) => {
         console.error("[trigramIndex] backfill failed", err);
-    }
+    });
 
     // Wait a little to give the app time to load before deleting expired content to help speed up the initial app loading time
     setTimeout(() => {

--- a/shared/src/fts/fts.spec.ts
+++ b/shared/src/fts/fts.spec.ts
@@ -14,6 +14,7 @@ import {
     scheduleCorpusStatsRecompute,
 } from "./ftsIndexer";
 import { ftsSearch } from "./ftsSearch";
+import { flushPendingTrigramChanges } from "./trigramIndex";
 
 function makeContentDoc(overrides: Partial<ContentDto> & { _id: string }): ContentDto {
     return {
@@ -77,12 +78,15 @@ function mergeFtsEntries(...fieldResults: Array<{ entries: string[]; tokenCount:
 }
 
 /**
- * Helper: ingest a doc with FTS data via bulkPut.
+ * Helper: ingest a doc with FTS data via bulkPut. Drains the trigram-index
+ * write queue so the next `ftsSearch` call sees this doc on the fast path —
+ * in production the queue flushes on a 5 s quiescence debounce.
  */
 async function ingestDocWithFts(doc: ContentDto, ftsEntries: string[], tokenCount: number) {
     doc.fts = ftsEntries;
     doc.ftsTokenCount = tokenCount;
     await db.bulkPut([doc]);
+    await flushPendingTrigramChanges(db);
 }
 
 describe("FTS Indexer and Search", () => {
@@ -98,6 +102,12 @@ describe("FTS Indexer and Search", () => {
     beforeEach(async () => {
         await db.docs.clear();
         await db.luminaryInternals.clear();
+        // Drain the in-memory queue first so any pending changes from prior
+        // tests don't write back into the just-cleared trigram table, then
+        // clear it. `db.docs.clear()` may not fire deleting hooks (Dexie's
+        // bulk clear bypasses them), so we can't rely on the hook path alone.
+        await flushPendingTrigramChanges(db);
+        await db.trigramPostings.clear();
     });
 
     describe("FTS ingestion via bulkPut", () => {

--- a/shared/src/fts/ftsIndexer.ts
+++ b/shared/src/fts/ftsIndexer.ts
@@ -2,29 +2,21 @@ import { db } from "../db/database";
 import { DocType, type ContentDto } from "../types";
 import type { FtsCorpusStats } from "./types";
 
-/**
- * Get corpus statistics for BM25 scoring.
- */
+const RECOMPUTE_DEBOUNCE_MS = 10_000;
+
+/** BM25 needs N (doc count) and avgdl (avg doc length). The aggregate is
+ *  persisted so search doesn't have to scan all docs per query. */
 export async function getCorpusStats(): Promise<FtsCorpusStats> {
     const entry = await db.luminaryInternals.get("corpusStats");
     return entry?.value ?? { totalTokenCount: 0, docCount: 0 };
 }
 
-/**
- * Store corpus statistics for BM25 scoring.
- */
 export async function setCorpusStats(stats: FtsCorpusStats): Promise<void> {
     await db.luminaryInternals.put({ id: "corpusStats", value: stats });
 }
 
-let recomputeTimer: ReturnType<typeof setTimeout> | undefined;
-const RECOMPUTE_DEBOUNCE_MS = 10_000;
-
-/**
- * Recompute corpus stats from scratch by scanning all Content docs.
- * Uses the existing `type` index on the docs table for efficient filtering.
- * Streams docs via `.each()` to keep memory usage constant.
- */
+/** Stream all Content docs via `.each()` to keep memory constant, sum
+ *  `ftsTokenCount`, persist the aggregate. */
 export async function recomputeCorpusStats(): Promise<void> {
     let totalTokenCount = 0;
     let docCount = 0;
@@ -41,16 +33,16 @@ export async function recomputeCorpusStats(): Promise<void> {
     await setCorpusStats({ totalTokenCount, docCount });
 }
 
-/**
- * Schedule a debounced corpus stats recomputation.
- * Ensures only one recomputation fires 10 seconds after the last call.
- */
+let recomputeTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** Debounced full-corpus recompute. Coalesces a sync burst into a single
+ *  scan that fires after `RECOMPUTE_DEBOUNCE_MS` of quiescence. */
 export function scheduleCorpusStatsRecompute(): void {
-    if (recomputeTimer !== undefined) {
-        clearTimeout(recomputeTimer);
-    }
+    if (recomputeTimer !== undefined) clearTimeout(recomputeTimer);
     recomputeTimer = setTimeout(() => {
         recomputeTimer = undefined;
-        recomputeCorpusStats();
+        recomputeCorpusStats().catch((err) => {
+            console.error("[ftsIndexer] corpus stats recompute failed", err);
+        });
     }, RECOMPUTE_DEBOUNCE_MS);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -23,6 +23,40 @@ const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "author", boost: 1.0 },
 ];
 
+// LRU cache of per-doc normalized word sets.
+// stripHtml + normalizeText dominate word-match scoring cost; they depend only on
+// the doc's field content, so cache across queries and invalidate on edit via
+// `updatedTimeUtc` in the key.
+const WORD_SET_CACHE_MAX = 500;
+const wordSetCache = new Map<string, Record<string, Set<string>>>();
+
+function getWordSets(
+    doc: ContentDto,
+    fields: FtsFieldConfig[],
+): Record<string, Set<string>> {
+    const key = `${doc._id}:${doc.updatedTimeUtc}`;
+    const cached = wordSetCache.get(key);
+    if (cached) {
+        wordSetCache.delete(key);
+        wordSetCache.set(key, cached);
+        return cached;
+    }
+    const sets: Record<string, Set<string>> = {};
+    const docRec = doc as Record<string, any>;
+    for (const field of fields) {
+        const value = docRec[field.name];
+        if (typeof value !== "string" || !value) continue;
+        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
+        sets[field.name] = new Set(text.split(" "));
+    }
+    wordSetCache.set(key, sets);
+    if (wordSetCache.size > WORD_SET_CACHE_MAX) {
+        const oldest = wordSetCache.keys().next().value;
+        if (oldest !== undefined) wordSetCache.delete(oldest);
+    }
+    return sets;
+}
+
 /**
  * Compute a boost-weighted word match score across fields.
  * For each field, counts how many query words appear as full words,
@@ -30,15 +64,13 @@ const FTS_FIELDS: FtsFieldConfig[] = [
  */
 function computeFieldWordMatchScore(
     queryWords: string[],
-    doc: Record<string, any>,
+    wordSets: Record<string, Set<string>>,
     fields: FtsFieldConfig[],
 ): number {
     let totalScore = 0;
     for (const field of fields) {
-        const value = doc[field.name];
-        if (typeof value !== "string" || !value) continue;
-        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
-        const docWords = new Set(text.split(" "));
+        const docWords = wordSets[field.name];
+        if (!docWords) continue;
         let matches = 0;
         for (const word of queryWords) {
             if (docWords.has(word)) matches++;
@@ -65,6 +97,13 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         bm25b = DEFAULT_B,
     } = options;
 
+    // [perf] temporary timing — remove once investigation complete
+    const __perfMarks: Record<string, number> = {};
+    const __perfStart = performance.now();
+    const __perfMark = (label: string) => {
+        __perfMarks[label] = performance.now() - __perfStart;
+    };
+
     const trigrams = generateSearchTrigrams(query);
     if (trigrams.length === 0) return [];
 
@@ -72,52 +111,53 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
     const N = corpusStats.docCount;
     if (N === 0) return [];
     const avgdl = corpusStats.totalTokenCount / N;
+    __perfMark("corpusStats");
 
     const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
 
-    // Step 1: Count docs per trigram, filter over-represented
+    // Step 1 (merged from former step1+step3): fetch primaryKeys per trigram in parallel.
+    // `df` is derived from `ids.length`, so the previous separate .count() pass is gone.
+    const trigramResults = await Promise.all(
+        trigrams.map(async (trigram) => {
+            const ids = (await db.docs
+                .where("fts")
+                .between(trigram + ":", trigram + ";", true, false)
+                .primaryKeys()) as string[];
+            return { token: trigram, ids };
+        }),
+    );
     const usableTrigrams: Array<{ token: string; df: number }> = [];
-    for (const trigram of trigrams) {
-        const count = await db.docs
-            .where("fts")
-            .between(trigram + ":", trigram + ";", true, false)
-            .count();
-        if (count <= maxDocCount) {
-            usableTrigrams.push({ token: trigram, df: count });
-        }
+    const matchedDocIds = new Set<string>();
+    for (const { token, ids } of trigramResults) {
+        if (ids.length > maxDocCount) continue;
+        usableTrigrams.push({ token, df: ids.length });
+        for (const id of ids) matchedDocIds.add(id);
     }
     if (usableTrigrams.length === 0) return [];
+    __perfMark("step1_trigramLookup");
 
     // Step 2: Compute IDF for each usable trigram
     const idfMap = new Map<string, number>();
     for (const { token, df } of usableTrigrams) {
         idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
     }
+    __perfMark("step2_idf");
 
-    // Step 3: Collect matching doc IDs across all trigrams
-    const matchedDocIds = new Set<string>();
-    for (const { token } of usableTrigrams) {
-        const ids = await db.docs
-            .where("fts")
-            .between(token + ":", token + ";", true, false)
-            .primaryKeys();
-        for (const id of ids) matchedDocIds.add(id as string);
-    }
-
-    // Step 4: Load matched docs
+    // Step 4: Load matched docs, filtering by language at query time so wrong-language
+    // docs never enter the scoring/word-match loops below.
     const loadedDocs = await db.docs
         .where("_id")
         .anyOf(Array.from(matchedDocIds))
+        .and((d) => !languageId || (d as ContentDto).language === languageId)
         .toArray();
     const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
+    __perfMark("step4_loadDocs");
 
     // Step 5: Build per-doc trigram→tf map from fts array, compute BM25
     const usableTokens = new Set(usableTrigrams.map((t) => t.token));
     const results: FtsSearchResult[] = [];
 
     docMap.forEach((doc, docId) => {
-        if (languageId && doc.language !== languageId) return;
-
         const tfMap = new Map<string, number>();
         if (doc.fts) {
             for (const entry of doc.fts) {
@@ -141,6 +181,7 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
 
         results.push({ docId, score, wordMatchScore: 0 });
     });
+    __perfMark("step5_bm25");
 
     // Step 6: Boost-weighted full-word match scoring
     const normalizedQuery = normalizeText(query);
@@ -151,21 +192,51 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             const doc = docMap.get(result.docId);
             if (!doc) continue;
 
-            const wordMatchBonus = computeFieldWordMatchScore(
-                queryWords,
-                doc as Record<string, any>,
-                FTS_FIELDS,
-            );
+            const wordSets = getWordSets(doc, FTS_FIELDS);
+            const wordMatchBonus = computeFieldWordMatchScore(queryWords, wordSets, FTS_FIELDS);
             result.wordMatchScore = wordMatchBonus;
             result.score += wordMatchBonus;
         }
     }
+    __perfMark("step6_wordMatch");
 
     // Step 7: Sort by combined score desc, then word match desc
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
     });
+    __perfMark("step7_sort");
+
+    // [perf] temporary — emit phase breakdown
+    const __phases: string[] = [];
+    let __prev = 0;
+    for (const k of [
+        "corpusStats",
+        "step1_trigramLookup",
+        "step2_idf",
+        "step4_loadDocs",
+        "step5_bm25",
+        "step6_wordMatch",
+        "step7_sort",
+    ]) {
+        const t = __perfMarks[k];
+        if (t !== undefined) {
+            __phases.push(`${k}=${(t - __prev).toFixed(1)}`);
+            __prev = t;
+        }
+    }
+    // [perf] rough payload size — helps distinguish I/O cost from doc count
+    let __perfLoadedBytes = 0;
+    docMap.forEach((d) => {
+        try {
+            __perfLoadedBytes += JSON.stringify(d).length;
+        } catch {
+            /* ignore */
+        }
+    });
+    console.debug(
+        `[perf] ftsSearch phases trigrams=${trigrams.length} usable=${usableTrigrams.length} candidates=${matchedDocIds.size} loaded=${docMap.size} loadedKB=${(__perfLoadedBytes / 1024).toFixed(0)} wordSetCache=${wordSetCache.size} | ${__phases.join(" ")}`,
+    );
 
     return results.slice(offset, offset + limit);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -30,10 +30,7 @@ const FTS_FIELDS: FtsFieldConfig[] = [
 const WORD_SET_CACHE_MAX = 500;
 const wordSetCache = new Map<string, Record<string, Set<string>>>();
 
-function getWordSets(
-    doc: ContentDto,
-    fields: FtsFieldConfig[],
-): Record<string, Set<string>> {
+function getWordSets(doc: ContentDto, fields: FtsFieldConfig[]): Record<string, Set<string>> {
     const key = `${doc._id}:${doc.updatedTimeUtc}`;
     const cached = wordSetCache.get(key);
     if (cached) {
@@ -97,13 +94,6 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         bm25b = DEFAULT_B,
     } = options;
 
-    // [perf] temporary timing — remove once investigation complete
-    const __perfMarks: Record<string, number> = {};
-    const __perfStart = performance.now();
-    const __perfMark = (label: string) => {
-        __perfMarks[label] = performance.now() - __perfStart;
-    };
-
     const trigrams = generateSearchTrigrams(query);
     if (trigrams.length === 0) return [];
 
@@ -111,7 +101,6 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
     const N = corpusStats.docCount;
     if (N === 0) return [];
     const avgdl = corpusStats.totalTokenCount / N;
-    __perfMark("corpusStats");
 
     const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
 
@@ -134,14 +123,12 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         for (const id of ids) matchedDocIds.add(id);
     }
     if (usableTrigrams.length === 0) return [];
-    __perfMark("step1_trigramLookup");
 
     // Step 2: Compute IDF for each usable trigram
     const idfMap = new Map<string, number>();
     for (const { token, df } of usableTrigrams) {
         idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
     }
-    __perfMark("step2_idf");
 
     // Step 4: Load matched docs, filtering by language at query time so wrong-language
     // docs never enter the scoring/word-match loops below.
@@ -151,7 +138,6 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         .and((d) => !languageId || (d as ContentDto).language === languageId)
         .toArray();
     const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
-    __perfMark("step4_loadDocs");
 
     // Step 5: Build per-doc trigram→tf map from fts array, compute BM25
     const usableTokens = new Set(usableTrigrams.map((t) => t.token));
@@ -181,7 +167,6 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
 
         results.push({ docId, score, wordMatchScore: 0 });
     });
-    __perfMark("step5_bm25");
 
     // Step 6: Boost-weighted full-word match scoring
     const normalizedQuery = normalizeText(query);
@@ -198,45 +183,12 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             result.score += wordMatchBonus;
         }
     }
-    __perfMark("step6_wordMatch");
 
     // Step 7: Sort by combined score desc, then word match desc
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
     });
-    __perfMark("step7_sort");
-
-    // [perf] temporary — emit phase breakdown
-    const __phases: string[] = [];
-    let __prev = 0;
-    for (const k of [
-        "corpusStats",
-        "step1_trigramLookup",
-        "step2_idf",
-        "step4_loadDocs",
-        "step5_bm25",
-        "step6_wordMatch",
-        "step7_sort",
-    ]) {
-        const t = __perfMarks[k];
-        if (t !== undefined) {
-            __phases.push(`${k}=${(t - __prev).toFixed(1)}`);
-            __prev = t;
-        }
-    }
-    // [perf] rough payload size — helps distinguish I/O cost from doc count
-    let __perfLoadedBytes = 0;
-    docMap.forEach((d) => {
-        try {
-            __perfLoadedBytes += JSON.stringify(d).length;
-        } catch {
-            /* ignore */
-        }
-    });
-    console.debug(
-        `[perf] ftsSearch phases trigrams=${trigrams.length} usable=${usableTrigrams.length} candidates=${matchedDocIds.size} loaded=${docMap.size} loadedKB=${(__perfLoadedBytes / 1024).toFixed(0)} wordSetCache=${wordSetCache.size} | ${__phases.join(" ")}`,
-    );
 
     return results.slice(offset, offset + limit);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -23,37 +23,6 @@ const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "author", boost: 1.0 },
 ];
 
-// LRU cache of per-doc normalized word sets.
-// stripHtml + normalizeText dominate word-match scoring cost; they depend only on
-// the doc's field content, so cache across queries and invalidate on edit via
-// `updatedTimeUtc` in the key.
-const WORD_SET_CACHE_MAX = 500;
-const wordSetCache = new Map<string, Record<string, Set<string>>>();
-
-function getWordSets(doc: ContentDto, fields: FtsFieldConfig[]): Record<string, Set<string>> {
-    const key = `${doc._id}:${doc.updatedTimeUtc}`;
-    const cached = wordSetCache.get(key);
-    if (cached) {
-        wordSetCache.delete(key);
-        wordSetCache.set(key, cached);
-        return cached;
-    }
-    const sets: Record<string, Set<string>> = {};
-    const docRec = doc as Record<string, any>;
-    for (const field of fields) {
-        const value = docRec[field.name];
-        if (typeof value !== "string" || !value) continue;
-        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
-        sets[field.name] = new Set(text.split(" "));
-    }
-    wordSetCache.set(key, sets);
-    if (wordSetCache.size > WORD_SET_CACHE_MAX) {
-        const oldest = wordSetCache.keys().next().value;
-        if (oldest !== undefined) wordSetCache.delete(oldest);
-    }
-    return sets;
-}
-
 /**
  * Compute a boost-weighted word match score across fields.
  * For each field, counts how many query words appear as full words,
@@ -61,13 +30,15 @@ function getWordSets(doc: ContentDto, fields: FtsFieldConfig[]): Record<string, 
  */
 function computeFieldWordMatchScore(
     queryWords: string[],
-    wordSets: Record<string, Set<string>>,
+    doc: Record<string, any>,
     fields: FtsFieldConfig[],
 ): number {
     let totalScore = 0;
     for (const field of fields) {
-        const docWords = wordSets[field.name];
-        if (!docWords) continue;
+        const value = doc[field.name];
+        if (typeof value !== "string" || !value) continue;
+        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
+        const docWords = new Set(text.split(" "));
         let matches = 0;
         for (const word of queryWords) {
             if (docWords.has(word)) matches++;
@@ -115,11 +86,11 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             return { token: trigram, ids };
         }),
     );
-    const usableTrigrams: Array<{ token: string; df: number }> = [];
+    const usableTrigrams: Array<{ token: string; df: number; ids: string[] }> = [];
     const matchedDocIds = new Set<string>();
     for (const { token, ids } of trigramResults) {
         if (ids.length > maxDocCount) continue;
-        usableTrigrams.push({ token, df: ids.length });
+        usableTrigrams.push({ token, df: ids.length, ids });
         for (const id of ids) matchedDocIds.add(id);
     }
     if (usableTrigrams.length === 0) return [];
@@ -130,11 +101,32 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
     }
 
+    // Step 3: Coarse-rank all candidates by Σ idf over matched trigrams, then slice the
+    // page window. Loads only the docs needed for the current page (constant per-page
+    // cost regardless of pagination depth) — supports infinite scroll without ballooning
+    // K with offset. IDF is the dominant ranking signal for trigram queries, so coarse
+    // order tracks exact BM25 closely; final BM25 + word-match still runs on the loaded
+    // slice, so within-page ordering matches the full pipeline.
+    // Buffer of 50 over `limit` absorbs language-filter shrinkage and any disagreement
+    // between coarse and exact scoring at the page boundary.
+    const coarseScore = new Map<string, number>();
+    for (const { token, ids } of usableTrigrams) {
+        const idf = idfMap.get(token)!;
+        for (const id of ids) {
+            coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
+        }
+    }
+    const ranked = Array.from(coarseScore.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(([id]) => id);
+    const candidateIds = ranked.slice(offset, offset + limit + 50);
+    if (candidateIds.length === 0) return [];
+
     // Step 4: Load matched docs, filtering by language at query time so wrong-language
     // docs never enter the scoring/word-match loops below.
     const loadedDocs = await db.docs
         .where("_id")
-        .anyOf(Array.from(matchedDocIds))
+        .anyOf(candidateIds)
         .and((d) => !languageId || (d as ContentDto).language === languageId)
         .toArray();
     const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
@@ -165,7 +157,7 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
                 idf * ((tf * (bm25k1 + 1)) / (tf + bm25k1 * (1 - bm25b + bm25b * (dl / avgdl))));
         }
 
-        results.push({ docId, score, wordMatchScore: 0 });
+        results.push({ docId, score, wordMatchScore: 0, doc });
     });
 
     // Step 6: Boost-weighted full-word match scoring
@@ -177,18 +169,23 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             const doc = docMap.get(result.docId);
             if (!doc) continue;
 
-            const wordSets = getWordSets(doc, FTS_FIELDS);
-            const wordMatchBonus = computeFieldWordMatchScore(queryWords, wordSets, FTS_FIELDS);
+            const wordMatchBonus = computeFieldWordMatchScore(
+                queryWords,
+                doc as Record<string, any>,
+                FTS_FIELDS,
+            );
             result.wordMatchScore = wordMatchBonus;
             result.score += wordMatchBonus;
         }
     }
 
-    // Step 7: Sort by combined score desc, then word match desc
+    // Step 7: Sort by combined score desc, then word match desc.
+    // `results` already represents the page window (Step 3 sliced ranked candidates by
+    // [offset, offset+limit+50]), so we just take the first `limit` after re-sorting.
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
     });
 
-    return results.slice(offset, offset + limit);
+    return results.slice(0, limit);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -1,6 +1,7 @@
 import { db } from "../db/database";
 import { generateSearchTrigrams, normalizeText, stripHtml } from "./trigram";
 import { getCorpusStats } from "./ftsIndexer";
+import { flushPendingTrigramChanges } from "./trigramIndex";
 import type { FtsFieldConfig, FtsSearchOptions, FtsSearchResult } from "./types";
 import type { ContentDto } from "../types";
 
@@ -51,8 +52,12 @@ function computeFieldWordMatchScore(
 }
 
 /**
- * Perform a full-text search using BM25 scoring via the MultiEntry index on docs.
- * Trigram lookups use `between(trigram + ":", trigram + ";")` on the `*fts` index.
+ * Perform a full-text search using BM25 scoring against the persisted trigram
+ * inverted index (`trigramStats` + `trigramPostings` tables).
+ *
+ * All four IDB reads (corpus stats, trigram stats, trigram postings, candidate
+ * docs) run inside a single readonly transaction so we pay the transaction
+ * setup cost once per search rather than four times.
  */
 export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchResult[]> {
     const {
@@ -65,100 +70,180 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         bm25b = DEFAULT_B,
     } = options;
 
+    const t0 = performance.now();
     const trigrams = generateSearchTrigrams(query);
+    const tTrigrams = performance.now();
     if (trigrams.length === 0) return [];
 
-    const corpusStats = await getCorpusStats();
-    const N = corpusStats.docCount;
-    if (N === 0) return [];
-    const avgdl = corpusStats.totalTokenCount / N;
+    // Drain any queued trigram-index writes outside the readonly transaction
+    // (writes can't run inside `r` mode). No-op when nothing's pending.
+    await flushPendingTrigramChanges(db);
+    const tFlush = performance.now();
 
-    const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
+    type UsableTrigram = {
+        token: string;
+        df: number;
+        ids: string[];
+        tfByDoc: Map<string, number>;
+    };
 
-    // Step 1 (merged from former step1+step3): fetch primaryKeys per trigram in parallel.
-    // `df` is derived from `ids.length`, so the previous separate .count() pass is gone.
-    const trigramResults = await Promise.all(
-        trigrams.map(async (trigram) => {
-            const ids = (await db.docs
-                .where("fts")
-                .between(trigram + ":", trigram + ";", true, false)
-                .primaryKeys()) as string[];
-            return { token: trigram, ids };
-        }),
+    type ReadResult = {
+        N: number;
+        avgdl: number;
+        usableTrigrams: UsableTrigram[];
+        docMap: Map<string, ContentDto>;
+    } | null;
+
+    const phaseTimes = {
+        corpusStats: 0,
+        statsBulkGet: 0,
+        postingsBulkGet: 0,
+        postingsParse: 0,
+        coarseRank: 0,
+        docsLoad: 0,
+        usableTrigramCount: 0,
+        candidateCount: 0,
+        statsRowCount: 0,
+        postingsRowCount: 0,
+        docsLoaded: 0,
+    };
+
+    const tTxStart = performance.now();
+    const reads: ReadResult = await db.transaction(
+        "r",
+        [db.luminaryInternals, db.trigramStats, db.trigramPostings, db.docs],
+        async () => {
+            // 1. Corpus stats (uses parent transaction via Dexie.currentTransaction)
+            const tA = performance.now();
+            const corpusStats = await getCorpusStats();
+            phaseTimes.corpusStats = performance.now() - tA;
+            const N = corpusStats.docCount;
+            if (N === 0) return null;
+            const avgdl = corpusStats.totalTokenCount / N;
+            const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
+
+            // 2. Stats: tiny rows used to skip common trigrams (df > maxDocCount)
+            //    before paying for any postings deserialization.
+            const tB = performance.now();
+            const statsRows = await db.trigramStats.bulkGet(trigrams);
+            phaseTimes.statsBulkGet = performance.now() - tB;
+            phaseTimes.statsRowCount = statsRows.filter(Boolean).length;
+            const usableTokens: string[] = [];
+            const usableDfs: number[] = [];
+            for (let i = 0; i < trigrams.length; i++) {
+                const stats = statsRows[i];
+                if (!stats || stats.df === 0 || stats.df > maxDocCount) continue;
+                usableTokens.push(trigrams[i]);
+                usableDfs.push(stats.df);
+            }
+            if (usableTokens.length === 0) return null;
+
+            // 3. Postings: load full posting lists only for usable trigrams.
+            const tC = performance.now();
+            const postingsRows = await db.trigramPostings.bulkGet(usableTokens);
+            phaseTimes.postingsBulkGet = performance.now() - tC;
+            phaseTimes.postingsRowCount = postingsRows.filter(Boolean).length;
+            const tCParse = performance.now();
+            const usableTrigrams: UsableTrigram[] = [];
+            for (let k = 0; k < usableTokens.length; k++) {
+                const row = postingsRows[k];
+                if (!row) continue;
+                const tfByDoc = new Map<string, number>();
+                const ids: string[] = new Array(row.postings.length);
+                for (let j = 0; j < row.postings.length; j++) {
+                    const [docId, tf] = row.postings[j];
+                    ids[j] = docId;
+                    tfByDoc.set(docId, tf);
+                }
+                usableTrigrams.push({
+                    token: usableTokens[k],
+                    df: usableDfs[k],
+                    ids,
+                    tfByDoc,
+                });
+            }
+            phaseTimes.postingsParse = performance.now() - tCParse;
+            phaseTimes.usableTrigramCount = usableTrigrams.length;
+            if (usableTrigrams.length === 0) return null;
+
+            // Coarse-rank by Σ idf over matched trigrams to pick a page window.
+            const tD = performance.now();
+            const idfMap = new Map<string, number>();
+            for (const { token, df } of usableTrigrams) {
+                idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
+            }
+            const coarseScore = new Map<string, number>();
+            for (const { token, ids } of usableTrigrams) {
+                const idf = idfMap.get(token)!;
+                for (const id of ids) {
+                    coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
+                }
+            }
+            const ranked = Array.from(coarseScore.entries())
+                .sort((a, b) => b[1] - a[1])
+                .map(([id]) => id);
+            const candidateIds = ranked.slice(offset, offset + limit + 50);
+            phaseTimes.coarseRank = performance.now() - tD;
+            phaseTimes.candidateCount = candidateIds.length;
+            if (candidateIds.length === 0) return null;
+
+            // 4. Load candidate docs. When a languageId is provided, use the
+            //    compound `[language+_id]` index so wrong-language candidates
+            //    miss at the IDB layer — no row read, no structured-clone
+            //    deserialization for docs we'd discard anyway.
+            const tE = performance.now();
+            const loadedDocs = languageId
+                ? await db.docs
+                      .where("[language+_id]")
+                      .anyOf(candidateIds.map((id) => [languageId, id]))
+                      .toArray()
+                : await db.docs.where("_id").anyOf(candidateIds).toArray();
+            const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
+            phaseTimes.docsLoad = performance.now() - tE;
+            phaseTimes.docsLoaded = loadedDocs.length;
+
+            return { N, avgdl, usableTrigrams, docMap };
+        },
     );
-    const usableTrigrams: Array<{ token: string; df: number; ids: string[] }> = [];
-    const matchedDocIds = new Set<string>();
-    for (const { token, ids } of trigramResults) {
-        if (ids.length > maxDocCount) continue;
-        usableTrigrams.push({ token, df: ids.length, ids });
-        for (const id of ids) matchedDocIds.add(id);
-    }
-    if (usableTrigrams.length === 0) return [];
+    const tTxEnd = performance.now();
 
-    // Step 2: Compute IDF for each usable trigram
+    if (!reads) {
+        const tEnd = performance.now();
+        console.log("[ftsSearch]", {
+            query,
+            trigramCount: trigrams.length,
+            total_ms: +(tEnd - t0).toFixed(2),
+            trigramGen_ms: +(tTrigrams - t0).toFixed(2),
+            flush_ms: +(tFlush - tTrigrams).toFixed(2),
+            tx_total_ms: +(tTxEnd - tTxStart).toFixed(2),
+            ...phaseTimes,
+            note: "no results",
+        });
+        return [];
+    }
+    const { N, avgdl, usableTrigrams, docMap } = reads;
+
+    // Pure-JS work below — no IDB.
+    const tBm25Start = performance.now();
     const idfMap = new Map<string, number>();
     for (const { token, df } of usableTrigrams) {
         idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
     }
 
-    // Step 3: Coarse-rank all candidates by Σ idf over matched trigrams, then slice the
-    // page window. Loads only the docs needed for the current page (constant per-page
-    // cost regardless of pagination depth) — supports infinite scroll without ballooning
-    // K with offset. IDF is the dominant ranking signal for trigram queries, so coarse
-    // order tracks exact BM25 closely; final BM25 + word-match still runs on the loaded
-    // slice, so within-page ordering matches the full pipeline.
-    // Buffer of 50 over `limit` absorbs language-filter shrinkage and any disagreement
-    // between coarse and exact scoring at the page boundary.
-    const coarseScore = new Map<string, number>();
-    for (const { token, ids } of usableTrigrams) {
-        const idf = idfMap.get(token)!;
-        for (const id of ids) {
-            coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
-        }
-    }
-    const ranked = Array.from(coarseScore.entries())
-        .sort((a, b) => b[1] - a[1])
-        .map(([id]) => id);
-    const candidateIds = ranked.slice(offset, offset + limit + 50);
-    if (candidateIds.length === 0) return [];
-
-    // Step 4: Load matched docs, filtering by language at query time so wrong-language
-    // docs never enter the scoring/word-match loops below.
-    const loadedDocs = await db.docs
-        .where("_id")
-        .anyOf(candidateIds)
-        .and((d) => !languageId || (d as ContentDto).language === languageId)
-        .toArray();
-    const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
-
-    // Step 5: Build per-doc trigram→tf map from fts array, compute BM25
-    const usableTokens = new Set(usableTrigrams.map((t) => t.token));
     const results: FtsSearchResult[] = [];
-
     docMap.forEach((doc, docId) => {
-        const tfMap = new Map<string, number>();
-        if (doc.fts) {
-            for (const entry of doc.fts) {
-                const colonIdx = entry.indexOf(":", 3); // token is always 3 chars
-                const token = entry.substring(0, colonIdx);
-                if (usableTokens.has(token)) {
-                    tfMap.set(token, parseFloat(entry.substring(colonIdx + 1)));
-                }
-            }
-        }
-
         const dl = doc.ftsTokenCount || 1;
         let score = 0;
-        for (const { token } of usableTrigrams) {
-            const tf = tfMap.get(token) || 0;
+        for (const t of usableTrigrams) {
+            const tf = t.tfByDoc.get(docId) || 0;
             if (tf === 0) continue;
-            const idf = idfMap.get(token)!;
+            const idf = idfMap.get(t.token)!;
             score +=
                 idf * ((tf * (bm25k1 + 1)) / (tf + bm25k1 * (1 - bm25b + bm25b * (dl / avgdl))));
         }
-
         results.push({ docId, score, wordMatchScore: 0, doc });
     });
+    const tBm25End = performance.now();
 
     // Step 6: Boost-weighted full-word match scoring
     const normalizedQuery = normalizeText(query);
@@ -178,6 +263,7 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             result.score += wordMatchBonus;
         }
     }
+    const tWordMatchEnd = performance.now();
 
     // Step 7: Sort by combined score desc, then word match desc.
     // `results` already represents the page window (Step 3 sliced ranked candidates by
@@ -185,6 +271,34 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
+    });
+    const tEnd = performance.now();
+
+    console.log("[ftsSearch]", {
+        query,
+        trigramCount: trigrams.length,
+        total_ms: +(tEnd - t0).toFixed(2),
+        trigramGen_ms: +(tTrigrams - t0).toFixed(2),
+        flush_ms: +(tFlush - tTrigrams).toFixed(2),
+        tx_total_ms: +(tTxEnd - tTxStart).toFixed(2),
+        // Inside-tx phases:
+        corpusStats_ms: +phaseTimes.corpusStats.toFixed(2),
+        statsBulkGet_ms: +phaseTimes.statsBulkGet.toFixed(2),
+        postingsBulkGet_ms: +phaseTimes.postingsBulkGet.toFixed(2),
+        postingsParse_ms: +phaseTimes.postingsParse.toFixed(2),
+        coarseRank_ms: +phaseTimes.coarseRank.toFixed(2),
+        docsLoad_ms: +phaseTimes.docsLoad.toFixed(2),
+        // Post-tx phases:
+        bm25_ms: +(tBm25End - tBm25Start).toFixed(2),
+        wordMatch_ms: +(tWordMatchEnd - tBm25End).toFixed(2),
+        sort_ms: +(tEnd - tWordMatchEnd).toFixed(2),
+        // Counts (sanity-check what was loaded):
+        statsHit: phaseTimes.statsRowCount,
+        postingsHit: phaseTimes.postingsRowCount,
+        usableTrigrams: phaseTimes.usableTrigramCount,
+        candidates: phaseTimes.candidateCount,
+        docsLoaded: phaseTimes.docsLoaded,
+        results: results.length,
     });
 
     return results.slice(0, limit);

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -1,7 +1,7 @@
 import { db } from "../db/database";
 import { generateSearchTrigrams, normalizeText, stripHtml } from "./trigram";
 import { getCorpusStats } from "./ftsIndexer";
-import { flushPendingTrigramChanges } from "./trigramIndex";
+import { cacheDocs, getCachedDoc, isTrigramIndexReady } from "./trigramIndex";
 import type { FtsFieldConfig, FtsSearchOptions, FtsSearchResult } from "./types";
 import type { ContentDto } from "../types";
 
@@ -24,6 +24,37 @@ const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "author", boost: 1.0 },
 ];
 
+// LRU cache of per-doc normalized word sets.
+// stripHtml + normalizeText dominate word-match scoring cost; they depend only on
+// the doc's field content, so cache across queries and invalidate on edit via
+// `updatedTimeUtc` in the key.
+const WORD_SET_CACHE_MAX = 500;
+const wordSetCache = new Map<string, Record<string, Set<string>>>();
+
+function getWordSets(doc: ContentDto, fields: FtsFieldConfig[]): Record<string, Set<string>> {
+    const key = `${doc._id}:${doc.updatedTimeUtc}`;
+    const cached = wordSetCache.get(key);
+    if (cached) {
+        wordSetCache.delete(key);
+        wordSetCache.set(key, cached);
+        return cached;
+    }
+    const sets: Record<string, Set<string>> = {};
+    const docRec = doc as Record<string, any>;
+    for (const field of fields) {
+        const value = docRec[field.name];
+        if (typeof value !== "string" || !value) continue;
+        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
+        sets[field.name] = new Set(text.split(" "));
+    }
+    wordSetCache.set(key, sets);
+    if (wordSetCache.size > WORD_SET_CACHE_MAX) {
+        const oldest = wordSetCache.keys().next().value;
+        if (oldest !== undefined) wordSetCache.delete(oldest);
+    }
+    return sets;
+}
+
 /**
  * Compute a boost-weighted word match score across fields.
  * For each field, counts how many query words appear as full words,
@@ -31,15 +62,13 @@ const FTS_FIELDS: FtsFieldConfig[] = [
  */
 function computeFieldWordMatchScore(
     queryWords: string[],
-    doc: Record<string, any>,
+    wordSets: Record<string, Set<string>>,
     fields: FtsFieldConfig[],
 ): number {
     let totalScore = 0;
     for (const field of fields) {
-        const value = doc[field.name];
-        if (typeof value !== "string" || !value) continue;
-        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
-        const docWords = new Set(text.split(" "));
+        const docWords = wordSets[field.name];
+        if (!docWords) continue;
         let matches = 0;
         for (const word of queryWords) {
             if (docWords.has(word)) matches++;
@@ -52,12 +81,8 @@ function computeFieldWordMatchScore(
 }
 
 /**
- * Perform a full-text search using BM25 scoring against the persisted trigram
- * inverted index (`trigramStats` + `trigramPostings` tables).
- *
- * All four IDB reads (corpus stats, trigram stats, trigram postings, candidate
- * docs) run inside a single readonly transaction so we pay the transaction
- * setup cost once per search rather than four times.
+ * Perform a full-text search using BM25 scoring via the MultiEntry index on docs.
+ * Trigram lookups use `between(trigram + ":", trigram + ";")` on the `*fts` index.
  */
 export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchResult[]> {
     const {
@@ -75,172 +100,149 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
     const tTrigrams = performance.now();
     if (trigrams.length === 0) return [];
 
-    // Drain any queued trigram-index writes outside the readonly transaction
-    // (writes can't run inside `r` mode). No-op when nothing's pending.
-    await flushPendingTrigramChanges(db);
-    const tFlush = performance.now();
+    // Each `await` below is its own implicit IDB tx scoped to just the
+    // store(s) it touches. Narrow scopes get granted faster: trigramPostings
+    // doesn't have to wait for sync's writes on `db.docs`, and the docs read
+    // only enters that contention once we actually need it. Wider single-tx
+    // wrappers ended up *slower* in practice because the broader scope means
+    // the whole transaction starves until `db.docs` writers clear before any
+    // read inside can run.
+    const corpusStats = await getCorpusStats();
+    const tCorpusStats = performance.now();
+    const N = corpusStats.docCount;
+    if (N === 0) return [];
+    const avgdl = corpusStats.totalTokenCount / N;
+    const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
 
-    type UsableTrigram = {
+    // Step 1: trigram → docIds (and tf on the fast path).
+    const fastPath = isTrigramIndexReady();
+    type TrigramHit = {
         token: string;
-        df: number;
         ids: string[];
-        tfByDoc: Map<string, number>;
+        /** Per-doc tf for this trigram. Only populated on the fast path. */
+        tfByDoc?: Map<string, number>;
     };
-
-    type ReadResult = {
-        N: number;
-        avgdl: number;
-        usableTrigrams: UsableTrigram[];
-        docMap: Map<string, ContentDto>;
-    } | null;
-
-    const phaseTimes = {
-        corpusStats: 0,
-        statsBulkGet: 0,
-        postingsBulkGet: 0,
-        postingsParse: 0,
-        coarseRank: 0,
-        docsLoad: 0,
-        usableTrigramCount: 0,
-        candidateCount: 0,
-        statsRowCount: 0,
-        postingsRowCount: 0,
-        docsLoaded: 0,
-    };
-
-    const tTxStart = performance.now();
-    const reads: ReadResult = await db.transaction(
-        "r",
-        [db.luminaryInternals, db.trigramStats, db.trigramPostings, db.docs],
-        async () => {
-            // 1. Corpus stats (uses parent transaction via Dexie.currentTransaction)
-            const tA = performance.now();
-            const corpusStats = await getCorpusStats();
-            phaseTimes.corpusStats = performance.now() - tA;
-            const N = corpusStats.docCount;
-            if (N === 0) return null;
-            const avgdl = corpusStats.totalTokenCount / N;
-            const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
-
-            // 2. Stats: tiny rows used to skip common trigrams (df > maxDocCount)
-            //    before paying for any postings deserialization.
-            const tB = performance.now();
-            const statsRows = await db.trigramStats.bulkGet(trigrams);
-            phaseTimes.statsBulkGet = performance.now() - tB;
-            phaseTimes.statsRowCount = statsRows.filter(Boolean).length;
-            const usableTokens: string[] = [];
-            const usableDfs: number[] = [];
-            for (let i = 0; i < trigrams.length; i++) {
-                const stats = statsRows[i];
-                if (!stats || stats.df === 0 || stats.df > maxDocCount) continue;
-                usableTokens.push(trigrams[i]);
-                usableDfs.push(stats.df);
+    let trigramResults: TrigramHit[];
+    if (fastPath) {
+        const rows = await db.trigramPostings.bulkGet(trigrams);
+        trigramResults = trigrams.map((token, i) => {
+            const row = rows[i];
+            if (!row) return { token, ids: [] };
+            const ids: string[] = new Array(row.postings.length);
+            const tfByDoc = new Map<string, number>();
+            for (let j = 0; j < row.postings.length; j++) {
+                const [docId, tf] = row.postings[j];
+                ids[j] = docId;
+                tfByDoc.set(docId, tf);
             }
-            if (usableTokens.length === 0) return null;
-
-            // 3. Postings: load full posting lists only for usable trigrams.
-            const tC = performance.now();
-            const postingsRows = await db.trigramPostings.bulkGet(usableTokens);
-            phaseTimes.postingsBulkGet = performance.now() - tC;
-            phaseTimes.postingsRowCount = postingsRows.filter(Boolean).length;
-            const tCParse = performance.now();
-            const usableTrigrams: UsableTrigram[] = [];
-            for (let k = 0; k < usableTokens.length; k++) {
-                const row = postingsRows[k];
-                if (!row) continue;
-                const tfByDoc = new Map<string, number>();
-                const ids: string[] = new Array(row.postings.length);
-                for (let j = 0; j < row.postings.length; j++) {
-                    const [docId, tf] = row.postings[j];
-                    ids[j] = docId;
-                    tfByDoc.set(docId, tf);
-                }
-                usableTrigrams.push({
-                    token: usableTokens[k],
-                    df: usableDfs[k],
-                    ids,
-                    tfByDoc,
-                });
-            }
-            phaseTimes.postingsParse = performance.now() - tCParse;
-            phaseTimes.usableTrigramCount = usableTrigrams.length;
-            if (usableTrigrams.length === 0) return null;
-
-            // Coarse-rank by Σ idf over matched trigrams to pick a page window.
-            const tD = performance.now();
-            const idfMap = new Map<string, number>();
-            for (const { token, df } of usableTrigrams) {
-                idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
-            }
-            const coarseScore = new Map<string, number>();
-            for (const { token, ids } of usableTrigrams) {
-                const idf = idfMap.get(token)!;
-                for (const id of ids) {
-                    coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
-                }
-            }
-            const ranked = Array.from(coarseScore.entries())
-                .sort((a, b) => b[1] - a[1])
-                .map(([id]) => id);
-            const candidateIds = ranked.slice(offset, offset + limit + 50);
-            phaseTimes.coarseRank = performance.now() - tD;
-            phaseTimes.candidateCount = candidateIds.length;
-            if (candidateIds.length === 0) return null;
-
-            // 4. Load candidate docs. When a languageId is provided, use the
-            //    compound `[language+_id]` index so wrong-language candidates
-            //    miss at the IDB layer — no row read, no structured-clone
-            //    deserialization for docs we'd discard anyway.
-            const tE = performance.now();
-            const loadedDocs = languageId
-                ? await db.docs
-                      .where("[language+_id]")
-                      .anyOf(candidateIds.map((id) => [languageId, id]))
-                      .toArray()
-                : await db.docs.where("_id").anyOf(candidateIds).toArray();
-            const docMap = new Map(loadedDocs.map((d) => [d._id, d as ContentDto]));
-            phaseTimes.docsLoad = performance.now() - tE;
-            phaseTimes.docsLoaded = loadedDocs.length;
-
-            return { N, avgdl, usableTrigrams, docMap };
-        },
-    );
-    const tTxEnd = performance.now();
-
-    if (!reads) {
-        const tEnd = performance.now();
-        console.log("[ftsSearch]", {
-            query,
-            trigramCount: trigrams.length,
-            total_ms: +(tEnd - t0).toFixed(2),
-            trigramGen_ms: +(tTrigrams - t0).toFixed(2),
-            flush_ms: +(tFlush - tTrigrams).toFixed(2),
-            tx_total_ms: +(tTxEnd - tTxStart).toFixed(2),
-            ...phaseTimes,
-            note: "no results",
+            return { token, ids, tfByDoc };
         });
-        return [];
+    } else {
+        // Fallback path runs parallel multi-entry-index queries on `db.docs`
+        // while the backfill is still building `trigramPostings` after a
+        // fresh install. `tf` not available here.
+        trigramResults = await Promise.all(
+            trigrams.map(async (trigram) => {
+                const ids = (await db.docs
+                    .where("fts")
+                    .between(trigram + ":", trigram + ";", true, false)
+                    .primaryKeys()) as string[];
+                return { token: trigram, ids };
+            }),
+        );
     }
-    const { N, avgdl, usableTrigrams, docMap } = reads;
+    const tTrigramLookup = performance.now();
 
-    // Pure-JS work below — no IDB.
-    const tBm25Start = performance.now();
+    const usableTrigrams: Array<{ token: string; df: number; tfByDoc?: Map<string, number> }> = [];
+    for (const hit of trigramResults) {
+        if (hit.ids.length > maxDocCount) continue;
+        usableTrigrams.push({ token: hit.token, df: hit.ids.length, tfByDoc: hit.tfByDoc });
+    }
+    if (usableTrigrams.length === 0) return [];
+
+    // Step 2: IDF + coarse-rank from postings alone — no doc loads. Score per
+    // doc is Σ idf*tf (fast path) or Σ idf (fallback). +20 buffer absorbs
+    // reranking by full BM25 / word-match within the loaded window.
+    const tCoarseStart = performance.now();
     const idfMap = new Map<string, number>();
     for (const { token, df } of usableTrigrams) {
         idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
     }
+    const coarseScore = new Map<string, number>();
+    for (const hit of trigramResults) {
+        if (hit.ids.length > maxDocCount) continue;
+        const idf = idfMap.get(hit.token)!;
+        if (hit.tfByDoc) {
+            for (const id of hit.ids) {
+                const tf = hit.tfByDoc.get(id) ?? 1;
+                coarseScore.set(id, (coarseScore.get(id) || 0) + idf * tf);
+            }
+        } else {
+            for (const id of hit.ids) {
+                coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
+            }
+        }
+    }
+    const matchedCount = coarseScore.size;
+    const ranked = Array.from(coarseScore.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(([id]) => id);
+    const candidateIds = ranked.slice(0, offset + limit + 20);
+    const tCoarseEnd = performance.now();
+    if (candidateIds.length === 0) return [];
 
+    // Step 3: hydrate. Cache hits skip IDB; only `bulkGet` the misses. The
+    // implicit tx here is scoped to just `db.docs`.
+    const tDocsLoadStart = performance.now();
+    const docMap = new Map<string, ContentDto>();
+    const missingIds: string[] = [];
+    for (const id of candidateIds) {
+        const cached = getCachedDoc(id);
+        if (cached) docMap.set(id, cached);
+        else missingIds.push(id);
+    }
+    let loadedFromIdb = 0;
+    if (missingIds.length > 0) {
+        const loadedDocs = languageId
+            ? await db.docs
+                  .where("[language+_id]")
+                  .anyOf(missingIds.map((id) => [languageId, id]))
+                  .toArray()
+            : await db.docs.where("_id").anyOf(missingIds).toArray();
+        loadedFromIdb = loadedDocs.length;
+        for (const d of loadedDocs) docMap.set(d._id, d as ContentDto);
+        cacheDocs(loadedDocs as ContentDto[]);
+    }
+    const tDocsLoadEnd = performance.now();
+
+    // Step 5: Build per-doc trigram→tf map from fts array, compute BM25.
+    // (Pure JS — no IDB. Outside the readonly tx.)
+    const tBm25Start = performance.now();
+    const usableTokens = new Set(usableTrigrams.map((t) => t.token));
     const results: FtsSearchResult[] = [];
+
     docMap.forEach((doc, docId) => {
+        const tfMap = new Map<string, number>();
+        if (doc.fts) {
+            for (const entry of doc.fts) {
+                const colonIdx = entry.indexOf(":", 3); // token is always 3 chars
+                const token = entry.substring(0, colonIdx);
+                if (usableTokens.has(token)) {
+                    tfMap.set(token, parseFloat(entry.substring(colonIdx + 1)));
+                }
+            }
+        }
+
         const dl = doc.ftsTokenCount || 1;
         let score = 0;
-        for (const t of usableTrigrams) {
-            const tf = t.tfByDoc.get(docId) || 0;
+        for (const { token } of usableTrigrams) {
+            const tf = tfMap.get(token) || 0;
             if (tf === 0) continue;
-            const idf = idfMap.get(t.token)!;
+            const idf = idfMap.get(token)!;
             score +=
                 idf * ((tf * (bm25k1 + 1)) / (tf + bm25k1 * (1 - bm25b + bm25b * (dl / avgdl))));
         }
+
         results.push({ docId, score, wordMatchScore: 0, doc });
     });
     const tBm25End = performance.now();
@@ -254,20 +256,15 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
             const doc = docMap.get(result.docId);
             if (!doc) continue;
 
-            const wordMatchBonus = computeFieldWordMatchScore(
-                queryWords,
-                doc as Record<string, any>,
-                FTS_FIELDS,
-            );
+            const wordSets = getWordSets(doc, FTS_FIELDS);
+            const wordMatchBonus = computeFieldWordMatchScore(queryWords, wordSets, FTS_FIELDS);
             result.wordMatchScore = wordMatchBonus;
             result.score += wordMatchBonus;
         }
     }
     const tWordMatchEnd = performance.now();
 
-    // Step 7: Sort by combined score desc, then word match desc.
-    // `results` already represents the page window (Step 3 sliced ranked candidates by
-    // [offset, offset+limit+50]), so we just take the first `limit` after re-sorting.
+    // Step 7: Sort by combined score desc, then word match desc
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
@@ -277,29 +274,23 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
     console.log("[ftsSearch]", {
         query,
         trigramCount: trigrams.length,
+        path: fastPath ? "trigramPostings" : "multiEntryFallback",
         total_ms: +(tEnd - t0).toFixed(2),
         trigramGen_ms: +(tTrigrams - t0).toFixed(2),
-        flush_ms: +(tFlush - tTrigrams).toFixed(2),
-        tx_total_ms: +(tTxEnd - tTxStart).toFixed(2),
-        // Inside-tx phases:
-        corpusStats_ms: +phaseTimes.corpusStats.toFixed(2),
-        statsBulkGet_ms: +phaseTimes.statsBulkGet.toFixed(2),
-        postingsBulkGet_ms: +phaseTimes.postingsBulkGet.toFixed(2),
-        postingsParse_ms: +phaseTimes.postingsParse.toFixed(2),
-        coarseRank_ms: +phaseTimes.coarseRank.toFixed(2),
-        docsLoad_ms: +phaseTimes.docsLoad.toFixed(2),
-        // Post-tx phases:
+        corpusStats_ms: +(tCorpusStats - tTrigrams).toFixed(2),
+        trigramLookup_ms: +(tTrigramLookup - tCorpusStats).toFixed(2),
+        coarseRank_ms: +(tCoarseEnd - tCoarseStart).toFixed(2),
+        docsLoad_ms: +(tDocsLoadEnd - tDocsLoadStart).toFixed(2),
         bm25_ms: +(tBm25End - tBm25Start).toFixed(2),
         wordMatch_ms: +(tWordMatchEnd - tBm25End).toFixed(2),
         sort_ms: +(tEnd - tWordMatchEnd).toFixed(2),
-        // Counts (sanity-check what was loaded):
-        statsHit: phaseTimes.statsRowCount,
-        postingsHit: phaseTimes.postingsRowCount,
-        usableTrigrams: phaseTimes.usableTrigramCount,
-        candidates: phaseTimes.candidateCount,
-        docsLoaded: phaseTimes.docsLoaded,
+        usableTrigrams: usableTrigrams.length,
+        matchedDocs: matchedCount,
+        candidates: candidateIds.length,
+        docsCached: candidateIds.length - loadedFromIdb,
+        docsLoaded: loadedFromIdb,
         results: results.length,
     });
 
-    return results.slice(0, limit);
+    return results.slice(offset, offset + limit);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -1,7 +1,7 @@
 import { db } from "../db/database";
 import { generateSearchTrigrams, normalizeText, stripHtml } from "./trigram";
 import { getCorpusStats } from "./ftsIndexer";
-import { cacheDocs, getCachedDoc, isTrigramIndexReady } from "./trigramIndex";
+import { isTrigramIndexReady } from "./trigramIndex";
 import type { FtsFieldConfig, FtsSearchOptions, FtsSearchResult } from "./types";
 import type { ContentDto } from "../types";
 
@@ -9,6 +9,10 @@ const DEFAULT_LIMIT = 20;
 const DEFAULT_MAX_TRIGRAM_DOC_PERCENT = 50;
 const DEFAULT_K1 = 1.2;
 const DEFAULT_B = 0.75;
+
+/** Extra candidates above (offset+limit) that get fully scored, so BM25 +
+ *  word-match reranking has room to reorder the top page. */
+const RERANK_BUFFER = 20;
 
 /**
  * FTS field configuration for search-time word match scoring.
@@ -24,41 +28,313 @@ const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "author", boost: 1.0 },
 ];
 
-// LRU cache of per-doc normalized word sets.
-// stripHtml + normalizeText dominate word-match scoring cost; they depend only on
-// the doc's field content, so cache across queries and invalidate on edit via
-// `updatedTimeUtc` in the key.
-const WORD_SET_CACHE_MAX = 500;
-const wordSetCache = new Map<string, Record<string, Set<string>>>();
+/**
+ * Per-trigram lookup result. `tfByDoc` is only populated on the fast path
+ * (`trigramPostings`); on the fallback path tf is unknown and coarse rank
+ * falls back to Σ idf instead of Σ idf*tf.
+ */
+type TrigramHit = {
+    token: string;
+    ids: string[];
+    tfByDoc?: Map<string, number>;
+};
 
-function getWordSets(doc: ContentDto, fields: FtsFieldConfig[]): Record<string, Set<string>> {
-    const key = `${doc._id}:${doc.updatedTimeUtc}`;
-    const cached = wordSetCache.get(key);
-    if (cached) {
-        wordSetCache.delete(key);
-        wordSetCache.set(key, cached);
-        return cached;
-    }
-    const sets: Record<string, Set<string>> = {};
-    const docRec = doc as Record<string, any>;
-    for (const field of fields) {
-        const value = docRec[field.name];
-        if (typeof value !== "string" || !value) continue;
-        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
-        sets[field.name] = new Set(text.split(" "));
-    }
-    wordSetCache.set(key, sets);
-    if (wordSetCache.size > WORD_SET_CACHE_MAX) {
-        const oldest = wordSetCache.keys().next().value;
-        if (oldest !== undefined) wordSetCache.delete(oldest);
-    }
-    return sets;
+/**
+ * Perform a full-text search using BM25 scoring against the persisted trigram
+ * inverted index (`trigramPostings`), with a multi-entry-index fallback on
+ * `db.docs.fts` while the index is still being backfilled.
+ *
+ * Each `await` is its own implicit IDB tx scoped to just the store(s) it
+ * touches. Wider single-tx wrappers ended up slower in practice — the broad
+ * scope means the whole transaction starves until `db.docs` writers clear
+ * before any read inside can run.
+ *
+ * @param options Query, optional language scope, paging, and BM25 params.
+ * @returns Top `limit` results starting at `offset`, sorted by combined score.
+ */
+export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchResult[]> {
+    const {
+        query,
+        languageId,
+        limit = DEFAULT_LIMIT,
+        offset = 0,
+        maxTrigramDocPercent = DEFAULT_MAX_TRIGRAM_DOC_PERCENT,
+        bm25k1 = DEFAULT_K1,
+        bm25b = DEFAULT_B,
+    } = options;
+
+    const trigrams = generateSearchTrigrams(query);
+    if (trigrams.length === 0) return [];
+
+    const corpusStats = await getCorpusStats();
+    const N = corpusStats.docCount;
+    if (N === 0) return [];
+    const avgdl = corpusStats.totalTokenCount / N;
+    const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
+
+    const allHits = await lookupTrigrams(trigrams);
+    const usableHits = filterCommonTrigrams(allHits, maxDocCount);
+    if (usableHits.length === 0) return [];
+
+    const idfMap = buildIdfMap(usableHits, N);
+    const candidateIds = coarseRankCandidates(usableHits, idfMap, offset + limit + RERANK_BUFFER);
+    if (candidateIds.length === 0) return [];
+
+    const docMap = await hydrateCandidates(candidateIds, languageId);
+    const results = scoreCandidates(docMap, usableHits, idfMap, avgdl, bm25k1, bm25b);
+
+    applyWordMatchBonus(results, docMap, extractQueryWords(query));
+    sortByScore(results);
+
+    return results.slice(offset, offset + limit);
+}
+
+// --- Trigram lookup -------------------------------------------------------
+
+/**
+ * Resolve each query trigram to its matching docIds, choosing the fast or
+ * fallback path based on whether `trigramPostings` has been backfilled.
+ */
+async function lookupTrigrams(trigrams: string[]): Promise<TrigramHit[]> {
+    return isTrigramIndexReady()
+        ? lookupTrigramsFast(trigrams)
+        : lookupTrigramsFallback(trigrams);
 }
 
 /**
- * Compute a boost-weighted word match score across fields.
- * For each field, counts how many query words appear as full words,
- * multiplied by the field's boost. Returns the sum across all fields.
+ * Fast path: one `bulkGet` against `trigramPostings`. Each row gives both
+ * the docId list and the per-doc tf needed for tf-weighted coarse ranking.
+ */
+async function lookupTrigramsFast(trigrams: string[]): Promise<TrigramHit[]> {
+    const rows = await db.trigramPostings.bulkGet(trigrams);
+    return trigrams.map((token, i) => {
+        const row = rows[i];
+        if (!row) return { token, ids: [] };
+        const ids: string[] = new Array(row.postings.length);
+        const tfByDoc = new Map<string, number>();
+        for (let j = 0; j < row.postings.length; j++) {
+            const [docId, tf] = row.postings[j];
+            ids[j] = docId;
+            tfByDoc.set(docId, tf);
+        }
+        return { token, ids, tfByDoc };
+    });
+}
+
+/**
+ * Fallback path used while `trigramPostings` is still being backfilled after
+ * a fresh install. Runs parallel multi-entry-index queries on `db.docs.fts`.
+ * `tf` is not available on this path, so coarse rank falls back to Σ idf.
+ */
+async function lookupTrigramsFallback(trigrams: string[]): Promise<TrigramHit[]> {
+    return Promise.all(
+        trigrams.map(async (trigram) => {
+            const ids = (await db.docs
+                .where("fts")
+                .between(trigram + ":", trigram + ";", true, false)
+                .primaryKeys()) as string[];
+            return { token: trigram, ids };
+        }),
+    );
+}
+
+/**
+ * Drop empty hits and trigrams that match more than `maxDocCount` docs.
+ * Common-trigram filtering keeps low-signal tokens (e.g. " th", "the") from
+ * dominating the candidate set.
+ */
+function filterCommonTrigrams(hits: TrigramHit[], maxDocCount: number): TrigramHit[] {
+    return hits.filter((hit) => hit.ids.length > 0 && hit.ids.length <= maxDocCount);
+}
+
+// --- Ranking --------------------------------------------------------------
+
+/**
+ * Compute IDF per usable trigram using the standard BM25 IDF variant:
+ * `log((N - df + 0.5) / (df + 0.5) + 1)`. Rare trigrams get higher weight.
+ */
+function buildIdfMap(usable: TrigramHit[], N: number): Map<string, number> {
+    const idfMap = new Map<string, number>();
+    for (const { token, ids } of usable) {
+        const df = ids.length;
+        idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
+    }
+    return idfMap;
+}
+
+/**
+ * Score every matched doc by Σ idf*tf (fast path) or Σ idf (fallback) using
+ * postings alone — no doc loads. Returns the top `take` doc IDs by score.
+ *
+ * This is the candidate-window cut: a cheap approximation of BM25 used to
+ * pick which docs are worth fully scoring.
+ */
+function coarseRankCandidates(
+    usable: TrigramHit[],
+    idfMap: Map<string, number>,
+    take: number,
+): string[] {
+    const score = new Map<string, number>();
+    for (const hit of usable) {
+        const idf = idfMap.get(hit.token)!;
+        if (hit.tfByDoc) {
+            for (const id of hit.ids) {
+                const tf = hit.tfByDoc.get(id) ?? 1;
+                score.set(id, (score.get(id) || 0) + idf * tf);
+            }
+        } else {
+            for (const id of hit.ids) {
+                score.set(id, (score.get(id) || 0) + idf);
+            }
+        }
+    }
+    return Array.from(score.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, take)
+        .map(([id]) => id);
+}
+
+// --- Hydration ------------------------------------------------------------
+
+/**
+ * Resolve `candidateIds` to `ContentDto`s via a single IDB `bulkGet`,
+ * scoped to a language when provided.
+ */
+async function hydrateCandidates(
+    candidateIds: string[],
+    languageId: string | undefined,
+): Promise<Map<string, ContentDto>> {
+    const loadedDocs = await loadDocsByIds(candidateIds, languageId);
+    const docMap = new Map<string, ContentDto>();
+    for (const d of loadedDocs) docMap.set(d._id, d as ContentDto);
+    return docMap;
+}
+
+/**
+ * Load docs by id, optionally scoped to a language. The compound
+ * `[language+_id]` index lets wrong-language candidates miss at the IDB
+ * layer — no row read, no structured-clone deserialization for docs we'd
+ * discard anyway.
+ */
+async function loadDocsByIds(ids: string[], languageId: string | undefined): Promise<any[]> {
+    if (languageId) {
+        return db.docs
+            .where("[language+_id]")
+            .anyOf(ids.map((id) => [languageId, id]))
+            .toArray();
+    }
+    return db.docs.where("_id").anyOf(ids).toArray();
+}
+
+// --- BM25 scoring ---------------------------------------------------------
+
+/**
+ * Compute the full BM25 score for every hydrated candidate. Returns a result
+ * per doc with `wordMatchScore` initialised to 0; the word-match bonus is
+ * applied separately so it can be skipped for short queries.
+ */
+function scoreCandidates(
+    docMap: Map<string, ContentDto>,
+    usable: TrigramHit[],
+    idfMap: Map<string, number>,
+    avgdl: number,
+    k1: number,
+    b: number,
+): FtsSearchResult[] {
+    const usableTokens = new Set(usable.map((t) => t.token));
+    const results: FtsSearchResult[] = [];
+    docMap.forEach((doc, docId) => {
+        const tfMap = parseDocTfMap(doc, usableTokens);
+        const dl = doc.ftsTokenCount || 1;
+        const score = bm25Score(tfMap, usable, idfMap, dl, avgdl, k1, b);
+        results.push({ docId, score, wordMatchScore: 0, doc });
+    });
+    return results;
+}
+
+/**
+ * Parse a doc's `fts` array (`"trigram:tf"` entries) into a tf map, keeping
+ * only entries for trigrams in `usableTokens`. The `colonIdx` starts at 3
+ * because the trigram prefix is always 3 chars.
+ */
+function parseDocTfMap(doc: ContentDto, usableTokens: Set<string>): Map<string, number> {
+    const tfMap = new Map<string, number>();
+    if (!doc.fts) return tfMap;
+    for (const entry of doc.fts) {
+        const colonIdx = entry.indexOf(":", 3);
+        const token = entry.substring(0, colonIdx);
+        if (usableTokens.has(token)) {
+            tfMap.set(token, parseFloat(entry.substring(colonIdx + 1)));
+        }
+    }
+    return tfMap;
+}
+
+/**
+ * Okapi BM25 score for a single doc:
+ * `Σ idf(t) * (tf * (k1+1)) / (tf + k1 * (1 - b + b * dl/avgdl))`.
+ *
+ * @param tfMap Per-trigram tf for this doc.
+ * @param dl    Doc length in tokens (`ftsTokenCount`).
+ * @param avgdl Average doc length across the corpus.
+ * @param k1    Term-frequency saturation parameter.
+ * @param b     Length-normalization parameter.
+ */
+function bm25Score(
+    tfMap: Map<string, number>,
+    usable: TrigramHit[],
+    idfMap: Map<string, number>,
+    dl: number,
+    avgdl: number,
+    k1: number,
+    b: number,
+): number {
+    let score = 0;
+    for (const { token } of usable) {
+        const tf = tfMap.get(token) || 0;
+        if (tf === 0) continue;
+        const idf = idfMap.get(token)!;
+        score += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (dl / avgdl))));
+    }
+    return score;
+}
+
+// --- Word-match bonus -----------------------------------------------------
+
+/**
+ * Normalize the query and split into significant words. Words ≤2 chars are
+ * dropped because they overlap noisily with content.
+ */
+function extractQueryWords(query: string): string[] {
+    return normalizeText(query)
+        .split(" ")
+        .filter((w) => w.length > 2);
+}
+
+/**
+ * Add a boost-weighted full-word match bonus to each result's score and
+ * record it on `wordMatchScore` for use as a sort tiebreaker. Mutates
+ * `results` in place.
+ */
+function applyWordMatchBonus(
+    results: FtsSearchResult[],
+    docMap: Map<string, ContentDto>,
+    queryWords: string[],
+): void {
+    if (queryWords.length === 0 || results.length === 0) return;
+    for (const result of results) {
+        const doc = docMap.get(result.docId);
+        if (!doc) continue;
+        const wordSets = buildWordSets(doc, FTS_FIELDS);
+        const bonus = computeFieldWordMatchScore(queryWords, wordSets, FTS_FIELDS);
+        result.wordMatchScore = bonus;
+        result.score += bonus;
+    }
+}
+
+/**
+ * Boost-weighted word match score. For each field, count how many query words
+ * appear as full words and multiply by the field's boost; sum across fields.
  */
 function computeFieldWordMatchScore(
     queryWords: string[],
@@ -80,217 +356,37 @@ function computeFieldWordMatchScore(
     return totalScore;
 }
 
+// --- Word-set building ----------------------------------------------------
+
 /**
- * Perform a full-text search using BM25 scoring via the MultiEntry index on docs.
- * Trigram lookups use `between(trigram + ":", trigram + ";")` on the `*fts` index.
+ * Build the per-field `{ field → Set<word> }` map for `doc`, stripping HTML
+ * for fields configured with `isHtml` and normalizing whitespace/case.
  */
-export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchResult[]> {
-    const {
-        query,
-        languageId,
-        limit = DEFAULT_LIMIT,
-        offset = 0,
-        maxTrigramDocPercent = DEFAULT_MAX_TRIGRAM_DOC_PERCENT,
-        bm25k1 = DEFAULT_K1,
-        bm25b = DEFAULT_B,
-    } = options;
-
-    const t0 = performance.now();
-    const trigrams = generateSearchTrigrams(query);
-    const tTrigrams = performance.now();
-    if (trigrams.length === 0) return [];
-
-    // Each `await` below is its own implicit IDB tx scoped to just the
-    // store(s) it touches. Narrow scopes get granted faster: trigramPostings
-    // doesn't have to wait for sync's writes on `db.docs`, and the docs read
-    // only enters that contention once we actually need it. Wider single-tx
-    // wrappers ended up *slower* in practice because the broader scope means
-    // the whole transaction starves until `db.docs` writers clear before any
-    // read inside can run.
-    const corpusStats = await getCorpusStats();
-    const tCorpusStats = performance.now();
-    const N = corpusStats.docCount;
-    if (N === 0) return [];
-    const avgdl = corpusStats.totalTokenCount / N;
-    const maxDocCount = Math.max(1, Math.floor((N * maxTrigramDocPercent) / 100));
-
-    // Step 1: trigram → docIds (and tf on the fast path).
-    const fastPath = isTrigramIndexReady();
-    type TrigramHit = {
-        token: string;
-        ids: string[];
-        /** Per-doc tf for this trigram. Only populated on the fast path. */
-        tfByDoc?: Map<string, number>;
-    };
-    let trigramResults: TrigramHit[];
-    if (fastPath) {
-        const rows = await db.trigramPostings.bulkGet(trigrams);
-        trigramResults = trigrams.map((token, i) => {
-            const row = rows[i];
-            if (!row) return { token, ids: [] };
-            const ids: string[] = new Array(row.postings.length);
-            const tfByDoc = new Map<string, number>();
-            for (let j = 0; j < row.postings.length; j++) {
-                const [docId, tf] = row.postings[j];
-                ids[j] = docId;
-                tfByDoc.set(docId, tf);
-            }
-            return { token, ids, tfByDoc };
-        });
-    } else {
-        // Fallback path runs parallel multi-entry-index queries on `db.docs`
-        // while the backfill is still building `trigramPostings` after a
-        // fresh install. `tf` not available here.
-        trigramResults = await Promise.all(
-            trigrams.map(async (trigram) => {
-                const ids = (await db.docs
-                    .where("fts")
-                    .between(trigram + ":", trigram + ";", true, false)
-                    .primaryKeys()) as string[];
-                return { token: trigram, ids };
-            }),
-        );
+function buildWordSets(
+    doc: ContentDto,
+    fields: FtsFieldConfig[],
+): Record<string, Set<string>> {
+    const sets: Record<string, Set<string>> = {};
+    const docRec = doc as Record<string, any>;
+    for (const field of fields) {
+        const value = docRec[field.name];
+        if (typeof value !== "string" || !value) continue;
+        const text = normalizeText(field.isHtml ? stripHtml(value) : value);
+        sets[field.name] = new Set(text.split(" "));
     }
-    const tTrigramLookup = performance.now();
+    return sets;
+}
 
-    const usableTrigrams: Array<{ token: string; df: number; tfByDoc?: Map<string, number> }> = [];
-    for (const hit of trigramResults) {
-        if (hit.ids.length > maxDocCount) continue;
-        usableTrigrams.push({ token: hit.token, df: hit.ids.length, tfByDoc: hit.tfByDoc });
-    }
-    if (usableTrigrams.length === 0) return [];
+// --- Sort -----------------------------------------------------------------
 
-    // Step 2: IDF + coarse-rank from postings alone — no doc loads. Score per
-    // doc is Σ idf*tf (fast path) or Σ idf (fallback). +20 buffer absorbs
-    // reranking by full BM25 / word-match within the loaded window.
-    const tCoarseStart = performance.now();
-    const idfMap = new Map<string, number>();
-    for (const { token, df } of usableTrigrams) {
-        idfMap.set(token, Math.log((N - df + 0.5) / (df + 0.5) + 1));
-    }
-    const coarseScore = new Map<string, number>();
-    for (const hit of trigramResults) {
-        if (hit.ids.length > maxDocCount) continue;
-        const idf = idfMap.get(hit.token)!;
-        if (hit.tfByDoc) {
-            for (const id of hit.ids) {
-                const tf = hit.tfByDoc.get(id) ?? 1;
-                coarseScore.set(id, (coarseScore.get(id) || 0) + idf * tf);
-            }
-        } else {
-            for (const id of hit.ids) {
-                coarseScore.set(id, (coarseScore.get(id) || 0) + idf);
-            }
-        }
-    }
-    const matchedCount = coarseScore.size;
-    const ranked = Array.from(coarseScore.entries())
-        .sort((a, b) => b[1] - a[1])
-        .map(([id]) => id);
-    const candidateIds = ranked.slice(0, offset + limit + 20);
-    const tCoarseEnd = performance.now();
-    if (candidateIds.length === 0) return [];
-
-    // Step 3: hydrate. Cache hits skip IDB; only `bulkGet` the misses. The
-    // implicit tx here is scoped to just `db.docs`.
-    const tDocsLoadStart = performance.now();
-    const docMap = new Map<string, ContentDto>();
-    const missingIds: string[] = [];
-    for (const id of candidateIds) {
-        const cached = getCachedDoc(id);
-        if (cached) docMap.set(id, cached);
-        else missingIds.push(id);
-    }
-    let loadedFromIdb = 0;
-    if (missingIds.length > 0) {
-        const loadedDocs = languageId
-            ? await db.docs
-                  .where("[language+_id]")
-                  .anyOf(missingIds.map((id) => [languageId, id]))
-                  .toArray()
-            : await db.docs.where("_id").anyOf(missingIds).toArray();
-        loadedFromIdb = loadedDocs.length;
-        for (const d of loadedDocs) docMap.set(d._id, d as ContentDto);
-        cacheDocs(loadedDocs as ContentDto[]);
-    }
-    const tDocsLoadEnd = performance.now();
-
-    // Step 5: Build per-doc trigram→tf map from fts array, compute BM25.
-    // (Pure JS — no IDB. Outside the readonly tx.)
-    const tBm25Start = performance.now();
-    const usableTokens = new Set(usableTrigrams.map((t) => t.token));
-    const results: FtsSearchResult[] = [];
-
-    docMap.forEach((doc, docId) => {
-        const tfMap = new Map<string, number>();
-        if (doc.fts) {
-            for (const entry of doc.fts) {
-                const colonIdx = entry.indexOf(":", 3); // token is always 3 chars
-                const token = entry.substring(0, colonIdx);
-                if (usableTokens.has(token)) {
-                    tfMap.set(token, parseFloat(entry.substring(colonIdx + 1)));
-                }
-            }
-        }
-
-        const dl = doc.ftsTokenCount || 1;
-        let score = 0;
-        for (const { token } of usableTrigrams) {
-            const tf = tfMap.get(token) || 0;
-            if (tf === 0) continue;
-            const idf = idfMap.get(token)!;
-            score +=
-                idf * ((tf * (bm25k1 + 1)) / (tf + bm25k1 * (1 - bm25b + bm25b * (dl / avgdl))));
-        }
-
-        results.push({ docId, score, wordMatchScore: 0, doc });
-    });
-    const tBm25End = performance.now();
-
-    // Step 6: Boost-weighted full-word match scoring
-    const normalizedQuery = normalizeText(query);
-    const queryWords = normalizedQuery.split(" ").filter((w) => w.length > 2);
-
-    if (queryWords.length > 0 && results.length > 0) {
-        for (const result of results) {
-            const doc = docMap.get(result.docId);
-            if (!doc) continue;
-
-            const wordSets = getWordSets(doc, FTS_FIELDS);
-            const wordMatchBonus = computeFieldWordMatchScore(queryWords, wordSets, FTS_FIELDS);
-            result.wordMatchScore = wordMatchBonus;
-            result.score += wordMatchBonus;
-        }
-    }
-    const tWordMatchEnd = performance.now();
-
-    // Step 7: Sort by combined score desc, then word match desc
+/**
+ * Sort by combined score desc, with `wordMatchScore` as the tiebreaker for
+ * scores within `0.001` of each other (BM25 floats often collide near the
+ * top when several docs share the same trigram set).
+ */
+function sortByScore(results: FtsSearchResult[]): void {
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;
         return b.wordMatchScore - a.wordMatchScore;
     });
-    const tEnd = performance.now();
-
-    console.log("[ftsSearch]", {
-        query,
-        trigramCount: trigrams.length,
-        path: fastPath ? "trigramPostings" : "multiEntryFallback",
-        total_ms: +(tEnd - t0).toFixed(2),
-        trigramGen_ms: +(tTrigrams - t0).toFixed(2),
-        corpusStats_ms: +(tCorpusStats - tTrigrams).toFixed(2),
-        trigramLookup_ms: +(tTrigramLookup - tCorpusStats).toFixed(2),
-        coarseRank_ms: +(tCoarseEnd - tCoarseStart).toFixed(2),
-        docsLoad_ms: +(tDocsLoadEnd - tDocsLoadStart).toFixed(2),
-        bm25_ms: +(tBm25End - tBm25Start).toFixed(2),
-        wordMatch_ms: +(tWordMatchEnd - tBm25End).toFixed(2),
-        sort_ms: +(tEnd - tWordMatchEnd).toFixed(2),
-        usableTrigrams: usableTrigrams.length,
-        matchedDocs: matchedCount,
-        candidates: candidateIds.length,
-        docsCached: candidateIds.length - loadedFromIdb,
-        docsLoaded: loadedFromIdb,
-        results: results.length,
-    });
-
-    return results.slice(offset, offset + limit);
 }

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -1,7 +1,6 @@
 import { db } from "../db/database";
 import { generateSearchTrigrams, normalizeText, stripHtml } from "./trigram";
 import { getCorpusStats } from "./ftsIndexer";
-import { isTrigramIndexReady } from "./trigramIndex";
 import type { FtsFieldConfig, FtsSearchOptions, FtsSearchResult } from "./types";
 import type { ContentDto } from "../types";
 
@@ -10,16 +9,16 @@ const DEFAULT_MAX_TRIGRAM_DOC_PERCENT = 50;
 const DEFAULT_K1 = 1.2;
 const DEFAULT_B = 0.75;
 
-/** Extra candidates above (offset+limit) that get fully scored, so BM25 +
+/** Extra candidates above `offset + limit` that get fully scored, so BM25 +
  *  word-match reranking has room to reorder the top page. */
 const RERANK_BUFFER = 20;
 
 /**
  * FTS field configuration for search-time word match scoring.
  *
- * **IMPORTANT**: This config must be kept in sync with the index-time config in
- * `api/src/util/ftsIndexing.ts`. If you change boost values or fields here,
- * update the other location as well.
+ * **IMPORTANT**: keep in sync with the index-time config in
+ * `api/src/util/ftsIndexing.ts`. Changing boosts or fields here without
+ * updating the other side silently drifts query and index behaviour.
  */
 const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "title", boost: 3.0 },
@@ -28,29 +27,20 @@ const FTS_FIELDS: FtsFieldConfig[] = [
     { name: "author", boost: 1.0 },
 ];
 
-/**
- * Per-trigram lookup result. `tfByDoc` is only populated on the fast path
- * (`trigramPostings`); on the fallback path tf is unknown and coarse rank
- * falls back to Σ idf instead of Σ idf*tf.
- */
 type TrigramHit = {
     token: string;
     ids: string[];
-    tfByDoc?: Map<string, number>;
+    tfByDoc: Map<string, number>;
 };
 
 /**
- * Perform a full-text search using BM25 scoring against the persisted trigram
- * inverted index (`trigramPostings`), with a multi-entry-index fallback on
- * `db.docs.fts` while the index is still being backfilled.
+ * Full-text search using BM25 scoring against the persisted trigram inverted
+ * index (`trigramPostings`).
  *
  * Each `await` is its own implicit IDB tx scoped to just the store(s) it
  * touches. Wider single-tx wrappers ended up slower in practice — the broad
  * scope means the whole transaction starves until `db.docs` writers clear
  * before any read inside can run.
- *
- * @param options Query, optional language scope, paging, and BM25 params.
- * @returns Top `limit` results starting at `offset`, sorted by combined score.
  */
 export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchResult[]> {
     const {
@@ -91,27 +81,15 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
 
 // --- Trigram lookup -------------------------------------------------------
 
-/**
- * Resolve each query trigram to its matching docIds, choosing the fast or
- * fallback path based on whether `trigramPostings` has been backfilled.
- */
+/** One `bulkGet` against `trigramPostings`. Each row gives both the docId
+ *  list and the per-doc tf needed for tf-weighted coarse ranking. */
 async function lookupTrigrams(trigrams: string[]): Promise<TrigramHit[]> {
-    return isTrigramIndexReady()
-        ? lookupTrigramsFast(trigrams)
-        : lookupTrigramsFallback(trigrams);
-}
-
-/**
- * Fast path: one `bulkGet` against `trigramPostings`. Each row gives both
- * the docId list and the per-doc tf needed for tf-weighted coarse ranking.
- */
-async function lookupTrigramsFast(trigrams: string[]): Promise<TrigramHit[]> {
     const rows = await db.trigramPostings.bulkGet(trigrams);
     return trigrams.map((token, i) => {
         const row = rows[i];
-        if (!row) return { token, ids: [] };
-        const ids: string[] = new Array(row.postings.length);
         const tfByDoc = new Map<string, number>();
+        if (!row) return { token, ids: [], tfByDoc };
+        const ids: string[] = new Array(row.postings.length);
         for (let j = 0; j < row.postings.length; j++) {
             const [docId, tf] = row.postings[j];
             ids[j] = docId;
@@ -121,38 +99,16 @@ async function lookupTrigramsFast(trigrams: string[]): Promise<TrigramHit[]> {
     });
 }
 
-/**
- * Fallback path used while `trigramPostings` is still being backfilled after
- * a fresh install. Runs parallel multi-entry-index queries on `db.docs.fts`.
- * `tf` is not available on this path, so coarse rank falls back to Σ idf.
- */
-async function lookupTrigramsFallback(trigrams: string[]): Promise<TrigramHit[]> {
-    return Promise.all(
-        trigrams.map(async (trigram) => {
-            const ids = (await db.docs
-                .where("fts")
-                .between(trigram + ":", trigram + ";", true, false)
-                .primaryKeys()) as string[];
-            return { token: trigram, ids };
-        }),
-    );
-}
-
-/**
- * Drop empty hits and trigrams that match more than `maxDocCount` docs.
- * Common-trigram filtering keeps low-signal tokens (e.g. " th", "the") from
- * dominating the candidate set.
- */
+/** Drop empty hits and trigrams that match more than `maxDocCount` docs.
+ *  Common-trigram filtering keeps low-signal tokens from dominating the
+ *  candidate set. */
 function filterCommonTrigrams(hits: TrigramHit[], maxDocCount: number): TrigramHit[] {
     return hits.filter((hit) => hit.ids.length > 0 && hit.ids.length <= maxDocCount);
 }
 
 // --- Ranking --------------------------------------------------------------
 
-/**
- * Compute IDF per usable trigram using the standard BM25 IDF variant:
- * `log((N - df + 0.5) / (df + 0.5) + 1)`. Rare trigrams get higher weight.
- */
+/** Standard BM25 IDF: `log((N - df + 0.5) / (df + 0.5) + 1)`. */
 function buildIdfMap(usable: TrigramHit[], N: number): Map<string, number> {
     const idfMap = new Map<string, number>();
     for (const { token, ids } of usable) {
@@ -163,11 +119,8 @@ function buildIdfMap(usable: TrigramHit[], N: number): Map<string, number> {
 }
 
 /**
- * Score every matched doc by Σ idf*tf (fast path) or Σ idf (fallback) using
- * postings alone — no doc loads. Returns the top `take` doc IDs by score.
- *
- * This is the candidate-window cut: a cheap approximation of BM25 used to
- * pick which docs are worth fully scoring.
+ * Pick the top `take` doc IDs by Σ idf*tf over the postings alone — no doc
+ * loads. A cheap BM25 approximation used as the candidate-window cut.
  */
 function coarseRankCandidates(
     usable: TrigramHit[],
@@ -177,15 +130,9 @@ function coarseRankCandidates(
     const score = new Map<string, number>();
     for (const hit of usable) {
         const idf = idfMap.get(hit.token)!;
-        if (hit.tfByDoc) {
-            for (const id of hit.ids) {
-                const tf = hit.tfByDoc.get(id) ?? 1;
-                score.set(id, (score.get(id) || 0) + idf * tf);
-            }
-        } else {
-            for (const id of hit.ids) {
-                score.set(id, (score.get(id) || 0) + idf);
-            }
+        for (const id of hit.ids) {
+            const tf = hit.tfByDoc.get(id) ?? 1;
+            score.set(id, (score.get(id) || 0) + idf * tf);
         }
     }
     return Array.from(score.entries())
@@ -196,43 +143,34 @@ function coarseRankCandidates(
 
 // --- Hydration ------------------------------------------------------------
 
-/**
- * Resolve `candidateIds` to `ContentDto`s via a single IDB `bulkGet`,
- * scoped to a language when provided.
- */
 async function hydrateCandidates(
     candidateIds: string[],
     languageId: string | undefined,
 ): Promise<Map<string, ContentDto>> {
     const loadedDocs = await loadDocsByIds(candidateIds, languageId);
     const docMap = new Map<string, ContentDto>();
-    for (const d of loadedDocs) docMap.set(d._id, d as ContentDto);
+    for (const d of loadedDocs) docMap.set(d._id, d);
     return docMap;
 }
 
-/**
- * Load docs by id, optionally scoped to a language. The compound
- * `[language+_id]` index lets wrong-language candidates miss at the IDB
- * layer — no row read, no structured-clone deserialization for docs we'd
- * discard anyway.
- */
-async function loadDocsByIds(ids: string[], languageId: string | undefined): Promise<any[]> {
+/** When `languageId` is provided, use the compound `[language+_id]` index
+ *  so wrong-language candidates miss at the IDB layer — no row read, no
+ *  structured-clone deserialization for docs we'd discard anyway. */
+async function loadDocsByIds(
+    ids: string[],
+    languageId: string | undefined,
+): Promise<ContentDto[]> {
     if (languageId) {
-        return db.docs
+        return (await db.docs
             .where("[language+_id]")
             .anyOf(ids.map((id) => [languageId, id]))
-            .toArray();
+            .toArray()) as ContentDto[];
     }
-    return db.docs.where("_id").anyOf(ids).toArray();
+    return (await db.docs.where("_id").anyOf(ids).toArray()) as ContentDto[];
 }
 
 // --- BM25 scoring ---------------------------------------------------------
 
-/**
- * Compute the full BM25 score for every hydrated candidate. Returns a result
- * per doc with `wordMatchScore` initialised to 0; the word-match bonus is
- * applied separately so it can be skipped for short queries.
- */
 function scoreCandidates(
     docMap: Map<string, ContentDto>,
     usable: TrigramHit[],
@@ -252,26 +190,22 @@ function scoreCandidates(
     return results;
 }
 
-/**
- * Parse a doc's `fts` array (`"trigram:tf"` entries) into a tf map, keeping
- * only entries for trigrams in `usableTokens`. The `colonIdx` starts at 3
- * because the trigram prefix is always 3 chars.
- */
+/** Parse a doc's `fts` array (`"XYZ:tf"` entries, trigram always 3 chars)
+ *  into a tf map, keeping only entries for trigrams in `usableTokens`. */
 function parseDocTfMap(doc: ContentDto, usableTokens: Set<string>): Map<string, number> {
     const tfMap = new Map<string, number>();
     if (!doc.fts) return tfMap;
     for (const entry of doc.fts) {
-        const colonIdx = entry.indexOf(":", 3);
-        const token = entry.substring(0, colonIdx);
+        const token = entry.substring(0, 3);
         if (usableTokens.has(token)) {
-            tfMap.set(token, parseFloat(entry.substring(colonIdx + 1)));
+            tfMap.set(token, parseFloat(entry.substring(4)));
         }
     }
     return tfMap;
 }
 
 /**
- * Okapi BM25 score for a single doc:
+ * Okapi BM25 score for one doc:
  * `Σ idf(t) * (tf * (k1+1)) / (tf + k1 * (1 - b + b * dl/avgdl))`.
  *
  * @param tfMap Per-trigram tf for this doc.
@@ -301,21 +235,15 @@ function bm25Score(
 
 // --- Word-match bonus -----------------------------------------------------
 
-/**
- * Normalize the query and split into significant words. Words ≤2 chars are
- * dropped because they overlap noisily with content.
- */
+/** Words ≤2 chars are dropped because they overlap noisily with content. */
 function extractQueryWords(query: string): string[] {
     return normalizeText(query)
         .split(" ")
         .filter((w) => w.length > 2);
 }
 
-/**
- * Add a boost-weighted full-word match bonus to each result's score and
- * record it on `wordMatchScore` for use as a sort tiebreaker. Mutates
- * `results` in place.
- */
+/** Adds a boost-weighted word-match bonus to each result's score and records
+ *  it on `wordMatchScore` for use as a sort tiebreaker. Mutates `results`. */
 function applyWordMatchBonus(
     results: FtsSearchResult[],
     docMap: Map<string, ContentDto>,
@@ -332,10 +260,8 @@ function applyWordMatchBonus(
     }
 }
 
-/**
- * Boost-weighted word match score. For each field, count how many query words
- * appear as full words and multiply by the field's boost; sum across fields.
- */
+/** For each field, count how many query words appear as full words and
+ *  multiply by the field's boost; sum across fields. */
 function computeFieldWordMatchScore(
     queryWords: string[],
     wordSets: Record<string, Set<string>>,
@@ -356,20 +282,15 @@ function computeFieldWordMatchScore(
     return totalScore;
 }
 
-// --- Word-set building ----------------------------------------------------
-
-/**
- * Build the per-field `{ field → Set<word> }` map for `doc`, stripping HTML
- * for fields configured with `isHtml` and normalizing whitespace/case.
- */
+/** Build `{ field → Set<word> }` for `doc`, stripping HTML on `isHtml`
+ *  fields and normalizing whitespace/case. */
 function buildWordSets(
     doc: ContentDto,
     fields: FtsFieldConfig[],
 ): Record<string, Set<string>> {
     const sets: Record<string, Set<string>> = {};
-    const docRec = doc as Record<string, any>;
     for (const field of fields) {
-        const value = docRec[field.name];
+        const value = (doc as Record<string, any>)[field.name];
         if (typeof value !== "string" || !value) continue;
         const text = normalizeText(field.isHtml ? stripHtml(value) : value);
         sets[field.name] = new Set(text.split(" "));
@@ -379,11 +300,9 @@ function buildWordSets(
 
 // --- Sort -----------------------------------------------------------------
 
-/**
- * Sort by combined score desc, with `wordMatchScore` as the tiebreaker for
- * scores within `0.001` of each other (BM25 floats often collide near the
- * top when several docs share the same trigram set).
- */
+/** Sort by combined score desc, with `wordMatchScore` as a tiebreaker for
+ *  scores within `0.001` (BM25 floats often collide near the top when
+ *  several docs share the same trigram set). */
 function sortByScore(results: FtsSearchResult[]): void {
     results.sort((a, b) => {
         if (Math.abs(b.score - a.score) > 0.001) return b.score - a.score;

--- a/shared/src/fts/trigramIndex.ts
+++ b/shared/src/fts/trigramIndex.ts
@@ -1,0 +1,312 @@
+import type Dexie from "dexie";
+import type { Table } from "dexie";
+import { DocType, type ContentDto } from "../types";
+
+/**
+ * Persisted inverted FTS index, split across two tables so common-trigram
+ * filtering doesn't pay for postings deserialization:
+ *
+ * - `trigramStats`: tiny `{ trigram, df }` rows used to skip too-common trigrams
+ *   (df > maxDocCount) before any postings are loaded.
+ * - `trigramPostings`: the actual `[docId, tf]` lists, looked up only for
+ *   trigrams that survive the df filter.
+ *
+ * Per-query lookups become a 2-phase bulkGet: stats first, then postings for
+ * the survivors. Each is a B-tree page hit per trigram instead of N cursor
+ * scans over the multi-entry `*fts` index.
+ */
+export type TrigramStatsRow = {
+    /** Three-character trigram, primary key. */
+    trigram: string;
+    /** Document frequency, equal to postings.length on the matching postings row. */
+    df: number;
+};
+
+export type TrigramPostingsRow = {
+    /** Three-character trigram, primary key. */
+    trigram: string;
+    /** [docId, tf] pairs. */
+    postings: Array<[string, number]>;
+};
+
+const FLUSH_DEBOUNCE_MS = 100;
+
+type PendingDocChange = { oldFts: string[]; newFts: string[] };
+
+let pendingChanges = new Map<string, PendingDocChange>();
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+let flushChain: Promise<void> = Promise.resolve();
+let backfilled = false;
+
+/**
+ * Parse an `fts` array of "trigram:tf" entries into a Map<trigram, tf>.
+ */
+function parseFtsArray(fts: readonly string[]): Map<string, number> {
+    const out = new Map<string, number>();
+    for (const entry of fts) {
+        const colonIdx = entry.indexOf(":", 3);
+        if (colonIdx !== 3) continue;
+        const trigram = entry.substring(0, 3);
+        const tf = parseFloat(entry.substring(colonIdx + 1));
+        if (!Number.isFinite(tf)) continue;
+        out.set(trigram, tf);
+    }
+    return out;
+}
+
+/**
+ * Record a doc-level change in the pending queue. Coalesces multiple changes
+ * to the same doc within a flush window: keeps the original committed state
+ * as `oldFts` and overwrites `newFts` with the latest target state.
+ */
+function recordChange(docId: string, oldFts: string[], newFts: string[]): void {
+    const existing = pendingChanges.get(docId);
+    if (existing) {
+        existing.newFts = newFts;
+    } else {
+        pendingChanges.set(docId, { oldFts, newFts });
+    }
+}
+
+function scheduleFlush(db: TrigramDb): void {
+    if (flushTimer !== undefined) return;
+    flushTimer = setTimeout(() => {
+        flushTimer = undefined;
+        flushPendingTrigramChanges(db).catch((err) => {
+            console.error("[trigramIndex] flush failed", err);
+        });
+    }, FLUSH_DEBOUNCE_MS);
+}
+
+/**
+ * Subset of the Database we touch — keeps this module decoupled from the
+ * concrete Database class to avoid a circular import.
+ */
+export interface TrigramDb extends Dexie {
+    docs: Table<any>;
+    trigramStats: Table<TrigramStatsRow, string>;
+    trigramPostings: Table<TrigramPostingsRow, string>;
+    luminaryInternals: Table<{ id: string; value: any }, string>;
+}
+
+/**
+ * Apply queued doc-level changes to the trigram tables in one batched
+ * read-modify-write. Concurrent callers serialize via `flushChain`, so the
+ * latest call always sees a consistent state. Cancels any pending debounce
+ * timer so callers (e.g. ftsSearch) can drain on demand.
+ */
+export function flushPendingTrigramChanges(db: TrigramDb): Promise<void> {
+    if (flushTimer !== undefined) {
+        clearTimeout(flushTimer);
+        flushTimer = undefined;
+    }
+    flushChain = flushChain.then(() => doFlush(db));
+    return flushChain;
+}
+
+async function doFlush(db: TrigramDb): Promise<void> {
+    if (pendingChanges.size === 0) return;
+
+    const changes = pendingChanges;
+    pendingChanges = new Map();
+
+    // (trigram → docId → tf | null) where null means remove this docId.
+    const trigramOps = new Map<string, Map<string, number | null>>();
+
+    changes.forEach(({ oldFts, newFts }, docId) => {
+        const oldMap = parseFtsArray(oldFts);
+        const newMap = parseFtsArray(newFts);
+
+        oldMap.forEach((_tf, trigram) => {
+            if (!newMap.has(trigram)) {
+                let ops = trigramOps.get(trigram);
+                if (!ops) {
+                    ops = new Map();
+                    trigramOps.set(trigram, ops);
+                }
+                ops.set(docId, null);
+            }
+        });
+        newMap.forEach((tf, trigram) => {
+            let ops = trigramOps.get(trigram);
+            if (!ops) {
+                ops = new Map();
+                trigramOps.set(trigram, ops);
+            }
+            ops.set(docId, tf);
+        });
+    });
+
+    if (trigramOps.size === 0) return;
+
+    const touched: string[] = [];
+    trigramOps.forEach((_ops, trigram) => touched.push(trigram));
+
+    await db.transaction("rw", db.trigramStats, db.trigramPostings, async () => {
+        const postingsRows = await db.trigramPostings.bulkGet(touched);
+        const postingUpdates: TrigramPostingsRow[] = [];
+        const statsUpdates: TrigramStatsRow[] = [];
+        const deletes: string[] = [];
+
+        for (let i = 0; i < touched.length; i++) {
+            const trigram = touched[i];
+            const ops = trigramOps.get(trigram)!;
+            const existing = postingsRows[i];
+
+            const postingsMap = new Map<string, number>();
+            if (existing) {
+                for (let j = 0; j < existing.postings.length; j++) {
+                    const pair = existing.postings[j];
+                    postingsMap.set(pair[0], pair[1]);
+                }
+            }
+            ops.forEach((tf, docId) => {
+                if (tf === null) postingsMap.delete(docId);
+                else postingsMap.set(docId, tf);
+            });
+
+            if (postingsMap.size === 0) {
+                if (existing) deletes.push(trigram);
+            } else {
+                const postings: Array<[string, number]> = [];
+                postingsMap.forEach((tf, docId) => postings.push([docId, tf]));
+                postingUpdates.push({ trigram, postings });
+                statsUpdates.push({ trigram, df: postings.length });
+            }
+        }
+
+        if (deletes.length > 0) {
+            await db.trigramPostings.bulkDelete(deletes);
+            await db.trigramStats.bulkDelete(deletes);
+        }
+        if (postingUpdates.length > 0) {
+            await db.trigramPostings.bulkPut(postingUpdates);
+            await db.trigramStats.bulkPut(statsUpdates);
+        }
+    });
+}
+
+/**
+ * Install Dexie hooks on the docs table that record fts-affecting changes
+ * into the pending queue. The hooks fire for any write source (sync, manual
+ * upsert, deleteRevoked, etc.) so the index stays consistent without needing
+ * each call site to know about the trigram tables.
+ */
+export function installTrigramHooks(db: TrigramDb): void {
+    db.docs.hook("creating", (_pk, obj) => {
+        if (!obj || obj.type !== DocType.Content) return;
+        const fts = (obj as ContentDto).fts;
+        if (!Array.isArray(fts) || fts.length === 0) return;
+        recordChange(obj._id, [], fts);
+        scheduleFlush(db);
+    });
+
+    db.docs.hook("updating", (mods, _pk, obj) => {
+        if (!obj) return;
+        const after = { ...obj, ...(mods as object) } as ContentDto;
+        const isContentNow = after.type === DocType.Content;
+        const wasContent = (obj as any).type === DocType.Content;
+        if (!isContentNow && !wasContent) return;
+        const oldFts =
+            wasContent && Array.isArray((obj as ContentDto).fts)
+                ? ((obj as ContentDto).fts as string[])
+                : [];
+        const newFts = isContentNow && Array.isArray(after.fts) ? (after.fts as string[]) : [];
+        if (oldFts.length === 0 && newFts.length === 0) return;
+        recordChange(after._id ?? (obj as any)._id, oldFts, newFts);
+        scheduleFlush(db);
+    });
+
+    db.docs.hook("deleting", (_pk, obj) => {
+        if (!obj || obj.type !== DocType.Content) return;
+        const fts = (obj as ContentDto).fts;
+        if (!Array.isArray(fts) || fts.length === 0) return;
+        recordChange(obj._id, fts, []);
+        scheduleFlush(db);
+    });
+}
+
+/**
+ * Build the trigram tables from scratch by scanning every Content doc.
+ * Used on first run after the schema upgrade and as a recovery if the index
+ * gets out of sync.
+ */
+export async function backfillTrigramIndex(db: TrigramDb): Promise<void> {
+    // (trigram → docId → tf)
+    const accum = new Map<string, Map<string, number>>();
+
+    await db.docs
+        .where("type")
+        .equals(DocType.Content)
+        .each((doc) => {
+            const fts = (doc as ContentDto).fts;
+            if (!Array.isArray(fts)) return;
+            const docId = doc._id;
+            for (const entry of fts) {
+                const colonIdx = entry.indexOf(":", 3);
+                if (colonIdx !== 3) continue;
+                const trigram = entry.substring(0, 3);
+                const tf = parseFloat(entry.substring(colonIdx + 1));
+                if (!Number.isFinite(tf)) continue;
+                let postings = accum.get(trigram);
+                if (!postings) {
+                    postings = new Map();
+                    accum.set(trigram, postings);
+                }
+                postings.set(docId, tf);
+            }
+        });
+
+    const postingsRows: TrigramPostingsRow[] = [];
+    const statsRows: TrigramStatsRow[] = [];
+    accum.forEach((postingsMap, trigram) => {
+        const postings: Array<[string, number]> = [];
+        postingsMap.forEach((tf, docId) => postings.push([docId, tf]));
+        postingsRows.push({ trigram, postings });
+        statsRows.push({ trigram, df: postings.length });
+    });
+
+    await db.transaction("rw", db.trigramStats, db.trigramPostings, async () => {
+        await db.trigramPostings.clear();
+        await db.trigramStats.clear();
+        if (postingsRows.length > 0) {
+            await db.trigramPostings.bulkPut(postingsRows);
+            await db.trigramStats.bulkPut(statsRows);
+        }
+    });
+
+    backfilled = true;
+}
+
+/**
+ * Run a backfill if the trigram tables are empty but content docs exist.
+ * Called from initDatabase; safe to call repeatedly (no-op once populated).
+ */
+export async function ensureTrigramIndexBuilt(db: TrigramDb): Promise<void> {
+    if (backfilled) return;
+    const statsCount = await db.trigramStats.count();
+    if (statsCount > 0) {
+        backfilled = true;
+        return;
+    }
+    const hasContent = await db.docs.where("type").equals(DocType.Content).first();
+    if (!hasContent) {
+        backfilled = true; // nothing to build yet; hooks will populate as docs arrive
+        return;
+    }
+    await backfillTrigramIndex(db);
+}
+
+/**
+ * Reset module-level state. Used by tests between cases.
+ */
+export function resetTrigramIndexState(): void {
+    pendingChanges = new Map();
+    if (flushTimer !== undefined) {
+        clearTimeout(flushTimer);
+        flushTimer = undefined;
+    }
+    flushChain = Promise.resolve();
+    backfilled = false;
+}
+

--- a/shared/src/fts/trigramIndex.ts
+++ b/shared/src/fts/trigramIndex.ts
@@ -265,15 +265,6 @@ export async function ensureTrigramIndexBuilt(db: TrigramDb): Promise<void> {
     await backfillTrigramIndex(db);
 }
 
-/**
- * True once the backfill has populated `trigramPostings`. Searches before
- * this returns true must fall through to the multi-entry-index path on
- * `db.docs` to avoid returning empty results during the brief startup window.
- */
-export function isTrigramIndexReady(): boolean {
-    return backfilled;
-}
-
 /** Reset module-level state. Used by tests between cases. */
 export function resetTrigramIndexState(): void {
     pendingChanges = new Map();

--- a/shared/src/fts/trigramIndex.ts
+++ b/shared/src/fts/trigramIndex.ts
@@ -30,42 +30,6 @@ let flushChain: Promise<void> = Promise.resolve();
 let backfilled = false;
 
 /**
- * In-memory LRU cache of loaded `ContentDto`s keyed by `_id`. Lets `ftsSearch`
- * skip the contended `db.docs` bulkGet for docs we already loaded in a recent
- * search (heavy overlap during incremental typing, pagination, language
- * switch). Invalidated by the same Dexie hooks that maintain the trigram
- * index, so a doc write evicts its cache entry before the next search runs.
- */
-const DOC_CACHE_MAX = 500;
-const docCache = new Map<string, ContentDto>();
-
-export function getCachedDoc(id: string): ContentDto | undefined {
-    const doc = docCache.get(id);
-    if (doc !== undefined) {
-        // refresh LRU recency
-        docCache.delete(id);
-        docCache.set(id, doc);
-    }
-    return doc;
-}
-
-export function cacheDocs(docs: ContentDto[]): void {
-    for (const doc of docs) {
-        if (!doc._id) continue;
-        docCache.set(doc._id, doc);
-    }
-    while (docCache.size > DOC_CACHE_MAX) {
-        const oldest = docCache.keys().next().value;
-        if (oldest === undefined) break;
-        docCache.delete(oldest);
-    }
-}
-
-export function invalidateCachedDoc(id: string): void {
-    docCache.delete(id);
-}
-
-/**
  * Subset of the Database we touch — keeps this module decoupled from the
  * concrete Database class to avoid a circular import.
  */
@@ -204,7 +168,6 @@ async function doFlush(db: TrigramDb): Promise<void> {
 export function installTrigramHooks(db: TrigramDb): void {
     db.docs.hook("creating", (_pk, obj) => {
         if (!obj || obj.type !== DocType.Content) return;
-        invalidateCachedDoc(obj._id);
         const fts = (obj as ContentDto).fts;
         if (!Array.isArray(fts) || fts.length === 0) return;
         recordChange(obj._id, [], fts);
@@ -215,7 +178,6 @@ export function installTrigramHooks(db: TrigramDb): void {
         if (!obj) return;
         const after = { ...obj, ...(mods as object) } as ContentDto;
         const id = after._id ?? (obj as any)._id;
-        if (id) invalidateCachedDoc(id);
         const isContentNow = after.type === DocType.Content;
         const wasContent = (obj as any).type === DocType.Content;
         if (!isContentNow && !wasContent) return;
@@ -231,7 +193,6 @@ export function installTrigramHooks(db: TrigramDb): void {
 
     db.docs.hook("deleting", (_pk, obj) => {
         if (!obj) return;
-        if (obj._id) invalidateCachedDoc(obj._id);
         if (obj.type !== DocType.Content) return;
         const fts = (obj as ContentDto).fts;
         if (!Array.isArray(fts) || fts.length === 0) return;
@@ -322,5 +283,4 @@ export function resetTrigramIndexState(): void {
     }
     flushChain = Promise.resolve();
     backfilled = false;
-    docCache.clear();
 }

--- a/shared/src/fts/trigramIndex.ts
+++ b/shared/src/fts/trigramIndex.ts
@@ -3,33 +3,24 @@ import type { Table } from "dexie";
 import { DocType, type ContentDto } from "../types";
 
 /**
- * Persisted inverted FTS index, split across two tables so common-trigram
- * filtering doesn't pay for postings deserialization:
- *
- * - `trigramStats`: tiny `{ trigram, df }` rows used to skip too-common trigrams
- *   (df > maxDocCount) before any postings are loaded.
- * - `trigramPostings`: the actual `[docId, tf]` lists, looked up only for
- *   trigrams that survive the df filter.
- *
- * Per-query lookups become a 2-phase bulkGet: stats first, then postings for
- * the survivors. Each is a B-tree page hit per trigram instead of N cursor
- * scans over the multi-entry `*fts` index.
+ * Persisted inverted FTS index keyed by trigram. Search reads this instead of
+ * running per-trigram `between(...)` queries on the multi-entry `*fts` index of
+ * `db.docs` — those queries queue behind sync's `bulkPut` writes on `docs`,
+ * and on a fresh sync that wait dominates the search latency. `trigramPostings`
+ * is updated via debounced flushes from a Dexie hook on `db.docs`, so search
+ * reads contend only with infrequent index-update writes (5 s debounce).
  */
-export type TrigramStatsRow = {
-    /** Three-character trigram, primary key. */
-    trigram: string;
-    /** Document frequency, equal to postings.length on the matching postings row. */
-    df: number;
-};
-
 export type TrigramPostingsRow = {
     /** Three-character trigram, primary key. */
     trigram: string;
-    /** [docId, tf] pairs. */
+    /** [docId, tf] pairs. df is implicit as postings.length. */
     postings: Array<[string, number]>;
 };
 
-const FLUSH_DEBOUNCE_MS = 100;
+/** 5 s of quiescence before we flush the queue, sized to coalesce a sync burst
+ *  into one write tx so search reads on `trigramPostings` aren't queued behind
+ *  a stream of small updates. Mirrors the corpus-stats debounce. */
+const FLUSH_DEBOUNCE_MS = 5_000;
 
 type PendingDocChange = { oldFts: string[]; newFts: string[] };
 
@@ -39,8 +30,50 @@ let flushChain: Promise<void> = Promise.resolve();
 let backfilled = false;
 
 /**
- * Parse an `fts` array of "trigram:tf" entries into a Map<trigram, tf>.
+ * In-memory LRU cache of loaded `ContentDto`s keyed by `_id`. Lets `ftsSearch`
+ * skip the contended `db.docs` bulkGet for docs we already loaded in a recent
+ * search (heavy overlap during incremental typing, pagination, language
+ * switch). Invalidated by the same Dexie hooks that maintain the trigram
+ * index, so a doc write evicts its cache entry before the next search runs.
  */
+const DOC_CACHE_MAX = 500;
+const docCache = new Map<string, ContentDto>();
+
+export function getCachedDoc(id: string): ContentDto | undefined {
+    const doc = docCache.get(id);
+    if (doc !== undefined) {
+        // refresh LRU recency
+        docCache.delete(id);
+        docCache.set(id, doc);
+    }
+    return doc;
+}
+
+export function cacheDocs(docs: ContentDto[]): void {
+    for (const doc of docs) {
+        if (!doc._id) continue;
+        docCache.set(doc._id, doc);
+    }
+    while (docCache.size > DOC_CACHE_MAX) {
+        const oldest = docCache.keys().next().value;
+        if (oldest === undefined) break;
+        docCache.delete(oldest);
+    }
+}
+
+export function invalidateCachedDoc(id: string): void {
+    docCache.delete(id);
+}
+
+/**
+ * Subset of the Database we touch — keeps this module decoupled from the
+ * concrete Database class to avoid a circular import.
+ */
+export interface TrigramDb extends Dexie {
+    docs: Table<any>;
+    trigramPostings: Table<TrigramPostingsRow, string>;
+}
+
 function parseFtsArray(fts: readonly string[]): Map<string, number> {
     const out = new Map<string, number>();
     for (const entry of fts) {
@@ -55,9 +88,8 @@ function parseFtsArray(fts: readonly string[]): Map<string, number> {
 }
 
 /**
- * Record a doc-level change in the pending queue. Coalesces multiple changes
- * to the same doc within a flush window: keeps the original committed state
- * as `oldFts` and overwrites `newFts` with the latest target state.
+ * Coalesce multiple changes to the same doc within one flush window: keep the
+ * original committed state as `oldFts` and overwrite `newFts` with the latest.
  */
 function recordChange(docId: string, oldFts: string[], newFts: string[]): void {
     const existing = pendingChanges.get(docId);
@@ -69,7 +101,9 @@ function recordChange(docId: string, oldFts: string[], newFts: string[]): void {
 }
 
 function scheduleFlush(db: TrigramDb): void {
-    if (flushTimer !== undefined) return;
+    // Reset on every change so the flush only fires after the write stream
+    // has been quiet for FLUSH_DEBOUNCE_MS — i.e. after sync settles.
+    if (flushTimer !== undefined) clearTimeout(flushTimer);
     flushTimer = setTimeout(() => {
         flushTimer = undefined;
         flushPendingTrigramChanges(db).catch((err) => {
@@ -79,21 +113,8 @@ function scheduleFlush(db: TrigramDb): void {
 }
 
 /**
- * Subset of the Database we touch — keeps this module decoupled from the
- * concrete Database class to avoid a circular import.
- */
-export interface TrigramDb extends Dexie {
-    docs: Table<any>;
-    trigramStats: Table<TrigramStatsRow, string>;
-    trigramPostings: Table<TrigramPostingsRow, string>;
-    luminaryInternals: Table<{ id: string; value: any }, string>;
-}
-
-/**
- * Apply queued doc-level changes to the trigram tables in one batched
- * read-modify-write. Concurrent callers serialize via `flushChain`, so the
- * latest call always sees a consistent state. Cancels any pending debounce
- * timer so callers (e.g. ftsSearch) can drain on demand.
+ * Apply queued doc-level changes to `trigramPostings` in one batched
+ * read-modify-write. Concurrent callers serialize via `flushChain`.
  */
 export function flushPendingTrigramChanges(db: TrigramDb): Promise<void> {
     if (flushTimer !== undefined) {
@@ -106,7 +127,6 @@ export function flushPendingTrigramChanges(db: TrigramDb): Promise<void> {
 
 async function doFlush(db: TrigramDb): Promise<void> {
     if (pendingChanges.size === 0) return;
-
     const changes = pendingChanges;
     pendingChanges = new Map();
 
@@ -116,7 +136,6 @@ async function doFlush(db: TrigramDb): Promise<void> {
     changes.forEach(({ oldFts, newFts }, docId) => {
         const oldMap = parseFtsArray(oldFts);
         const newMap = parseFtsArray(newFts);
-
         oldMap.forEach((_tf, trigram) => {
             if (!newMap.has(trigram)) {
                 let ops = trigramOps.get(trigram);
@@ -138,20 +157,17 @@ async function doFlush(db: TrigramDb): Promise<void> {
     });
 
     if (trigramOps.size === 0) return;
+    const touched = Array.from(trigramOps.keys());
 
-    const touched: string[] = [];
-    trigramOps.forEach((_ops, trigram) => touched.push(trigram));
-
-    await db.transaction("rw", db.trigramStats, db.trigramPostings, async () => {
-        const postingsRows = await db.trigramPostings.bulkGet(touched);
-        const postingUpdates: TrigramPostingsRow[] = [];
-        const statsUpdates: TrigramStatsRow[] = [];
+    await db.transaction("rw", db.trigramPostings, async () => {
+        const existingRows = await db.trigramPostings.bulkGet(touched);
+        const upserts: TrigramPostingsRow[] = [];
         const deletes: string[] = [];
 
         for (let i = 0; i < touched.length; i++) {
             const trigram = touched[i];
             const ops = trigramOps.get(trigram)!;
-            const existing = postingsRows[i];
+            const existing = existingRows[i];
 
             const postingsMap = new Map<string, number>();
             if (existing) {
@@ -170,31 +186,25 @@ async function doFlush(db: TrigramDb): Promise<void> {
             } else {
                 const postings: Array<[string, number]> = [];
                 postingsMap.forEach((tf, docId) => postings.push([docId, tf]));
-                postingUpdates.push({ trigram, postings });
-                statsUpdates.push({ trigram, df: postings.length });
+                upserts.push({ trigram, postings });
             }
         }
 
-        if (deletes.length > 0) {
-            await db.trigramPostings.bulkDelete(deletes);
-            await db.trigramStats.bulkDelete(deletes);
-        }
-        if (postingUpdates.length > 0) {
-            await db.trigramPostings.bulkPut(postingUpdates);
-            await db.trigramStats.bulkPut(statsUpdates);
-        }
+        if (deletes.length > 0) await db.trigramPostings.bulkDelete(deletes);
+        if (upserts.length > 0) await db.trigramPostings.bulkPut(upserts);
     });
 }
 
 /**
  * Install Dexie hooks on the docs table that record fts-affecting changes
- * into the pending queue. The hooks fire for any write source (sync, manual
- * upsert, deleteRevoked, etc.) so the index stays consistent without needing
- * each call site to know about the trigram tables.
+ * into the pending queue. Hooks fire for any write source (sync, manual
+ * upsert, deleteRevoked, etc.) so the index stays consistent without each
+ * call site needing to know about `trigramPostings`.
  */
 export function installTrigramHooks(db: TrigramDb): void {
     db.docs.hook("creating", (_pk, obj) => {
         if (!obj || obj.type !== DocType.Content) return;
+        invalidateCachedDoc(obj._id);
         const fts = (obj as ContentDto).fts;
         if (!Array.isArray(fts) || fts.length === 0) return;
         recordChange(obj._id, [], fts);
@@ -204,6 +214,8 @@ export function installTrigramHooks(db: TrigramDb): void {
     db.docs.hook("updating", (mods, _pk, obj) => {
         if (!obj) return;
         const after = { ...obj, ...(mods as object) } as ContentDto;
+        const id = after._id ?? (obj as any)._id;
+        if (id) invalidateCachedDoc(id);
         const isContentNow = after.type === DocType.Content;
         const wasContent = (obj as any).type === DocType.Content;
         if (!isContentNow && !wasContent) return;
@@ -213,12 +225,14 @@ export function installTrigramHooks(db: TrigramDb): void {
                 : [];
         const newFts = isContentNow && Array.isArray(after.fts) ? (after.fts as string[]) : [];
         if (oldFts.length === 0 && newFts.length === 0) return;
-        recordChange(after._id ?? (obj as any)._id, oldFts, newFts);
+        recordChange(id, oldFts, newFts);
         scheduleFlush(db);
     });
 
     db.docs.hook("deleting", (_pk, obj) => {
-        if (!obj || obj.type !== DocType.Content) return;
+        if (!obj) return;
+        if (obj._id) invalidateCachedDoc(obj._id);
+        if (obj.type !== DocType.Content) return;
         const fts = (obj as ContentDto).fts;
         if (!Array.isArray(fts) || fts.length === 0) return;
         recordChange(obj._id, fts, []);
@@ -227,13 +241,12 @@ export function installTrigramHooks(db: TrigramDb): void {
 }
 
 /**
- * Build the trigram tables from scratch by scanning every Content doc.
- * Used on first run after the schema upgrade and as a recovery if the index
- * gets out of sync.
+ * Build `trigramPostings` from scratch by scanning every Content doc's fts
+ * array. Used on first run after the schema upgrade. Pure rearrangement of
+ * existing data — no `stripHtml` / `normalizeText` needed.
  */
 export async function backfillTrigramIndex(db: TrigramDb): Promise<void> {
-    // (trigram → docId → tf)
-    const accum = new Map<string, Map<string, number>>();
+    const accum = new Map<string, Map<string, number>>(); // trigram → docId → tf
 
     await db.docs
         .where("type")
@@ -257,49 +270,50 @@ export async function backfillTrigramIndex(db: TrigramDb): Promise<void> {
             }
         });
 
-    const postingsRows: TrigramPostingsRow[] = [];
-    const statsRows: TrigramStatsRow[] = [];
+    const rows: TrigramPostingsRow[] = [];
     accum.forEach((postingsMap, trigram) => {
         const postings: Array<[string, number]> = [];
         postingsMap.forEach((tf, docId) => postings.push([docId, tf]));
-        postingsRows.push({ trigram, postings });
-        statsRows.push({ trigram, df: postings.length });
+        rows.push({ trigram, postings });
     });
 
-    await db.transaction("rw", db.trigramStats, db.trigramPostings, async () => {
+    await db.transaction("rw", db.trigramPostings, async () => {
         await db.trigramPostings.clear();
-        await db.trigramStats.clear();
-        if (postingsRows.length > 0) {
-            await db.trigramPostings.bulkPut(postingsRows);
-            await db.trigramStats.bulkPut(statsRows);
-        }
+        if (rows.length > 0) await db.trigramPostings.bulkPut(rows);
     });
 
     backfilled = true;
 }
 
 /**
- * Run a backfill if the trigram tables are empty but content docs exist.
- * Called from initDatabase; safe to call repeatedly (no-op once populated).
+ * Run a backfill if `trigramPostings` is empty but content docs exist. Called
+ * from `initDatabase` (background, non-awaited); safe to call repeatedly.
  */
 export async function ensureTrigramIndexBuilt(db: TrigramDb): Promise<void> {
     if (backfilled) return;
-    const statsCount = await db.trigramStats.count();
-    if (statsCount > 0) {
+    const count = await db.trigramPostings.count();
+    if (count > 0) {
         backfilled = true;
         return;
     }
     const hasContent = await db.docs.where("type").equals(DocType.Content).first();
     if (!hasContent) {
-        backfilled = true; // nothing to build yet; hooks will populate as docs arrive
+        backfilled = true; // nothing to build yet; hooks will populate as docs arrive.
         return;
     }
     await backfillTrigramIndex(db);
 }
 
 /**
- * Reset module-level state. Used by tests between cases.
+ * True once the backfill has populated `trigramPostings`. Searches before
+ * this returns true must fall through to the multi-entry-index path on
+ * `db.docs` to avoid returning empty results during the brief startup window.
  */
+export function isTrigramIndexReady(): boolean {
+    return backfilled;
+}
+
+/** Reset module-level state. Used by tests between cases. */
 export function resetTrigramIndexState(): void {
     pendingChanges = new Map();
     if (flushTimer !== undefined) {
@@ -308,5 +322,5 @@ export function resetTrigramIndexState(): void {
     }
     flushChain = Promise.resolve();
     backfilled = false;
+    docCache.clear();
 }
-

--- a/shared/src/fts/types.ts
+++ b/shared/src/fts/types.ts
@@ -18,11 +18,11 @@ export type FtsSearchResult = {
     /** Boost-weighted count of full query words matched in document fields */
     wordMatchScore: number;
     /**
-     * The loaded document. `ftsSearch` already reads this from IDB during scoring,
-     * so we hand it back to consumers — they don't need a second `db.docs.where(...)`
-     * round-trip on the rendering path. Optional so test fixtures and synthetic
-     * `FtsSearchResult` literals stay valid; consumers should fall back to a DB
-     * lookup when missing.
+     * The loaded `ContentDto`. `ftsSearch` already reads this from IDB during
+     * scoring, so we hand it back to consumers — they don't need a second
+     * `db.docs.where(...)` round-trip on the rendering path. Optional so test
+     * fixtures and synthetic `FtsSearchResult` literals stay valid; consumers
+     * should fall back to a DB lookup when missing.
      */
     doc?: ContentDto;
 };

--- a/shared/src/fts/types.ts
+++ b/shared/src/fts/types.ts
@@ -1,4 +1,4 @@
-import type { Uuid } from "../types";
+import type { ContentDto, Uuid } from "../types";
 
 /** Configuration for a single field to be indexed or searched */
 export type FtsFieldConfig = {
@@ -17,6 +17,14 @@ export type FtsSearchResult = {
     score: number;
     /** Boost-weighted count of full query words matched in document fields */
     wordMatchScore: number;
+    /**
+     * The loaded document. `ftsSearch` already reads this from IDB during scoring,
+     * so we hand it back to consumers — they don't need a second `db.docs.where(...)`
+     * round-trip on the rendering path. Optional so test fixtures and synthetic
+     * `FtsSearchResult` literals stay valid; consumers should fall back to a DB
+     * lookup when missing.
+     */
+    doc?: ContentDto;
 };
 
 /** Search options */

--- a/shared/src/fts/useFtsSearch.ts
+++ b/shared/src/fts/useFtsSearch.ts
@@ -66,6 +66,8 @@ export function useFtsSearch(
 
         isSearching.value = true;
         try {
+            // [perf] temporary timing — remove once investigation complete
+            const __perfT0 = performance.now();
             const searchResults = await ftsSearch({
                 query,
                 languageId: options.languageId?.value,
@@ -73,6 +75,9 @@ export function useFtsSearch(
                 offset,
                 maxTrigramDocPercent,
             });
+            console.debug(
+                `[perf] ftsSearch total q=${JSON.stringify(query)} offset=${offset} hits=${searchResults.length}: ${(performance.now() - __perfT0).toFixed(1)}ms`,
+            );
 
             // Discard if a newer search was started while this one was running
             if (generation !== searchGeneration) return;

--- a/shared/src/fts/useFtsSearch.ts
+++ b/shared/src/fts/useFtsSearch.ts
@@ -1,4 +1,12 @@
-import { ref, watch, type Ref, getCurrentScope, onScopeDispose, isRef, type WatchStopHandle } from "vue";
+import {
+    ref,
+    watch,
+    type Ref,
+    getCurrentScope,
+    onScopeDispose,
+    isRef,
+    type WatchStopHandle,
+} from "vue";
 import { ftsSearch } from "./ftsSearch";
 import type { FtsSearchResult } from "./types";
 
@@ -66,8 +74,6 @@ export function useFtsSearch(
 
         isSearching.value = true;
         try {
-            // [perf] temporary timing — remove once investigation complete
-            const __perfT0 = performance.now();
             const searchResults = await ftsSearch({
                 query,
                 languageId: options.languageId?.value,
@@ -75,9 +81,6 @@ export function useFtsSearch(
                 offset,
                 maxTrigramDocPercent,
             });
-            console.debug(
-                `[perf] ftsSearch total q=${JSON.stringify(query)} offset=${offset} hits=${searchResults.length}: ${(performance.now() - __perfT0).toFixed(1)}ms`,
-            );
 
             // Discard if a newer search was started while this one was running
             if (generation !== searchGeneration) return;
@@ -123,9 +126,12 @@ export function useFtsSearch(
                 if (debounceTimer) clearTimeout(debounceTimer);
                 currentQuery = newQuery;
                 const d = getDebounce();
-                debounceTimer = setTimeout(() => {
-                    doSearch(newQuery, 0, false);
-                }, typeof d === "number" ? d : 0);
+                debounceTimer = setTimeout(
+                    () => {
+                        doSearch(newQuery, 0, false);
+                    },
+                    typeof d === "number" ? d : 0,
+                );
             },
             { immediate: true },
         );


### PR DESCRIPTION
# FTS search perf comparison: branch `1549` vs `main`

Local IndexedDB, instrumented `shared/src/fts/ftsSearch.ts` with identical phase timers and ran the same queries against each algorithm. Numbers in ms.

Three variants measured:

1. **main** — the algorithm on `main`. No trigram inverted index, no candidate window, no in-memory caches. Scores every matched doc.
2. **branch+caches** — branch `1549` with `trigramPostings`, coarse-rank candidate window, plus in-memory `docCache` and `wordSetCache`.
3. **branch no-caches** — the final shipped version: same persistent-IDB optimizations as variant 2 but with both in-memory caches removed (per senior directive: no process-memory caching).

## Per-query totals

| query | main | branch+caches | branch no-caches |
|---|---:|---:|---:|
| "What is the benefits to self-denial" | 1188 | 465 | 767 |
| "How to overcome habitual sin" | 2501 | 407 | — |
| "How we can overcome sin" | 1054 | — | 2314 ⚠ |
| "14 Bible verses…overcome sin" | — | — | 1299 |

⚠ "How we can overcome sin" on no-caches hit a sync-contention spike: 2188 ms to load just 60 docs (36 ms/doc vs the normal 5–10 ms). Treat as variance, not algorithmic regression — rerun for a fair picture.

## Phase breakdown — *"What is the benefits to self-denial"*

15 query trigrams, 10 usable, ~442 matched docs in the corpus.

| metric | main (slow) | branch+caches | branch no-caches |
|---|---:|---:|---:|
| **total** | **1188** | **465** | **767** |
| candidates scored | 442 | 60 | 60 |
| corpusStats | 19 | 18 | 23 |
| trigramCount (main only) | 52 | — | — |
| trigramLookup | 15 | 16 | 8 |
| coarseRank | — | 2 | 2 |
| docsLoad | 527 | 343 | 639 |
| bm25 | 94 | 15 | 17 |
| wordMatch | 481 | 71 | 78 |
| sort | 1.3 | 0 | 0.4 |

## What's driving the win (preserved in no-caches version)

| change on the branch | impact | preserved without caches? |
|---|---|---|
| **Coarse-rank candidate window** (`Σ idf·tf` from postings → top `offset+limit+20` docs) | Dominant. Cuts 442 → 60 docs that get full BM25 + word-match. Multiplies through every later phase. | ✅ Yes |
| **Trigram inverted index** (`trigramPostings` table, single `bulkGet`) | Replaces main's two sequential per-trigram passes (`count()` + `primaryKeys()`). Saves the ~50 ms `trigramCount` phase outright. | ✅ Yes |
| **Per-store implicit transactions** instead of one big readonly tx | Smaller scopes get granted faster under sync write contention. | ✅ Yes |
| **Compound `[language+_id]` index** on docs | Wrong-language candidates miss at the IDB layer — no row read for docs we'd discard. | ✅ Yes |
| **Doc cache** (LRU 500, `ContentDto` by `_id`) | Skipped IDB hydration for overlapping candidate sets during typing/pagination. | ❌ Removed |
| **Word-set cache** (LRU 500, per-doc normalized field word sets) | Skipped repeat `stripHtml` + `normalizeText` work for docs seen in adjacent queries. | ❌ Removed |

## Per-doc scoring cost is identical, the win is in N

| | main | branch+caches | branch no-caches |
|---|---:|---:|---:|
| wordMatch ms / doc | 1.09 | 1.18 | 1.30 |
| bm25 ms / doc | 0.21 | 0.25 | 0.28 |

The branch isn't faster *per doc* — it just does the work on far fewer docs.

## Cost of removing the in-memory caches

| flow | regression |
|---|---|
| **Cold first search** | **None.** Both caches start empty anyway; numbers are within run-to-run variance of the cached version. |
| **Repeated overlapping queries** (interactive typing, pagination) | Theoretical ~30–200 ms slower per follow-up keystroke. Not measured in either trace set — would need a separate test with repeated queries to quantify. |
| **Sync-contention bursts** | `docCache` would have damped some of the `docsLoad` variance. Without it, slow-run spikes are larger. |

## Recall tradeoff (and why it's fine)

Coarse rank doesn't account for word-match field boosts (e.g. title at 3.0×), so in theory a low-coarse-score doc with a strong title match could be excluded by the candidate window.

In practice this isn't an issue because:

- A title match means the title's trigrams hit, which drives high coarse score anyway — the doc is already in the window.
- Empirically: title-match queries return the expected doc on the branch.
- **Pagination expands the window** — `slice(0, offset + limit + 20)` grows with offset, so as the user pages forward, more candidates become reachable. A doc that "should have been" in the top 20 by full BM25 but missed the coarse cut will surface within a page or two.

## What's still on the table

- **`docsLoad` is the remaining bottleneck** (~75% of branch latency, baseline ~80 ms uncontended, much worse during sync). Avoiding `db.docs` at search time entirely (precomputed display data in a smaller store) would be the next biggest win.
- **Web Worker** wouldn't reduce work but would stop main-thread sync from causing the 6× slow-run amplification.
- **Remove the `*fts` multi-entry index from `db.docs`** — its only runtime consumer is the fallback path. Removal cuts IDB storage materially and reduces sync write amplification. Backfill iterates docs directly, so it doesn't need the index either.
