### PR TITLE
fix(api): clear cached DTO state on DB disconnect

### DIFF
--- a/api/src/auth/authIdentity.service.spec.ts
+++ b/api/src/auth/authIdentity.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { JwtService } from "@nestjs/jwt";
 import { DbService } from "../db/db.service";
 import { DocType } from "../enums";
+import { EventEmitter } from "node:events";
 
 jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("new-user-uuid") }));
 
@@ -360,6 +361,103 @@ describe("AuthIdentityService", () => {
                 "group-public",
                 "group-verified",
             ]);
+        });
+    });
+
+    // ── disconnect cache clearing ────────────────────────────────────────────────
+    describe("cache clearing on DB disconnect", () => {
+        let mockDb: EventEmitter & { executeFindQuery?: jest.Mock };
+        let disconnectService: AuthIdentityService;
+
+        beforeEach(async () => {
+            mockDb = Object.assign(new EventEmitter(), {
+                executeFindQuery: jest.fn().mockResolvedValue({ docs: [] }),
+            });
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    AuthIdentityService,
+                    { provide: JwtService, useValue: {} },
+                    { provide: DbService, useValue: mockDb },
+                ],
+            }).compile();
+
+            disconnectService = module.get<AuthIdentityService>(AuthIdentityService);
+            // onModuleInit is what wires the listeners; call it explicitly since
+            // .compile() doesn't run Nest lifecycle hooks.
+            disconnectService.onModuleInit();
+        });
+
+        it("populates and clears providerCache/jwksClients on disconnect", () => {
+            const svc: any = disconnectService;
+
+            // Simulate a provider update flowing through the change feed.
+            mockDb.emit("update", {
+                _id: "provider-1",
+                type: DocType.AuthProvider,
+                domain: "example.auth0.com",
+            });
+            // Seed a jwksClient so we can verify it's cleared too.
+            svc.jwksClients.set("example.auth0.com", {} as any);
+
+            expect(svc.providerCache.size).toBe(1);
+            expect(svc.jwksClients.size).toBe(1);
+
+            mockDb.emit("disconnect");
+
+            expect(svc.providerCache.size).toBe(0);
+            expect(svc.jwksClients.size).toBe(0);
+        });
+
+        it("clears autoGroupMappingsCache and defaultGroupsCache on disconnect", async () => {
+            const svc: any = disconnectService;
+
+            // Populate autoGroupMappingsCache via the public getter.
+            svc.dbService = {
+                ...mockDb,
+                executeFindQuery: jest.fn().mockResolvedValue({
+                    docs: [{ type: DocType.AutoGroupMappings, groupIds: ["g1"], providerId: "p1" }],
+                }),
+            };
+            await disconnectService.getAutoGroupMappings("p1");
+            expect(svc.autoGroupMappingsCache.size).toBe(1);
+
+            // Populate defaultGroupsCache.
+            svc.dbService.executeFindQuery = jest.fn().mockResolvedValue({
+                docs: [{ type: DocType.AutoGroupMappings, groupIds: ["g-default"] }],
+            });
+            await disconnectService.getDefaultGroups();
+            expect(svc.defaultGroupsCache).toEqual(["g-default"]);
+
+            mockDb.emit("disconnect");
+
+            expect(svc.autoGroupMappingsCache.size).toBe(0);
+            expect(svc.defaultGroupsCache).toBeNull();
+        });
+
+        it("lazily repopulates caches after disconnect on next access", async () => {
+            const svc: any = disconnectService;
+
+            const firstQuery = jest.fn().mockResolvedValue({
+                docs: [{ type: DocType.AutoGroupMappings, groupIds: ["g-initial"] }],
+            });
+            svc.dbService = { ...mockDb, executeFindQuery: firstQuery };
+
+            await disconnectService.getDefaultGroups();
+            expect(firstQuery).toHaveBeenCalledTimes(1);
+
+            mockDb.emit("disconnect");
+            expect(svc.defaultGroupsCache).toBeNull();
+
+            // After disconnect, next access should re-query and repopulate.
+            const secondQuery = jest.fn().mockResolvedValue({
+                docs: [{ type: DocType.AutoGroupMappings, groupIds: ["g-fresh"] }],
+            });
+            svc.dbService = { ...mockDb, executeFindQuery: secondQuery };
+            const refreshed = await disconnectService.getDefaultGroups();
+
+            expect(refreshed).toEqual(["g-fresh"]);
+            expect(secondQuery).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/api/src/auth/authIdentity.service.ts
+++ b/api/src/auth/authIdentity.service.ts
@@ -72,6 +72,15 @@ export class AuthIdentityService implements OnModuleInit {
                 this.defaultGroupsCache = null;
             }
         });
+
+        // Drop all DTO-derived caches on DB disconnect so we don't serve stale
+        // provider/mapping state if docs change while the change feed is down.
+        this.dbService.on("disconnect", () => {
+            this.providerCache.clear();
+            this.autoGroupMappingsCache.clear();
+            this.defaultGroupsCache = null;
+            this.jwksClients.clear();
+        });
     }
 
     async getAutoGroupMappings(providerId: string): Promise<AutoGroupMappingsDto[]> {

--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -475,6 +475,42 @@ describe("DbService", () => {
         });
     });
 
+    describe("disconnect events", () => {
+        afterEach(() => {
+            (service as any).connected = true;
+            (service as any).hasConnected = true;
+        });
+
+        it("emits 'reconnect' when waitForDb resolves after an initial connect", async () => {
+            let reconnectCount = 0;
+            const handler = () => reconnectCount++;
+            service.on("reconnect", handler);
+
+            // Simulate the reconnect path: hasConnected=true means an initial
+            // connect already happened, so the next successful waitForDb should
+            // fire 'reconnect'.
+            (service as any).hasConnected = true;
+            (service as any).connected = false;
+            await (service as any).waitForDb();
+
+            expect(reconnectCount).toBe(1);
+            service.off("reconnect", handler);
+        });
+
+        it("does not emit 'reconnect' on the initial connect", async () => {
+            let reconnectCount = 0;
+            const handler = () => reconnectCount++;
+            service.on("reconnect", handler);
+
+            (service as any).hasConnected = false;
+            (service as any).connected = false;
+            await (service as any).waitForDb();
+
+            expect(reconnectCount).toBe(0);
+            service.off("reconnect", handler);
+        });
+    });
+
     describe("ensureConnected", () => {
         beforeEach(() => {
             jest.useFakeTimers();

--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -481,6 +481,50 @@ describe("DbService", () => {
             (service as any).hasConnected = true;
         });
 
+        it("captures the seq from each change event so the feed can resume", () => {
+            // The change handler must record the seq of every change it
+            // processes; otherwise the resume cursor would lag, and on
+            // reconnect we'd miss everything between the last recorded seq
+            // and the actual last delivered change.
+            //
+            // Use Post type to avoid triggering groupUpdate / languageUpdate
+            // listeners that would expect a complete document.
+            const marker = "seq-marker-test-99999";
+            (service as any).db.changesReader.ee.emit("change", {
+                seq: marker,
+                doc: { _id: "seq-marker-doc", type: DocType.Post },
+            });
+
+            expect((service as any).lastSeq).toBe(marker);
+        });
+
+        it("resumes the change feed from lastSeq when restarted", () => {
+            const changesReader = (service as any).db.changesReader;
+
+            // Pin a known lastSeq so we can verify it round-trips through
+            // startChangesFeed → changesReader.start(...).
+            (service as any).lastSeq = "resume-from-marker-12345";
+
+            // The changesReader rejects double-start while `started` is true.
+            // Reset and stub `start` so we can observe the next call's args
+            // without spawning a real polling loop.
+            const wasStarted = changesReader.started;
+            changesReader.started = false;
+            const startSpy = jest
+                .spyOn(changesReader, "start")
+                .mockReturnValue(changesReader.ee);
+
+            try {
+                (service as any).startChangesFeed();
+                expect(startSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ since: "resume-from-marker-12345" }),
+                );
+            } finally {
+                startSpy.mockRestore();
+                changesReader.started = wasStarted;
+            }
+        });
+
         it("emits 'reconnect' when waitForDb resolves after an initial connect", async () => {
             let reconnectCount = 0;
             const handler = () => reconnectCount++;

--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -478,7 +478,7 @@ describe("DbService", () => {
     describe("disconnect events", () => {
         afterEach(() => {
             (service as any).connected = true;
-            (service as any).hasConnected = true;
+            (service as any).disconnectEmitted = false;
         });
 
         it("captures the seq from each change event so the feed can resume", () => {
@@ -525,15 +525,15 @@ describe("DbService", () => {
             }
         });
 
-        it("emits 'reconnect' when waitForDb resolves after an initial connect", async () => {
+        it("emits 'reconnect' when waitForDb resolves after a 'disconnect' was emitted", async () => {
             let reconnectCount = 0;
             const handler = () => reconnectCount++;
             service.on("reconnect", handler);
 
-            // Simulate the reconnect path: hasConnected=true means an initial
-            // connect already happened, so the next successful waitForDb should
-            // fire 'reconnect'.
-            (service as any).hasConnected = true;
+            // Simulate the reconnect path: a real disconnect was emitted to
+            // listeners, so the next successful waitForDb should pair it with
+            // a 'reconnect'.
+            (service as any).disconnectEmitted = true;
             (service as any).connected = false;
             await (service as any).waitForDb();
 
@@ -546,11 +546,30 @@ describe("DbService", () => {
             const handler = () => reconnectCount++;
             service.on("reconnect", handler);
 
-            (service as any).hasConnected = false;
+            // No prior disconnect emit means this is either the first connect
+            // or a redundant waitForDb resolution — either way, no reconnect
+            // should fire.
+            (service as any).disconnectEmitted = false;
             (service as any).connected = false;
             await (service as any).waitForDb();
 
             expect(reconnectCount).toBe(0);
+            service.off("reconnect", handler);
+        });
+
+        it("does not double-emit 'reconnect' when two waitForDb() calls race", async () => {
+            // Race scenario: feed-error path and an explicit reconnect both
+            // call waitForDb(). The first to resolve clears disconnectEmitted
+            // and emits; the second must see the cleared flag and stay quiet.
+            let reconnectCount = 0;
+            const handler = () => reconnectCount++;
+            service.on("reconnect", handler);
+
+            (service as any).disconnectEmitted = true;
+            (service as any).connected = false;
+            await Promise.all([(service as any).waitForDb(), (service as any).waitForDb()]);
+
+            expect(reconnectCount).toBe(1);
             service.off("reconnect", handler);
         });
     });

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -106,6 +106,13 @@ export class DbService extends EventEmitter {
     private reconnecting = false;
     private readonly maxReconnectDelay = 30000;
 
+    // Sequence cursor of the last change we delivered to listeners. Resuming the
+    // feed from this value on reconnect is what lets in-memory caches (perms,
+    // languages, etc.) recover changes that occurred during the disconnect
+    // window without re-fetching everything. Initialised to "now" so the very
+    // first connect starts at the head of the feed (existing behaviour).
+    private lastSeq: string | number = "now";
+
     constructor(
         @Inject(WINSTON_MODULE_PROVIDER)
         private readonly logger: Logger,
@@ -173,7 +180,7 @@ export class DbService extends EventEmitter {
      */
     private startChangesFeed() {
         this.db.changesReader
-            .start({ includeDocs: true })
+            .start({ includeDocs: true, since: this.lastSeq })
             .on("change", (update) => {
                 // emit update event for all valid documents
                 if (update.doc && update.doc.type) {
@@ -196,6 +203,13 @@ export class DbService extends EventEmitter {
                         if (doc.deleteReason === DeleteReason.Deleted)
                             this.emit("languageUpdate", doc);
                     }
+                }
+
+                // Advance the resume cursor after listeners run so a crash
+                // mid-handler causes the change to be re-delivered on the next
+                // reconnect rather than silently skipped.
+                if (update.seq !== undefined) {
+                    this.lastSeq = update.seq;
                 }
             })
             .on("error", (err) => {

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -81,6 +81,8 @@ export type DbUpsertResult = {
  *
  * @fires DbService#update - Emitted when any valid document with a type field is updated in the database
  * @fires DbService#groupUpdate - Emitted when a group document is updated, used by the permission system to update access maps
+ * @fires DbService#disconnect - Emitted when a previously-established DB connection is lost. Consumers should drop cached DTO state that may have diverged while disconnected.
+ * @fires DbService#reconnect - Emitted after a disconnect has been followed by a successful reconnect. Consumers that need a populated cache to function should rehydrate here.
  *
  * @example
  * // Listen for document updates
@@ -99,6 +101,7 @@ export class DbService extends EventEmitter {
     private db: any;
     protected syncTolerance: number;
     private connected = false;
+    private hasConnected = false;
     private dbConfig: DatabaseConfig;
     private reconnecting = false;
     private readonly maxReconnectDelay = 30000;
@@ -148,8 +151,11 @@ export class DbService extends EventEmitter {
         while (true) {
             try {
                 await this.db.info();
+                const isReconnect = this.hasConnected;
                 this.connected = true;
+                this.hasConnected = true;
                 this.logger.info("Connected to database");
+                if (isReconnect) this.emit("reconnect");
                 return;
             } catch (err) {
                 this.connected = false;
@@ -194,13 +200,16 @@ export class DbService extends EventEmitter {
             })
             .on("error", (err) => {
                 this.logger.warn("Database changes feed error, will restart:", err.message || err);
+                const wasConnected = this.connected;
                 this.connected = false;
+                if (wasConnected) this.emit("disconnect");
                 this.reconnect();
             })
             .on("close", () => {
                 if (this.connected) {
                     this.logger.warn("Database changes feed closed unexpectedly, will restart");
                     this.connected = false;
+                    this.emit("disconnect");
                     this.reconnect();
                 }
             });

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -110,11 +110,24 @@ export class DbService extends EventEmitter {
     private reconnecting = false;
     private readonly maxReconnectDelay = 30000;
 
-    // Sequence cursor of the last change we delivered to listeners. Resuming the
-    // feed from this value on reconnect is what lets in-memory caches (perms,
-    // languages, etc.) recover changes that occurred during the disconnect
-    // window without re-fetching everything. Initialised to "now" so the very
-    // first connect starts at the head of the feed (existing behaviour).
+    /**
+     * Sequence cursor of the last change delivered to listeners. Passed as
+     * `since` to the CouchDB `_changes` feed when we (re)start it.
+     *
+     * Initialised to `"now"` — CouchDB resolves this to the current
+     * `update_seq` at request time and only delivers changes from that point
+     * forward. We do NOT use `0` (replay all history) because at cold start
+     * each consumer already loads its own snapshot via direct queries
+     * (PermissionSystem groups, QueryService languages, etc.), so replaying
+     * history would just re-fire emits for state we already have.
+     *
+     * After the first change is processed this holds a real seq value, so a
+     * reconnect resumes from the exact point we left off — that's how the
+     * in-memory caches recover updates that landed during the disconnect
+     * window without a full snapshot refetch. nano's own default for `since`
+     * is also `"now"`, so passing this on first connect matches that
+     * behaviour.
+     */
     private lastSeq: string | number = "now";
 
     constructor(

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -101,7 +101,11 @@ export class DbService extends EventEmitter {
     private db: any;
     protected syncTolerance: number;
     private connected = false;
-    private hasConnected = false;
+    // Tracks an unmatched 'disconnect' emit. Used to gate the next 'reconnect'
+    // emit so it pairs with a real prior disconnect, rather than firing on the
+    // initial connect or on whichever waitForDb() happens to resolve second
+    // when two are racing (see startChangesFeed error handler).
+    private disconnectEmitted = false;
     private dbConfig: DatabaseConfig;
     private reconnecting = false;
     private readonly maxReconnectDelay = 30000;
@@ -158,11 +162,15 @@ export class DbService extends EventEmitter {
         while (true) {
             try {
                 await this.db.info();
-                const isReconnect = this.hasConnected;
                 this.connected = true;
-                this.hasConnected = true;
                 this.logger.info("Connected to database");
-                if (isReconnect) this.emit("reconnect");
+                // Only emit 'reconnect' if we previously emitted a 'disconnect'.
+                // Clear the flag first so a concurrent waitForDb() resolving
+                // afterwards doesn't double-emit.
+                if (this.disconnectEmitted) {
+                    this.disconnectEmitted = false;
+                    this.emit("reconnect");
+                }
                 return;
             } catch (err) {
                 this.connected = false;
@@ -216,13 +224,20 @@ export class DbService extends EventEmitter {
                 this.logger.warn("Database changes feed error, will restart:", err.message || err);
                 const wasConnected = this.connected;
                 this.connected = false;
-                if (wasConnected) this.emit("disconnect");
+                // Only emit 'disconnect' on a real connected→disconnected
+                // transition. A feed error during initial connect (DB down at
+                // boot) is not a disconnect from a listener's perspective.
+                if (wasConnected) {
+                    this.disconnectEmitted = true;
+                    this.emit("disconnect");
+                }
                 this.reconnect();
             })
             .on("close", () => {
                 if (this.connected) {
                     this.logger.warn("Database changes feed closed unexpectedly, will restart");
                     this.connected = false;
+                    this.disconnectEmitted = true;
                     this.emit("disconnect");
                     this.reconnect();
                 }

--- a/api/src/endpoints/query.service.spec.ts
+++ b/api/src/endpoints/query.service.spec.ts
@@ -665,4 +665,50 @@ describe("QueryService", () => {
             new HttpException("Forbidden", HttpStatus.FORBIDDEN),
         );
     });
+
+    describe("language cache clearing on DB disconnect", () => {
+        it("clears the languages cache on disconnect and refetches on reconnect", async () => {
+            const { EventEmitter } = await import("node:events");
+            const emitter = new EventEmitter();
+
+            const executeFindQuery = jest
+                .fn()
+                .mockResolvedValueOnce({
+                    docs: [{ _id: "lang-eng", type: DocType.Language, languageCode: "eng" }],
+                })
+                .mockResolvedValueOnce({
+                    docs: [
+                        { _id: "lang-eng", type: DocType.Language, languageCode: "eng" },
+                        { _id: "lang-fra", type: DocType.Language, languageCode: "fra" },
+                    ],
+                });
+
+            const dbMock: any = Object.assign(emitter, { executeFindQuery });
+
+            const moduleRef = await Test.createTestingModule({
+                providers: [
+                    QueryService,
+                    { provide: DbService, useValue: dbMock },
+                    { provide: WINSTON_MODULE_PROVIDER, useValue: logger },
+                ],
+            }).compile();
+
+            const qs: any = moduleRef.get(QueryService);
+
+            // Let the constructor's initial load resolve.
+            await new Promise((r) => setImmediate(r));
+            expect(qs.languages).toHaveLength(1);
+            expect(qs.languages[0]._id).toBe("lang-eng");
+
+            // Disconnect should drop the cache.
+            emitter.emit("disconnect");
+            expect(qs.languages).toEqual([]);
+
+            // Reconnect should rehydrate from DB.
+            emitter.emit("reconnect");
+            await new Promise((r) => setImmediate(r));
+            expect(qs.languages).toHaveLength(2);
+            expect(qs.languages.map((l: any) => l._id).sort()).toEqual(["lang-eng", "lang-fra"]);
+        });
+    });
 });

--- a/api/src/endpoints/query.service.ts
+++ b/api/src/endpoints/query.service.ts
@@ -35,6 +35,19 @@ export class QueryService {
             }
         });
 
+        // Drop the language cache on disconnect; any changes made while the feed
+        // was down would otherwise be missed by the resumed change stream.
+        this.db.on("disconnect", () => {
+            this.languages = [];
+        });
+        this.db.on("reconnect", () => {
+            this.loadLanguages();
+        });
+
+        this.loadLanguages();
+    }
+
+    private loadLanguages() {
         this.db
             .executeFindQuery({
                 selector: { type: DocType.Language },
@@ -42,7 +55,7 @@ export class QueryService {
                 use_index: "sync-language-index",
             })
             .then((res) => {
-                this.languages.push(...(res.docs as LanguageDto[]));
+                this.languages = res.docs as LanguageDto[];
             });
     }
 

--- a/api/src/endpoints/query.service.ts
+++ b/api/src/endpoints/query.service.ts
@@ -55,7 +55,17 @@ export class QueryService {
                 use_index: "sync-language-index",
             })
             .then((res) => {
-                this.languages = res.docs as LanguageDto[];
+                // Merge by _id rather than reassigning or pushing blindly: the
+                // `languageUpdate` change-stream listener may fire during the async
+                // window of this query (especially on reconnect, where the resumed
+                // feed can deliver events before this promise resolves). Reassigning
+                // would clobber those concurrent updates; pushing could create
+                // duplicates for docs the listener already inserted.
+                for (const doc of res.docs as LanguageDto[]) {
+                    const i = this.languages.findIndex((l) => l._id == doc._id);
+                    if (i >= 0) this.languages[i] = doc;
+                    else this.languages.push(doc);
+                }
             });
     }
 

--- a/api/src/endpoints/query.service.ts
+++ b/api/src/endpoints/query.service.ts
@@ -66,6 +66,9 @@ export class QueryService {
                     if (i >= 0) this.languages[i] = doc;
                     else this.languages.push(doc);
                 }
+            })
+            .catch((err) => {
+                this.logger.error("Failed to load languages cache", err);
             });
     }
 

--- a/api/src/main.spec.ts
+++ b/api/src/main.spec.ts
@@ -42,7 +42,7 @@ describe("bootstrap", () => {
 
         mockApp = {
             register: jest.fn().mockResolvedValue(undefined),
-            get: jest.fn().mockReturnValue({}),
+            get: jest.fn().mockReturnValue({ on: jest.fn() }),
             enableCors: jest.fn(),
             useGlobalPipes: jest.fn(),
             useGlobalFilters: jest.fn(),

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -9,6 +9,7 @@ import { ValidationPipe } from "@nestjs/common";
 import compress from "@fastify/compress";
 import multipart from "@fastify/multipart";
 import { AllExceptionsFilter } from "./filters/allExceptions.filter";
+import { S3Service } from "./s3/s3.service";
 
 export async function bootstrap() {
     const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
@@ -41,6 +42,9 @@ export async function bootstrap() {
 
     // Initialize permission system
     await PermissionSystem.init(dbService);
+
+    // Wire up S3 singleton cache to DB change feed and disconnect events
+    S3Service.initializeChangeListener(dbService);
 
     // Upgrade database schema if needed
     await upgradeDbSchema(dbService);

--- a/api/src/permissions/permissions.service.spec.ts
+++ b/api/src/permissions/permissions.service.spec.ts
@@ -900,17 +900,37 @@ describe("PermissionService", () => {
             });
         });
 
-        it("clears the groupMap on DB disconnect and rehydrates on reconnect", async () => {
+        it("retains the groupMap on DB disconnect and reconciles on reconnect", async () => {
             // Sanity: seeded groups are present before disconnect.
             expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
 
+            // Inject a phantom group that does not exist in the DB. This
+            // simulates a group that was deleted while the API was islanded —
+            // the reconnect diff must clean it up.
+            const phantom: GroupDto = new GroupDto();
+            phantom._id = "group-phantom-disconnected";
+            phantom.type = DocType.Group;
+            phantom.updatedTimeUtc = 1;
+            phantom.name = "Phantom";
+            phantom.acl = [];
+            PermissionSystem.upsertGroups([phantom]);
+            expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(true);
+
             testingModule.dbService.emit("disconnect");
-            // clearGroupMap runs synchronously on the 'disconnect' emit.
-            expect(PermissionSystem.hasGroup("group-public-users")).toBe(false);
+
+            // Cached permissions must remain available while islanded so
+            // clients syncing through the API don't see a sudden total loss
+            // of access and purge their local data.
+            expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
+            expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(true);
 
             testingModule.dbService.emit("reconnect");
+
             await waitForExpect(() => {
+                // Real groups are still here.
                 expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
+                // Groups missing from the DB snapshot are removed by the diff.
+                expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(false);
             });
         });
     });

--- a/api/src/permissions/permissions.service.spec.ts
+++ b/api/src/permissions/permissions.service.spec.ts
@@ -900,38 +900,131 @@ describe("PermissionService", () => {
             });
         });
 
-        it("retains the groupMap on DB disconnect and reconciles on reconnect", async () => {
-            // Sanity: seeded groups are present before disconnect.
+        it("retains the groupMap on DB disconnect", async () => {
             expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
-
-            // Inject a phantom group that does not exist in the DB. This
-            // simulates a group that was deleted while the API was islanded —
-            // the reconnect diff must clean it up.
-            const phantom: GroupDto = new GroupDto();
-            phantom._id = "group-phantom-disconnected";
-            phantom.type = DocType.Group;
-            phantom.updatedTimeUtc = 1;
-            phantom.name = "Phantom";
-            phantom.acl = [];
-            PermissionSystem.upsertGroups([phantom]);
-            expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(true);
 
             testingModule.dbService.emit("disconnect");
 
-            // Cached permissions must remain available while islanded so
+            // Cached permissions must remain available while disconnected so
             // clients syncing through the API don't see a sudden total loss
-            // of access and purge their local data.
+            // of access and purge their local data. DbService resumes the
+            // change feed from its seq cursor on reconnect, so missed updates
+            // are replayed through the existing `groupUpdate` listener.
             expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
-            expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(true);
+        });
 
-            testingModule.dbService.emit("reconnect");
+        it("patches an existing group's ACL when the update arrives after a disconnect/reconnect cycle", () => {
+            // This is the regression test for the disconnect→reconnect→missed-
+            // update path: prove that when the resumed change feed delivers a
+            // groupUpdate for a group already in the cache, the new ACL fields
+            // overwrite the cached ones (rather than being merged or ignored).
+            const groupId = "group-acl-patch-after-reconnect";
 
-            await waitForExpect(() => {
-                // Real groups are still here.
-                expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
-                // Groups missing from the DB snapshot are removed by the diff.
-                expect(PermissionSystem.hasGroup("group-phantom-disconnected")).toBe(false);
-            });
+            const initial: GroupDto = new GroupDto();
+            initial._id = groupId;
+            initial.type = DocType.Group;
+            initial.updatedTimeUtc = 1;
+            initial.name = "Initial";
+            initial.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+            PermissionSystem.upsertGroups([initial]);
+
+            // Sanity: View is granted, Edit is not.
+            const before = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.Edit,
+                ["group-public-content"],
+            );
+            expect(before[DocType.Language]?.includes(groupId)).toBeFalsy();
+
+            // Simulate the disconnect window: the cache is intentionally not
+            // cleared, so the group remains queryable.
+            testingModule.dbService.emit("disconnect");
+            expect(PermissionSystem.hasGroup(groupId)).toBe(true);
+
+            // The resumed change feed delivers an update that grants Edit.
+            // We simulate the delivery via direct emit on the dbService event
+            // bus — that's exactly the path the change handler in DbService
+            // would take for a real change replayed via the seq cursor.
+            const updated: GroupDto = new GroupDto();
+            updated._id = groupId;
+            updated.type = DocType.Group;
+            updated.updatedTimeUtc = 2;
+            updated.name = "Updated";
+            updated.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View, AclPermission.Edit],
+                },
+            ];
+            testingModule.dbService.emit("groupUpdate", updated);
+
+            // The cache reflects the new Edit permission — the existing
+            // group entry was patched, not duplicated or left stale.
+            const after = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.Edit,
+                ["group-public-content"],
+            );
+            expect(after[DocType.Language]?.includes(groupId)).toBe(true);
+        });
+
+        it("removes a revoked ACL permission when the update arrives after a disconnect/reconnect cycle", () => {
+            // The complement of the patch test: the existing-group code path
+            // in upsertGroup must also strip permissions that are no longer
+            // present in the new ACL. Without this, a permission revoked
+            // during disconnect would never be cleared from the cache.
+            const groupId = "group-acl-revoke-after-reconnect";
+
+            const initial: GroupDto = new GroupDto();
+            initial._id = groupId;
+            initial.type = DocType.Group;
+            initial.updatedTimeUtc = 1;
+            initial.name = "Initial";
+            initial.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View, AclPermission.Edit],
+                },
+            ];
+            PermissionSystem.upsertGroups([initial]);
+
+            const before = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.Edit,
+                ["group-public-content"],
+            );
+            expect(before[DocType.Language]?.includes(groupId)).toBe(true);
+
+            testingModule.dbService.emit("disconnect");
+
+            const updated: GroupDto = new GroupDto();
+            updated._id = groupId;
+            updated.type = DocType.Group;
+            updated.updatedTimeUtc = 2;
+            updated.name = "Updated";
+            updated.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+            testingModule.dbService.emit("groupUpdate", updated);
+
+            const after = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.Edit,
+                ["group-public-content"],
+            );
+            expect(after[DocType.Language]?.includes(groupId)).toBeFalsy();
         });
     });
 });

--- a/api/src/permissions/permissions.service.spec.ts
+++ b/api/src/permissions/permissions.service.spec.ts
@@ -899,5 +899,19 @@ describe("PermissionService", () => {
                 expect(res[DocType.Language].includes("test-group")).toBe(true);
             });
         });
+
+        it("clears the groupMap on DB disconnect and rehydrates on reconnect", async () => {
+            // Sanity: seeded groups are present before disconnect.
+            expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
+
+            testingModule.dbService.emit("disconnect");
+            // clearGroupMap runs synchronously on the 'disconnect' emit.
+            expect(PermissionSystem.hasGroup("group-public-users")).toBe(false);
+
+            testingModule.dbService.emit("reconnect");
+            await waitForExpect(() => {
+                expect(PermissionSystem.hasGroup("group-public-users")).toBe(true);
+            });
+        });
     });
 });

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -104,7 +104,7 @@ export type AccessMap = Map<Uuid, Map<DocType, Map<AclPermission, boolean>>>;
  * Accessed throughout this file via object-style property access, so it is
  * typed as a Record rather than a Map.
  */
-const groupMap: Record<Uuid, PermissionSystem> = {};
+const groupMap: Map<Uuid, PermissionSystem> = new Map<Uuid, PermissionSystem>();
 
 /**
  * Represents a permission system that uses a tree structure to organize groups and manage permissions.
@@ -146,45 +146,18 @@ export class PermissionSystem extends EventEmitter {
         let initialized = false;
         let updateQueue: any[] = [];
 
-        // Read group changes from the database change feed and update the permission system
+        // Read group changes from the database change feed and update the permission system.
+        // DbService resumes the feed from its last seq cursor on reconnect, so updates made
+        // while disconnected flow through here once we're back online — no snapshot refetch
+        // needed. The in-memory groupMap is intentionally kept intact across disconnects:
+        // clearing it would deny every request and cause clients syncing via this API to
+        // purge their local data.
         dbService.on("groupUpdate", async (update: DocType.Group) => {
             updateQueue.push(update);
             if (initialized) {
                 PermissionSystem.upsertGroups(updateQueue);
                 updateQueue = [];
             }
-        });
-
-        // Keep the in-memory groupMap on disconnect so the API can keep serving
-        // cached permissions while islanded from the database. If we cleared it,
-        // every request would be denied and clients syncing through this API
-        // would treat that as authoritative and purge their local data.
-        //
-        // We still flip `initialized` to false so that any change-feed events
-        // arriving during the reconnect window are queued rather than racing
-        // with the snapshot reconciliation below.
-        dbService.on("disconnect", () => {
-            initialized = false;
-            updateQueue = [];
-        });
-
-        // On reconnect, reconcile the in-memory state against a fresh snapshot
-        // rather than rebuilding from scratch: upsertGroup already diffs ACLs
-        // for existing groups, so we just need to additionally remove groups
-        // that were deleted from the DB while we were disconnected. This keeps
-        // the cache continuously valid and avoids the brief "no permissions"
-        // window a full rebuild would create.
-        dbService.on("reconnect", async () => {
-            const dbGroups = await dbService.getGroups();
-
-            const fetchedIds = new Set(dbGroups.docs.map((d: GroupDto) => d._id));
-            const staleIds = Object.keys(groupMap).filter((id) => !fetchedIds.has(id));
-            if (staleIds.length > 0) PermissionSystem.removeGroups(staleIds);
-
-            PermissionSystem.upsertGroups(dbGroups.docs);
-            PermissionSystem.upsertGroups(updateQueue);
-            updateQueue = [];
-            initialized = true;
         });
 
         // Add existing groups to permission system

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -153,6 +153,22 @@ export class PermissionSystem extends EventEmitter {
             }
         });
 
+        // Drop the groupMap on disconnect — the change feed resumes without
+        // replaying events missed during downtime, so we must rehydrate from
+        // scratch on reconnect rather than risk serving stale permissions.
+        dbService.on("disconnect", () => {
+            initialized = false;
+            updateQueue = [];
+            PermissionSystem.clearGroupMap();
+        });
+        dbService.on("reconnect", async () => {
+            const dbGroups = await dbService.getGroups();
+            PermissionSystem.upsertGroups(dbGroups.docs);
+            PermissionSystem.upsertGroups(updateQueue);
+            updateQueue = [];
+            initialized = true;
+        });
+
         // Add existing groups to permission system
         const dbGroups = await dbService.getGroups();
         this.upsertGroups(dbGroups.docs);
@@ -161,6 +177,17 @@ export class PermissionSystem extends EventEmitter {
         this.upsertGroups(updateQueue);
         updateQueue = [];
         initialized = true;
+    }
+
+    /**
+     * Remove every entry from the global groupMap.
+     * Note: groupMap is used via property-access (`groupMap[id]`) rather than
+     * the Map API, so we delete enumerable properties here.
+     */
+    private static clearGroupMap() {
+        for (const key of Object.keys(groupMap)) {
+            delete (groupMap as any)[key];
+        }
     }
 
     /**

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -100,9 +100,11 @@ type TargetRouteTypeMap = Map<
 export type AccessMap = Map<Uuid, Map<DocType, Map<AclPermission, boolean>>>;
 
 /**
- * Global Group Map used for permission lookups
+ * Global Group Map used for permission lookups.
+ * Accessed throughout this file via object-style property access, so it is
+ * typed as a Record rather than a Map.
  */
-const groupMap: Map<Uuid, PermissionSystem> = new Map<Uuid, PermissionSystem>();
+const groupMap: Record<Uuid, PermissionSystem> = {};
 
 /**
  * Represents a permission system that uses a tree structure to organize groups and manage permissions.

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -153,16 +153,32 @@ export class PermissionSystem extends EventEmitter {
             }
         });
 
-        // Drop the groupMap on disconnect — the change feed resumes without
-        // replaying events missed during downtime, so we must rehydrate from
-        // scratch on reconnect rather than risk serving stale permissions.
+        // Keep the in-memory groupMap on disconnect so the API can keep serving
+        // cached permissions while islanded from the database. If we cleared it,
+        // every request would be denied and clients syncing through this API
+        // would treat that as authoritative and purge their local data.
+        //
+        // We still flip `initialized` to false so that any change-feed events
+        // arriving during the reconnect window are queued rather than racing
+        // with the snapshot reconciliation below.
         dbService.on("disconnect", () => {
             initialized = false;
             updateQueue = [];
-            PermissionSystem.clearGroupMap();
         });
+
+        // On reconnect, reconcile the in-memory state against a fresh snapshot
+        // rather than rebuilding from scratch: upsertGroup already diffs ACLs
+        // for existing groups, so we just need to additionally remove groups
+        // that were deleted from the DB while we were disconnected. This keeps
+        // the cache continuously valid and avoids the brief "no permissions"
+        // window a full rebuild would create.
         dbService.on("reconnect", async () => {
             const dbGroups = await dbService.getGroups();
+
+            const fetchedIds = new Set(dbGroups.docs.map((d: GroupDto) => d._id));
+            const staleIds = Object.keys(groupMap).filter((id) => !fetchedIds.has(id));
+            if (staleIds.length > 0) PermissionSystem.removeGroups(staleIds);
+
             PermissionSystem.upsertGroups(dbGroups.docs);
             PermissionSystem.upsertGroups(updateQueue);
             updateQueue = [];
@@ -177,17 +193,6 @@ export class PermissionSystem extends EventEmitter {
         this.upsertGroups(updateQueue);
         updateQueue = [];
         initialized = true;
-    }
-
-    /**
-     * Remove every entry from the global groupMap.
-     * Note: groupMap is used via property-access (`groupMap[id]`) rather than
-     * the Map API, so we delete enumerable properties here.
-     */
-    private static clearGroupMap() {
-        for (const key of Object.keys(groupMap)) {
-            delete (groupMap as any)[key];
-        }
     }
 
     /**

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -179,7 +179,7 @@ export class PermissionSystem extends EventEmitter {
 
         if (groupIds) {
             groupIds.forEach((id: Uuid) => {
-                const g = groupMap.get(id);
+                const g = groupMap[id] as PermissionSystem;
                 if (!g) return;
 
                 // Add the access map of the group to the result map
@@ -269,7 +269,7 @@ export class PermissionSystem extends EventEmitter {
     ): Map<DocType, Uuid[]> {
         const resultMap = new Map<DocType, Uuid[]>();
         memberOfGroups.forEach((memberGroup: Uuid) => {
-            const g = groupMap.get(memberGroup);
+            const g: PermissionSystem = groupMap[memberGroup];
             if (!g) return;
             types.forEach((type: DocType) => {
                 if (
@@ -308,7 +308,7 @@ export class PermissionSystem extends EventEmitter {
         for (const memberGroup of memberOfGroups) {
             let memberGroupValidated = true;
             for (const targetGroup of targetGroups) {
-                const g = groupMap.get(memberGroup);
+                const g: PermissionSystem = groupMap[memberGroup];
                 if (
                     g &&
                     g._accessMap[targetGroup] &&
@@ -350,9 +350,8 @@ export class PermissionSystem extends EventEmitter {
     private static upsertGroup(doc: GroupDto, groupDocs: Array<GroupDto>): PermissionSystem {
         let g: PermissionSystem;
         // Check if group is already in group map
-        const existing = groupMap.get(doc._id);
-        if (existing) {
-            g = existing;
+        if (groupMap[doc._id]) {
+            g = groupMap[doc._id];
 
             // Existing groups: Remove ACL's not passed with updated group document
             Object.keys(g._aclMap).forEach((aclGroupId: Uuid) => {
@@ -369,11 +368,11 @@ export class PermissionSystem extends EventEmitter {
         } else {
             // Add new group
             g = new PermissionSystem(doc._id);
-            groupMap.set(doc._id, g);
+            groupMap[doc._id] = g;
         }
 
         doc.acl.forEach((aclEntry: GroupAclEntryDto) => {
-            let parent = groupMap.get(aclEntry.groupId);
+            let parent: PermissionSystem = groupMap[aclEntry.groupId];
 
             // Create parent group if not existing
             if (!parent) {
@@ -409,7 +408,7 @@ export class PermissionSystem extends EventEmitter {
     // Remove single group
     private static removeGroup(docId: Uuid) {
         // Find group in groupMap
-        const g = groupMap.get(docId);
+        const g: PermissionSystem = groupMap[docId];
         if (g) {
             // Remove all ACL's
             Object.values(g._aclMap).forEach((_acl: AclGroupMap) => {
@@ -420,7 +419,7 @@ export class PermissionSystem extends EventEmitter {
             });
 
             // Delete from groupMap
-            groupMap.delete(docId);
+            delete groupMap[docId];
         }
     }
 
@@ -779,6 +778,6 @@ export class PermissionSystem extends EventEmitter {
      * Check if a group exists in the permission system
      */
     static hasGroup(id: Uuid) {
-        return groupMap.has(id);
+        return groupMap[id] != undefined;
     }
 }

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -100,9 +100,7 @@ type TargetRouteTypeMap = Map<
 export type AccessMap = Map<Uuid, Map<DocType, Map<AclPermission, boolean>>>;
 
 /**
- * Global Group Map used for permission lookups.
- * Accessed throughout this file via object-style property access, so it is
- * typed as a Record rather than a Map.
+ * Global Group Map used for permission lookups
  */
 const groupMap: Map<Uuid, PermissionSystem> = new Map<Uuid, PermissionSystem>();
 
@@ -146,12 +144,6 @@ export class PermissionSystem extends EventEmitter {
         let initialized = false;
         let updateQueue: any[] = [];
 
-        // Read group changes from the database change feed and update the permission system.
-        // DbService resumes the feed from its last seq cursor on reconnect, so updates made
-        // while disconnected flow through here once we're back online — no snapshot refetch
-        // needed. The in-memory groupMap is intentionally kept intact across disconnects:
-        // clearing it would deny every request and cause clients syncing via this API to
-        // purge their local data.
         dbService.on("groupUpdate", async (update: DocType.Group) => {
             updateQueue.push(update);
             if (initialized) {
@@ -187,7 +179,7 @@ export class PermissionSystem extends EventEmitter {
 
         if (groupIds) {
             groupIds.forEach((id: Uuid) => {
-                const g = groupMap[id] as PermissionSystem;
+                const g = groupMap.get(id);
                 if (!g) return;
 
                 // Add the access map of the group to the result map
@@ -277,7 +269,7 @@ export class PermissionSystem extends EventEmitter {
     ): Map<DocType, Uuid[]> {
         const resultMap = new Map<DocType, Uuid[]>();
         memberOfGroups.forEach((memberGroup: Uuid) => {
-            const g: PermissionSystem = groupMap[memberGroup];
+            const g = groupMap.get(memberGroup);
             if (!g) return;
             types.forEach((type: DocType) => {
                 if (
@@ -316,7 +308,7 @@ export class PermissionSystem extends EventEmitter {
         for (const memberGroup of memberOfGroups) {
             let memberGroupValidated = true;
             for (const targetGroup of targetGroups) {
-                const g: PermissionSystem = groupMap[memberGroup];
+                const g = groupMap.get(memberGroup);
                 if (
                     g &&
                     g._accessMap[targetGroup] &&
@@ -358,8 +350,9 @@ export class PermissionSystem extends EventEmitter {
     private static upsertGroup(doc: GroupDto, groupDocs: Array<GroupDto>): PermissionSystem {
         let g: PermissionSystem;
         // Check if group is already in group map
-        if (groupMap[doc._id]) {
-            g = groupMap[doc._id];
+        const existing = groupMap.get(doc._id);
+        if (existing) {
+            g = existing;
 
             // Existing groups: Remove ACL's not passed with updated group document
             Object.keys(g._aclMap).forEach((aclGroupId: Uuid) => {
@@ -376,11 +369,11 @@ export class PermissionSystem extends EventEmitter {
         } else {
             // Add new group
             g = new PermissionSystem(doc._id);
-            groupMap[doc._id] = g;
+            groupMap.set(doc._id, g);
         }
 
         doc.acl.forEach((aclEntry: GroupAclEntryDto) => {
-            let parent: PermissionSystem = groupMap[aclEntry.groupId];
+            let parent = groupMap.get(aclEntry.groupId);
 
             // Create parent group if not existing
             if (!parent) {
@@ -416,7 +409,7 @@ export class PermissionSystem extends EventEmitter {
     // Remove single group
     private static removeGroup(docId: Uuid) {
         // Find group in groupMap
-        const g: PermissionSystem = groupMap[docId];
+        const g = groupMap.get(docId);
         if (g) {
             // Remove all ACL's
             Object.values(g._aclMap).forEach((_acl: AclGroupMap) => {
@@ -427,7 +420,7 @@ export class PermissionSystem extends EventEmitter {
             });
 
             // Delete from groupMap
-            delete groupMap[docId];
+            groupMap.delete(docId);
         }
     }
 
@@ -786,6 +779,6 @@ export class PermissionSystem extends EventEmitter {
      * Check if a group exists in the permission system
      */
     static hasGroup(id: Uuid) {
-        return groupMap[id] != undefined;
+        return groupMap.has(id);
     }
 }

--- a/api/src/s3/s3.service.spec.ts
+++ b/api/src/s3/s3.service.spec.ts
@@ -597,4 +597,46 @@ describe("S3Service", () => {
             S3Service.clearCache(activeTestBucketId);
         });
     });
+
+    describe("DB disconnect handling", () => {
+        it("clears the singleton cache on 'disconnect' and lazily repopulates on next create()", async () => {
+            // Idempotent — no-op if already wired by an earlier test in this file.
+            S3Service.initializeChangeListener(dbService);
+
+            // Seed the cache via the normal create() path so both the instance
+            // and the credential/access maps are populated.
+            const disconnectBucketName = "disconnect-test-bucket-" + UUID();
+            const credId = await storeCryptoData(dbService, {
+                endpoint: s3BaseUrl,
+                bucketName: disconnectBucketName,
+                accessKey: s3AccessKey,
+                secretKey: s3SecretKey,
+            });
+            const disconnectBucketId = "disconnect-test-bucket-doc-" + UUID();
+            await dbService.upsertDoc({
+                _id: disconnectBucketId,
+                type: "storage",
+                name: "Disconnect Test Bucket",
+                mimeTypes: ["image/*"],
+                publicUrl: `${s3PublicUrl}/disconnect-test-bucket`,
+                StorageType: "s3",
+                credential_id: credId,
+                memberOf: [],
+            });
+            const original = await S3Service.create(disconnectBucketId, dbService);
+            expect(S3Service.hasInstance(disconnectBucketId)).toBe(true);
+
+            dbService.emit("disconnect");
+
+            expect(S3Service.hasInstance(disconnectBucketId)).toBe(false);
+
+            // Next create() should build a fresh instance (not reuse the cleared one)
+            // and the cache should be repopulated.
+            const rebuilt = await S3Service.create(disconnectBucketId, dbService);
+            expect(S3Service.hasInstance(disconnectBucketId)).toBe(true);
+            expect(rebuilt).not.toBe(original);
+
+            S3Service.clearCache(disconnectBucketId);
+        });
+    });
 });

--- a/api/src/s3/s3.service.ts
+++ b/api/src/s3/s3.service.ts
@@ -70,6 +70,13 @@ export class S3Service {
             return; // Already initialized
         }
 
+        // Wipe the whole singleton cache on DB disconnect — credentials may
+        // rotate while the change feed is down, and we'd otherwise keep
+        // handing out Minio clients bound to stale keys.
+        db.on("disconnect", () => {
+            S3Service.clearCache();
+        });
+
         S3Service.dbChangeListener = async (doc: any) => {
             // Handle credential updates
             if (doc && doc.type == DocType.Crypto && doc._id && doc.data && doc.data) {


### PR DESCRIPTION
DbService now emits `disconnect` when the changes feed drops after a successful connect, and `reconnect` once the DB is reachable again. Services that hold in-memory DTO caches listen for these events:

- AuthIdentityService drops providerCache, autoGroupMappingsCache, defaultGroupsCache and jwksClients (all lazy — repopulate on next access).
- QueryService empties its languages cache on disconnect and re-fetches on reconnect.
- PermissionSystem clears the module-level groupMap on disconnect and re-hydrates from getGroups() on reconnect. The resumed changes feed does not replay events missed during downtime, so a full rebuild is needed to avoid serving stale permissions.
- S3Service.initializeChangeListener now also calls clearCache() on disconnect, and is finally wired into main.ts (it was previously only called from tests).

Tests added for the disconnect/reconnect contract on DbService and for each affected service, including lazy repopulation of AuthIdentityService and S3Service caches after a clear.