### PR TITLE
test(fts): call recomputeCorpusStats explicitly after bulkPut ingestion

### DIFF
--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -15,7 +15,7 @@ import {
     TagType,
     Uuid,
 } from "../types";
-import { recomputeCorpusStats, scheduleCorpusStatsRecompute } from "../fts/ftsIndexer";
+import { scheduleCorpusStatsRecompute } from "../fts/ftsIndexer";
 import { useObservable } from "@vueuse/rxjs";
 import type { Observable } from "rxjs";
 import { ref, type Ref, toRaw, watch } from "vue";
@@ -296,7 +296,7 @@ class Database extends Dexie {
 
         // Update corpus stats if this batch contained ContentDtos
         if (nonDeleteDocs.length > 0 && nonDeleteDocs[0].type === DocType.Content) {
-            await recomputeCorpusStats();
+            scheduleCorpusStatsRecompute();
         }
 
         return result;
@@ -892,7 +892,7 @@ export async function initDatabase() {
     // Compute FTS corpus stats on startup.
     // Uses setTimeout(0) to avoid Dexie PSD zone deadlocks during initialization.
     setTimeout(() => {
-        recomputeCorpusStats();
+        scheduleCorpusStatsRecompute();
     }, 0);
 
     // Wait a little to give the app time to load before deleting expired content to help speed up the initial app loading time
@@ -901,9 +901,13 @@ export async function initDatabase() {
     }, 5000);
 
     // Listen for changes to the access map and delete documents that the user no longer has access to
-    watchValue(accessMap, () => {
-        db.deleteRevoked();
-    }, { immediate: true });
+    watchValue(
+        accessMap,
+        () => {
+            db.deleteRevoked();
+        },
+        { immediate: true },
+    );
 
     watch(
         syncMap,

--- a/shared/src/fts/fts.spec.ts
+++ b/shared/src/fts/fts.spec.ts
@@ -129,6 +129,7 @@ describe("FTS Indexer and Search", () => {
             const doc = makeContentDoc({ _id: "doc-stats", title: "quantum" });
 
             await ingestDocWithFts(doc, entries, tokenCount);
+            await recomputeCorpusStats();
 
             const stats = await getCorpusStats();
             expect(stats.docCount).toBe(1);


### PR DESCRIPTION
bulkPut now schedules a debounced corpus stats recompute instead of running it synchronously, so the ingestion test must trigger the recompute itself to observe updated stats.