### PR TITLE
fix: LCombobox inline tag removal and auto-group mapping discard - 1555

### DIFF
--- a/cms/src/components/autoGroupMappings/CreateOrEditAutoGroupMappingModal.vue
+++ b/cms/src/components/autoGroupMappings/CreateOrEditAutoGroupMappingModal.vue
@@ -64,13 +64,16 @@ watch(
     () => props.mapping,
     (existing) => {
         if (existing) {
-            const clone: AutoGroupMappingsDto = {
-                ..._.cloneDeep(existing),
-                providerId: existing.providerId ?? "",
-                groupIds: existing.groupIds ?? [],
-                conditions: existing.conditions ?? [],
+            // Deep-clone up front and read defaults off the clone so editable
+            // never shares array refs with props.mapping (otherwise edits would
+            // mutate the parent mapping and survive a discard).
+            const cloned = _.cloneDeep(existing) as AutoGroupMappingsDto;
+            editable.value = {
+                ...cloned,
+                providerId: cloned.providerId ?? "",
+                groupIds: cloned.groupIds ?? [],
+                conditions: cloned.conditions ?? [],
             };
-            editable.value = clone;
         } else {
             editable.value = {
                 _id: db.uuid(),
@@ -193,11 +196,12 @@ function discardAndClose() {
 
 function revert() {
     if (props.mapping) {
+        const cloned = _.cloneDeep(props.mapping) as AutoGroupMappingsDto;
         editable.value = {
-            ..._.cloneDeep(props.mapping),
-            providerId: props.mapping.providerId ?? "",
-            groupIds: props.mapping.groupIds ?? [],
-            conditions: props.mapping.conditions ?? [],
+            ...cloned,
+            providerId: cloned.providerId ?? "",
+            groupIds: cloned.groupIds ?? [],
+            conditions: cloned.conditions ?? [],
         };
     }
     hasAttemptedSave.value = false;

--- a/cms/src/components/common/LDropdown.vue
+++ b/cms/src/components/common/LDropdown.vue
@@ -183,7 +183,7 @@ const paddingClass = computed(() =>
             :aria-expanded="show ? 'true' : 'false'"
             :aria-controls="show ? panelId : undefined"
             data-dropdown-trigger
-            @click.capture.stop="onTriggerClick"
+            @click.stop="onTriggerClick"
             @keydown.enter.prevent.stop="toggle()"
             @keydown.space.prevent.stop="toggle()"
         >

--- a/cms/src/components/content/LTag.vue
+++ b/cms/src/components/content/LTag.vue
@@ -34,7 +34,7 @@ const emit = defineEmits(["remove"]);
         </div>
         <div class="flex items-center gap-2">
             <slot />
-            <button @click="emit('remove')" data-test="removeTag" v-if="!disabled" type="button">
+            <button @click.stop="emit('remove')" data-test="removeTag" v-if="!disabled" type="button">
                 <XMarkIcon class="h-4 w-4 text-zinc-400 hover:text-zinc-800" title="Remove tag" />
             </button>
         </div>


### PR DESCRIPTION
- LDropdown trigger used @click.capture.stop which swallowed clicks to nested interactive elements (e.g. LTag X button). Switched to @click.stop and added .stop on LTag's remove button.
- CreateOrEditAutoGroupMappingModal cloned props.mapping via spread but overrode groupIds/conditions with the original reactive arrays, so edits mutated the parent mapping and survived discard. Now reads defaults off the deep-cloned value in both the watcher and revert().