### PR TITLE
Refactor: Update heroicons imports and usage to outline

### DIFF
--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -35,11 +35,8 @@ import * as _ from "lodash";
 import router from "@/router";
 import { capitaliseFirstLetter } from "@/util/string";
 import { sortByName } from "@/util/sortByName";
-import {
-    ArrowTopRightOnSquareIcon,
-    DocumentDuplicateIcon,
-    PlusIcon,
-} from "@heroicons/vue/20/solid";
+import { ArrowTopRightOnSquareIcon, PlusIcon } from "@heroicons/vue/20/solid";
+import { Square2StackIcon, DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import { clientAppUrl } from "@/globalConfig";
 import { cmsLanguages, translatableLanguagesAsRef } from "@/globalConfig";
 import EditContentImage from "./EditContentImage.vue";
@@ -715,7 +712,7 @@ const onSelectorHeightUpdate = (val: number) => {
             </div>
             <!-- main content instance -->
             <div
-                class="mt-2 min-h-0 w-full scrollbar-hide lg:mt-0 lg:static lg:flex-1 lg:overflow-y-auto"
+                class="mt-2 min-h-0 w-full scrollbar-hide lg:static lg:mt-0 lg:flex-1 lg:overflow-y-auto"
                 :class="isLanguageSelectorCollapsed ? 'sticky z-[5]' : 'overflow-y-auto'"
                 :style="mainContentStickyStyle"
             >

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -36,7 +36,7 @@ import router from "@/router";
 import { capitaliseFirstLetter } from "@/util/string";
 import { sortByName } from "@/util/sortByName";
 import { ArrowTopRightOnSquareIcon, PlusIcon } from "@heroicons/vue/20/solid";
-import { Square2StackIcon, DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
+import { DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import { clientAppUrl } from "@/globalConfig";
 import { cmsLanguages, translatableLanguagesAsRef } from "@/globalConfig";
 import EditContentImage from "./EditContentImage.vue";

--- a/cms/src/components/groups/DuplicateGroupAclButton.vue
+++ b/cms/src/components/groups/DuplicateGroupAclButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { GroupDto } from "luminary-shared";
-import { DocumentDuplicateIcon } from "@heroicons/vue/20/solid";
+import { DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import { toRaw, toRefs, ref } from "vue";
 import LButton from "../button/LButton.vue";
 import LDropdown from "../common/LDropdown.vue";

--- a/cms/src/components/groups/EditGroup.vue
+++ b/cms/src/components/groups/EditGroup.vue
@@ -20,7 +20,7 @@ import { useNotificationStore } from "@/stores/notification";
 import LBadge from "@/components/common/LBadge.vue";
 import AddGroupAclButton from "./AddGroupAclButton.vue";
 import LInput from "../forms/LInput.vue";
-import { DocumentDuplicateIcon } from "@heroicons/vue/20/solid";
+import { Square2StackIcon, DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import LDialog from "../common/LDialog.vue";
 import { ArrowUturnLeftIcon } from "@heroicons/vue/24/solid";
 

--- a/cms/src/components/groups/EditGroup.vue
+++ b/cms/src/components/groups/EditGroup.vue
@@ -20,7 +20,7 @@ import { useNotificationStore } from "@/stores/notification";
 import LBadge from "@/components/common/LBadge.vue";
 import AddGroupAclButton from "./AddGroupAclButton.vue";
 import LInput from "../forms/LInput.vue";
-import { Square2StackIcon, DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
+import { DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import LDialog from "../common/LDialog.vue";
 import { ArrowUturnLeftIcon } from "@heroicons/vue/24/solid";
 

--- a/cms/src/components/redirects/CreateOrEditRedirectModal.vue
+++ b/cms/src/components/redirects/CreateOrEditRedirectModal.vue
@@ -22,7 +22,7 @@ import {
 } from "@heroicons/vue/20/solid";
 import { useNotificationStore } from "@/stores/notification";
 import { Slug } from "@/util/slug";
-import { TrashIcon } from "@heroicons/vue/24/solid";
+import { TrashIcon } from "@heroicons/vue/24/outline";
 import LDialog from "../common/LDialog.vue";
 import LCombobox from "../forms/LCombobox.vue";
 


### PR DESCRIPTION
Change `DocumentDuplicateIcon` to use `vue/24/outline` and import `Square2StackIcon` for duplication functionality. This aligns icon styles across the application.

_**I was wrong regarding the outlined document duplicate icon creating visual issues.**_ Tested across the cms and it looks fine now. Do not know why it suddenly works tho but yay ig 😅