### PR TITLE
Fix: Improve token refresh cache handling

### DIFF
--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -2,6 +2,7 @@ import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
 import type { App } from "vue";
+import type { Router } from "vue-router";
 
 // Hoisted spies the mocked createAuth0 closes over. We assert against these to
 // verify what refreshTokenSilently passes to the Auth0 SDK.

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -1,6 +1,22 @@
 import "fake-indexeddb/auto";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { db, DocType, type AuthProviderDto } from "luminary-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
+import type { App } from "vue";
+import type { Router } from "vue-router";
+
+// Hoisted spies the mocked createAuth0 closes over. We assert against these to
+// verify what refreshTokenSilently passes to the Auth0 SDK.
+const { mockGetAccessTokenSilently, mockHandleRedirectCallback, mockCreateAuth0 } = vi.hoisted(
+    () => ({
+        mockGetAccessTokenSilently: vi.fn(),
+        mockHandleRedirectCallback: vi.fn(),
+        mockCreateAuth0: vi.fn(),
+    }),
+);
+
+vi.mock("@auth0/auth0-vue", () => ({
+    createAuth0: mockCreateAuth0,
+}));
 
 import {
     activeProviderId,
@@ -8,6 +24,7 @@ import {
     openProviderModal,
     refreshTokenSilently,
     resolveActiveProvider,
+    setupAuth,
     showProviderSelectionModal,
 } from "./auth";
 
@@ -181,6 +198,138 @@ describe("auth", () => {
             // oauth handle. The socket connect_error handler relies on this
             // being a safe `false` rather than a throw.
             expect(await refreshTokenSilently()).toBe(false);
+        });
+    });
+
+    // Regression coverage for issue #1581 — "App: token not being refreshed
+    // after expiration". The bug: refreshTokenSilently called
+    // getAccessTokenSilently() with the SDK default `cacheMode: "on"`, so when
+    // the server fires connect_error: auth_failed the SDK happily returned the
+    // SAME server-rejected access token (any token still inside the SDK's 60s
+    // leeway looks valid to the cache check). The connect_error handler would
+    // loop with an unrejectable token and fall through to a visible re-login.
+    // Fix: connect_error handlers now pass `{ ignoreCache: true }`, which
+    // forwards `cacheMode: "off"` to the SDK so it must hit /oauth/token via
+    // the refresh token. These tests pin that contract in place.
+    describe("refreshTokenSilently — cache control (issue #1581 regression)", () => {
+        const appStub = { use: () => {} } as unknown as App<Element>;
+        const routerStub = { replace: () => Promise.resolve(undefined) } as unknown as Router;
+
+        beforeEach(async () => {
+            mockGetAccessTokenSilently.mockReset();
+            mockHandleRedirectCallback.mockReset();
+            mockCreateAuth0.mockReset();
+            mockCreateAuth0.mockImplementation(() => ({
+                getAccessTokenSilently: mockGetAccessTokenSilently,
+                handleRedirectCallback: mockHandleRedirectCallback,
+                install: () => {},
+            }));
+
+            // resolveActiveProvider needs both the Dexie doc AND a localStorage
+            // cache key whose clientId segment matches.
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            // setupAuth's trailing refreshTokenSilently() consumes one resolution
+            // before the actual test runs. Resolve it, then reset call history.
+            mockGetAccessTokenSilently.mockResolvedValueOnce("boot-token");
+            await setupAuth(appStub, routerStub);
+            mockGetAccessTokenSilently.mockClear();
+        });
+
+        afterEach(() => {
+            // The real Authorization header is set by refreshTokenSilently on
+            // success — don't leak it into other tests.
+            setCustomHeader("Authorization", "");
+        });
+
+        it("forwards cacheMode 'off' to getAccessTokenSilently when ignoreCache is true (regression: post-rejection refresh must skip the SDK cache)", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("fresh-token");
+
+            const ok = await refreshTokenSilently({ ignoreCache: true });
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(1);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith({ cacheMode: "off" });
+        });
+
+        it("calls getAccessTokenSilently without options when ignoreCache is omitted (boot path keeps SDK cache enabled)", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("cached-token");
+
+            const ok = await refreshTokenSilently();
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(1);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith(undefined);
+        });
+
+        it("calls getAccessTokenSilently without options when ignoreCache is explicitly false", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("cached-token");
+
+            const ok = await refreshTokenSilently({ ignoreCache: false });
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith(undefined);
+        });
+
+        it("regression: returns the FRESH token when Auth0 cache would replay the rejected one", async () => {
+            // Simulates the production bug shape: the cache holds a token the
+            // server has already rejected. A cacheMode='off' call must bypass
+            // it; otherwise we'd loop on connect_error forever.
+            const REJECTED = "expired-token-server-rejected";
+            const FRESH = "fresh-token-from-refresh";
+            mockGetAccessTokenSilently.mockImplementation(
+                async (opts?: { cacheMode?: string }) =>
+                    opts?.cacheMode === "off" ? FRESH : REJECTED,
+            );
+
+            await refreshTokenSilently({ ignoreCache: true });
+
+            // We can't read the in-memory custom-headers map from outside
+            // luminary-shared, so assert via the spy: the SDK was asked for a
+            // fresh token, not a cached one.
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith({ cacheMode: "off" });
+            const returnedTokens = await Promise.all(
+                mockGetAccessTokenSilently.mock.results.map((r) => r.value),
+            );
+            expect(returnedTokens).toEqual([FRESH]);
+        });
+
+        it("returns false when getAccessTokenSilently rejects (e.g. invalid_grant) and does not throw", async () => {
+            // Mirrors what happens when the refresh token itself is dead. The
+            // connect_error handler treats `false` as a signal to show a
+            // visible re-login.
+            mockGetAccessTokenSilently.mockRejectedValueOnce(
+                new Error("invalid refresh token"),
+            );
+
+            await expect(refreshTokenSilently({ ignoreCache: true })).resolves.toBe(false);
+        });
+
+        it("returns false when getAccessTokenSilently resolves to an empty token", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("");
+
+            const ok = await refreshTokenSilently({ ignoreCache: true });
+
+            expect(ok).toBe(false);
+        });
+
+        it("each call asks the SDK independently — back-to-back retries from connect_error must each hit /oauth/token", async () => {
+            // If the SDK is retried (e.g., another connect_error fires), we
+            // must not collapse the second call into the first via stale cache.
+            mockGetAccessTokenSilently
+                .mockResolvedValueOnce("first-fresh")
+                .mockResolvedValueOnce("second-fresh");
+
+            await refreshTokenSilently({ ignoreCache: true });
+            await refreshTokenSilently({ ignoreCache: true });
+
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(2);
+            expect(mockGetAccessTokenSilently.mock.calls[0]).toEqual([{ cacheMode: "off" }]);
+            expect(mockGetAccessTokenSilently.mock.calls[1]).toEqual([{ cacheMode: "off" }]);
         });
     });
 });

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -2,7 +2,6 @@ import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
 import type { App } from "vue";
-import type { Router } from "vue-router";
 
 // Hoisted spies the mocked createAuth0 closes over. We assert against these to
 // verify what refreshTokenSilently passes to the Auth0 SDK.
@@ -281,9 +280,8 @@ describe("auth", () => {
             // it; otherwise we'd loop on connect_error forever.
             const REJECTED = "expired-token-server-rejected";
             const FRESH = "fresh-token-from-refresh";
-            mockGetAccessTokenSilently.mockImplementation(
-                async (opts?: { cacheMode?: string }) =>
-                    opts?.cacheMode === "off" ? FRESH : REJECTED,
+            mockGetAccessTokenSilently.mockImplementation(async (opts?: { cacheMode?: string }) =>
+                opts?.cacheMode === "off" ? FRESH : REJECTED,
             );
 
             await refreshTokenSilently({ ignoreCache: true });
@@ -302,9 +300,7 @@ describe("auth", () => {
             // Mirrors what happens when the refresh token itself is dead. The
             // connect_error handler treats `false` as a signal to show a
             // visible re-login.
-            mockGetAccessTokenSilently.mockRejectedValueOnce(
-                new Error("invalid refresh token"),
-            );
+            mockGetAccessTokenSilently.mockRejectedValueOnce(new Error("invalid refresh token"));
 
             await expect(refreshTokenSilently({ ignoreCache: true })).resolves.toBe(false);
         });

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -140,18 +140,18 @@ export async function setupAuth(app: App<Element>, router: Router): Promise<void
 
 /**
  * Ask Auth0 for a fresh access token via the refresh token, then push it to
- * the Authorization header and the socket. Returns true on success. Call from
- * the socket's connect_error handler before falling back to a visible
- * re-login — this is what `useRefreshTokens: true` is for.
+ * the Authorization header and the socket. Call from the socket's
+ * `connect_error` handler before falling back to a visible re-login — this is
+ * what `useRefreshTokens: true` is for.
  *
- * Pass `ignoreCache: true` after the server has rejected a token. Otherwise
- * Auth0's default `cacheMode: "on"` can hand back the same cached
- * still-client-valid token (60s leeway) that the server just rejected, so
- * we'd loop forever on any clock skew or server-side revocation.
+ * @param opts - Options for the refresh.
+ * @param opts.ignoreCache - Pass `true` after the server has rejected a token.
+ *   Otherwise Auth0's default `cacheMode: "on"` can hand back the same cached
+ *   still-client-valid token (60s leeway) that the server just rejected, so
+ *   we'd loop forever on any clock skew or server-side revocation.
+ * @returns `true` on success, `false` otherwise.
  */
-export async function refreshTokenSilently(opts?: {
-    ignoreCache?: boolean;
-}): Promise<boolean> {
+export async function refreshTokenSilently(opts?: { ignoreCache?: boolean }): Promise<boolean> {
     if (!installedOauth) return false;
     try {
         const token = await installedOauth.getAccessTokenSilently(

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -143,11 +143,20 @@ export async function setupAuth(app: App<Element>, router: Router): Promise<void
  * the Authorization header and the socket. Returns true on success. Call from
  * the socket's connect_error handler before falling back to a visible
  * re-login — this is what `useRefreshTokens: true` is for.
+ *
+ * Pass `ignoreCache: true` after the server has rejected a token. Otherwise
+ * Auth0's default `cacheMode: "on"` can hand back the same cached
+ * still-client-valid token (60s leeway) that the server just rejected, so
+ * we'd loop forever on any clock skew or server-side revocation.
  */
-export async function refreshTokenSilently(): Promise<boolean> {
+export async function refreshTokenSilently(opts?: {
+    ignoreCache?: boolean;
+}): Promise<boolean> {
     if (!installedOauth) return false;
     try {
-        const token = await installedOauth.getAccessTokenSilently();
+        const token = await installedOauth.getAccessTokenSilently(
+            opts?.ignoreCache ? { cacheMode: "off" } : undefined,
+        );
         if (!token) return false;
         setCustomHeader("Authorization", `Bearer ${token}`);
         getSocket().setAuth(token, activeProviderId.value);

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -93,8 +93,10 @@ async function Startup() {
             }
 
             // Normal case: the access token expired. Ask the Auth0 SDK for a
-            // fresh one via the refresh token — no redirect needed.
-            if (await refreshTokenSilently()) return;
+            // fresh one via the refresh token — no redirect needed. Bypass
+            // the SDK's token cache: the server already rejected what we had,
+            // so the cached copy is useless and we must hit /oauth/token.
+            if (await refreshTokenSilently({ ignoreCache: true })) return;
 
             // The refresh token itself is gone or rejected — need a visible
             // re-login.

--- a/cms/src/auth.spec.ts
+++ b/cms/src/auth.spec.ts
@@ -2,7 +2,6 @@ import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
 import type { App } from "vue";
-import type { Router } from "vue-router";
 
 const { mockGetAccessTokenSilently, mockHandleRedirectCallback, mockCreateAuth0 } = vi.hoisted(
     () => ({
@@ -271,9 +270,8 @@ describe("auth", () => {
             // it; otherwise we'd loop on connect_error forever.
             const REJECTED = "expired-token-server-rejected";
             const FRESH = "fresh-token-from-refresh";
-            mockGetAccessTokenSilently.mockImplementation(
-                async (opts?: { cacheMode?: string }) =>
-                    opts?.cacheMode === "off" ? FRESH : REJECTED,
+            mockGetAccessTokenSilently.mockImplementation(async (opts?: { cacheMode?: string }) =>
+                opts?.cacheMode === "off" ? FRESH : REJECTED,
             );
 
             await refreshTokenSilently({ ignoreCache: true });
@@ -286,9 +284,7 @@ describe("auth", () => {
         });
 
         it("returns false when getAccessTokenSilently rejects (e.g. invalid_grant) and does not throw", async () => {
-            mockGetAccessTokenSilently.mockRejectedValueOnce(
-                new Error("invalid refresh token"),
-            );
+            mockGetAccessTokenSilently.mockRejectedValueOnce(new Error("invalid refresh token"));
 
             await expect(refreshTokenSilently({ ignoreCache: true })).resolves.toBe(false);
         });

--- a/cms/src/auth.spec.ts
+++ b/cms/src/auth.spec.ts
@@ -1,6 +1,20 @@
 import "fake-indexeddb/auto";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { db, DocType, type AuthProviderDto } from "luminary-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
+import type { App } from "vue";
+import type { Router } from "vue-router";
+
+const { mockGetAccessTokenSilently, mockHandleRedirectCallback, mockCreateAuth0 } = vi.hoisted(
+    () => ({
+        mockGetAccessTokenSilently: vi.fn(),
+        mockHandleRedirectCallback: vi.fn(),
+        mockCreateAuth0: vi.fn(),
+    }),
+);
+
+vi.mock("@auth0/auth0-vue", () => ({
+    createAuth0: mockCreateAuth0,
+}));
 
 import {
     activeProviderId,
@@ -8,6 +22,7 @@ import {
     openProviderModal,
     refreshTokenSilently,
     resolveActiveProvider,
+    setupAuth,
     showProviderSelectionModal,
 } from "./auth";
 
@@ -172,6 +187,131 @@ describe("auth", () => {
             // oauth handle. The socket connect_error handler relies on this
             // being a safe `false` rather than a throw.
             expect(await refreshTokenSilently()).toBe(false);
+        });
+    });
+
+    // Regression coverage for issue #1581 — "App: token not being refreshed
+    // after expiration". The bug: refreshTokenSilently called
+    // getAccessTokenSilently() with the SDK default `cacheMode: "on"`, so when
+    // the server fires connect_error: auth_failed the SDK happily returned the
+    // SAME server-rejected access token (any token still inside the SDK's 60s
+    // leeway looks valid to the cache check). The connect_error handler would
+    // loop with an unrejectable token and fall through to a visible re-login.
+    // Fix: connect_error handlers now pass `{ ignoreCache: true }`, which
+    // forwards `cacheMode: "off"` to the SDK so it must hit /oauth/token via
+    // the refresh token. These tests pin that contract in place.
+    describe("refreshTokenSilently — cache control (issue #1581 regression)", () => {
+        const appStub = { use: () => {} } as unknown as App<Element>;
+
+        beforeEach(async () => {
+            mockGetAccessTokenSilently.mockReset();
+            mockHandleRedirectCallback.mockReset();
+            mockCreateAuth0.mockReset();
+            mockCreateAuth0.mockImplementation(() => ({
+                getAccessTokenSilently: mockGetAccessTokenSilently,
+                handleRedirectCallback: mockHandleRedirectCallback,
+                install: () => {},
+            }));
+
+            // resolveActiveProvider needs both the Dexie doc AND a localStorage
+            // cache key whose clientId segment matches.
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            // setupAuth's trailing refreshTokenSilently() consumes one resolution
+            // before the actual test runs. Resolve it, then reset call history
+            // and the side-effects (CMS opens the provider modal on failure).
+            mockGetAccessTokenSilently.mockResolvedValueOnce("boot-token");
+            await setupAuth(appStub);
+            mockGetAccessTokenSilently.mockClear();
+            showProviderSelectionModal.value = false;
+        });
+
+        afterEach(() => {
+            // The real Authorization header is set by refreshTokenSilently on
+            // success — don't leak it into other tests.
+            setCustomHeader("Authorization", "");
+        });
+
+        it("forwards cacheMode 'off' to getAccessTokenSilently when ignoreCache is true (regression: post-rejection refresh must skip the SDK cache)", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("fresh-token");
+
+            const ok = await refreshTokenSilently({ ignoreCache: true });
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(1);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith({ cacheMode: "off" });
+        });
+
+        it("calls getAccessTokenSilently without options when ignoreCache is omitted (boot path keeps SDK cache enabled)", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("cached-token");
+
+            const ok = await refreshTokenSilently();
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(1);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith(undefined);
+        });
+
+        it("calls getAccessTokenSilently without options when ignoreCache is explicitly false", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("cached-token");
+
+            const ok = await refreshTokenSilently({ ignoreCache: false });
+
+            expect(ok).toBe(true);
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith(undefined);
+        });
+
+        it("regression: returns the FRESH token when Auth0 cache would replay the rejected one", async () => {
+            // Simulates the production bug shape: the cache holds a token the
+            // server has already rejected. A cacheMode='off' call must bypass
+            // it; otherwise we'd loop on connect_error forever.
+            const REJECTED = "expired-token-server-rejected";
+            const FRESH = "fresh-token-from-refresh";
+            mockGetAccessTokenSilently.mockImplementation(
+                async (opts?: { cacheMode?: string }) =>
+                    opts?.cacheMode === "off" ? FRESH : REJECTED,
+            );
+
+            await refreshTokenSilently({ ignoreCache: true });
+
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledWith({ cacheMode: "off" });
+            const returnedTokens = await Promise.all(
+                mockGetAccessTokenSilently.mock.results.map((r) => r.value),
+            );
+            expect(returnedTokens).toEqual([FRESH]);
+        });
+
+        it("returns false when getAccessTokenSilently rejects (e.g. invalid_grant) and does not throw", async () => {
+            mockGetAccessTokenSilently.mockRejectedValueOnce(
+                new Error("invalid refresh token"),
+            );
+
+            await expect(refreshTokenSilently({ ignoreCache: true })).resolves.toBe(false);
+        });
+
+        it("returns false when getAccessTokenSilently resolves to an empty token", async () => {
+            mockGetAccessTokenSilently.mockResolvedValueOnce("");
+
+            const ok = await refreshTokenSilently({ ignoreCache: true });
+
+            expect(ok).toBe(false);
+        });
+
+        it("each call asks the SDK independently — back-to-back retries from connect_error must each hit /oauth/token", async () => {
+            mockGetAccessTokenSilently
+                .mockResolvedValueOnce("first-fresh")
+                .mockResolvedValueOnce("second-fresh");
+
+            await refreshTokenSilently({ ignoreCache: true });
+            await refreshTokenSilently({ ignoreCache: true });
+
+            expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(2);
+            expect(mockGetAccessTokenSilently.mock.calls[0]).toEqual([{ cacheMode: "off" }]);
+            expect(mockGetAccessTokenSilently.mock.calls[1]).toEqual([{ cacheMode: "off" }]);
         });
     });
 });

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -156,14 +156,16 @@ export async function setupAuth(app: App<Element>): Promise<void> {
 
 /**
  * Ask Auth0 for a fresh access token via the refresh token, then push it to
- * the Authorization header and the socket. Returns true on success. Call from
- * the socket's connect_error handler before falling back to a visible
- * re-login — this is what `useRefreshTokens: true` is for.
+ * the Authorization header and the socket. Call from the socket's
+ * `connect_error` handler before falling back to a visible re-login — this is
+ * what `useRefreshTokens: true` is for.
  *
- * Pass `ignoreCache: true` after the server has rejected a token. Otherwise
- * Auth0's default `cacheMode: "on"` can hand back the same cached
- * still-client-valid token (60s leeway) that the server just rejected, so
- * we'd loop forever on any clock skew or server-side revocation.
+ * @param opts - Options for the refresh.
+ * @param opts.ignoreCache - Pass `true` after the server has rejected a token.
+ *   Otherwise Auth0's default `cacheMode: "on"` can hand back the same cached
+ *   still-client-valid token (60s leeway) that the server just rejected, so
+ *   we'd loop forever on any clock skew or server-side revocation.
+ * @returns `true` on success, `false` otherwise.
  */
 export async function refreshTokenSilently(opts?: {
     ignoreCache?: boolean;

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -159,11 +159,20 @@ export async function setupAuth(app: App<Element>): Promise<void> {
  * the Authorization header and the socket. Returns true on success. Call from
  * the socket's connect_error handler before falling back to a visible
  * re-login — this is what `useRefreshTokens: true` is for.
+ *
+ * Pass `ignoreCache: true` after the server has rejected a token. Otherwise
+ * Auth0's default `cacheMode: "on"` can hand back the same cached
+ * still-client-valid token (60s leeway) that the server just rejected, so
+ * we'd loop forever on any clock skew or server-side revocation.
  */
-export async function refreshTokenSilently(): Promise<boolean> {
+export async function refreshTokenSilently(opts?: {
+    ignoreCache?: boolean;
+}): Promise<boolean> {
     if (!installedOauth) return false;
     try {
-        const token = await installedOauth.getAccessTokenSilently();
+        const token = await installedOauth.getAccessTokenSilently(
+            opts?.ignoreCache ? { cacheMode: "off" } : undefined,
+        );
         if (!token) return false;
         setCustomHeader("Authorization", `Bearer ${token}`);
         getSocket().setAuth(token, activeProviderId.value);

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -111,7 +111,10 @@ async function Startup() {
 
                 // Normal case: the access token expired. Ask the Auth0 SDK for
                 // a fresh one via the refresh token — no redirect needed.
-                if (await auth.refreshTokenSilently()) return;
+                // Bypass the SDK's token cache: the server already rejected
+                // what we had, so the cached copy is useless and we must hit
+                // /oauth/token.
+                if (await auth.refreshTokenSilently({ ignoreCache: true })) return;
 
                 // The refresh token itself is gone or rejected — need a
                 // visible re-login.


### PR DESCRIPTION
When the server rejects a token, the Auth0 SDK's default cache can return a stale but still client-valid token. This prevents a proper refresh, leading to infinite re-login loops.

This change introduces an `ignoreCache` option to
`refreshTokenSilently`. When true, it forces `getAccessTokenSilently` to bypass the SDK's cache and hit the `/oauth/token` endpoint. This ensures a fresh token is obtained even if the cached one is still within its leeway period but has been revoked by the server.

Tests have been added to cover this cache behavior and its regression implications.