### PR TITLE
CMS: Refactor LCombobox to ignore punctuation and whitespace

### DIFF
--- a/cms/src/components/forms/LCombobox.spec.ts
+++ b/cms/src/components/forms/LCombobox.spec.ts
@@ -328,6 +328,42 @@ describe("LCombobox", () => {
         });
     });
 
+    it("filters options ignoring punctuation and whitespace in the query", async () => {
+        const wrapper = mount(LCombobox, {
+            props: {
+                options: [
+                    { id: 0, label: "Foo-Bar", value: "foo-bar" },
+                    { id: 1, label: "Hello, World!", value: "hello-world" },
+                    { id: 2, label: "Other", value: "other" },
+                ],
+                selectedOptions: [],
+            },
+            global: { stubs: { Teleport: true } },
+        });
+
+        await wrapper.find("[name='options-open-btn']").trigger("click");
+        await wrapper.vm.$nextTick();
+
+        const searchElement = wrapper.find("[name='option-search']");
+        await searchElement.setValue("foobar");
+        await wrapper.vm.$nextTick();
+
+        await waitForExpect(() => {
+            const items = wrapper.findAll("[name='list-item']");
+            expect(items).toHaveLength(1);
+            expect(items[0].text()).toContain("Foo-Bar");
+        });
+
+        await searchElement.setValue("helloworld");
+        await wrapper.vm.$nextTick();
+
+        await waitForExpect(() => {
+            const items = wrapper.findAll("[name='list-item']");
+            expect(items).toHaveLength(1);
+            expect(items[0].text()).toContain("Hello, World!");
+        });
+    });
+
     it("show the input search when the slot actions is not set", async () => {
         const wrapper = mount(LCombobox, {
             props: {

--- a/cms/src/components/forms/LCombobox.spec.ts
+++ b/cms/src/components/forms/LCombobox.spec.ts
@@ -364,6 +364,63 @@ describe("LCombobox", () => {
         });
     });
 
+    it("sorts dropdown options alphabetically ascending", async () => {
+        const wrapper = mount(LCombobox, {
+            props: {
+                options: [
+                    { id: 0, label: "Charlie", value: "c" },
+                    { id: 1, label: "alpha", value: "a" },
+                    { id: 2, label: "Bravo", value: "b" },
+                    { id: 3, label: "delta", value: "d" },
+                ],
+                selectedOptions: [],
+            },
+            global: { stubs: { Teleport: true } },
+        });
+
+        await wrapper.find("[name='options-open-btn']").trigger("click");
+        await wrapper.vm.$nextTick();
+
+        await waitForExpect(() => {
+            const items = wrapper.findAll("[name='list-item']");
+            expect(items).toHaveLength(4);
+            expect(items[0].text()).toContain("alpha");
+            expect(items[1].text()).toContain("Bravo");
+            expect(items[2].text()).toContain("Charlie");
+            expect(items[3].text()).toContain("delta");
+        });
+    });
+
+    it("keeps filtered options sorted alphabetically", async () => {
+        const wrapper = mount(LCombobox, {
+            props: {
+                options: [
+                    { id: 0, label: "Test Zebra", value: "z" },
+                    { id: 1, label: "Test Apple", value: "a" },
+                    { id: 2, label: "Test Mango", value: "m" },
+                    { id: 3, label: "Other", value: "o" },
+                ],
+                selectedOptions: [],
+            },
+            global: { stubs: { Teleport: true } },
+        });
+
+        await wrapper.find("[name='options-open-btn']").trigger("click");
+        await wrapper.vm.$nextTick();
+
+        const searchElement = wrapper.find("[name='option-search']");
+        await searchElement.setValue("Test");
+        await wrapper.vm.$nextTick();
+
+        await waitForExpect(() => {
+            const items = wrapper.findAll("[name='list-item']");
+            expect(items).toHaveLength(3);
+            expect(items[0].text()).toContain("Test Apple");
+            expect(items[1].text()).toContain("Test Mango");
+            expect(items[2].text()).toContain("Test Zebra");
+        });
+    });
+
     it("show the input search when the slot actions is not set", async () => {
         const wrapper = mount(LCombobox, {
             props: {

--- a/cms/src/components/forms/LCombobox.vue
+++ b/cms/src/components/forms/LCombobox.vue
@@ -78,12 +78,15 @@ const optionsList = computed(() =>
 
 const query = ref("");
 
-const filtered = computed(() =>
-    optionsList.value.filter((o) => {
+const normalize = (s: string) => s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
+
+const filtered = computed(() => {
+    const normalizedQuery = normalize(query.value);
+    return optionsList.value.filter((o) => {
         if (!props.showSelectedInDropdown && o.selected) return false;
-        return o.label.toLowerCase().includes(query.value.toLowerCase());
-    }),
-);
+        return normalize(o.label).includes(normalizedQuery);
+    });
+});
 
 const highlightedIndex = ref(-1);
 

--- a/cms/src/components/forms/LCombobox.vue
+++ b/cms/src/components/forms/LCombobox.vue
@@ -82,10 +82,12 @@ const normalize = (s: string) => s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
 
 const filtered = computed(() => {
     const normalizedQuery = normalize(query.value);
-    return optionsList.value.filter((o) => {
-        if (!props.showSelectedInDropdown && o.selected) return false;
-        return normalize(o.label).includes(normalizedQuery);
-    });
+    return optionsList.value
+        .filter((o) => {
+            if (!props.showSelectedInDropdown && o.selected) return false;
+            return normalize(o.label).includes(normalizedQuery);
+        })
+        .sort((a, b) => a.label.localeCompare(b.label));
 });
 
 const highlightedIndex = ref(-1);


### PR DESCRIPTION
Normalize query and option labels to improve search filtering. This change ensures that searches are more robust by ignoring non-alphanumeric characters and case differences.