### PR TITLE
API: Refactor group deletion to use DeleteCmd event

### DIFF
--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -473,6 +473,52 @@ describe("DbService", () => {
 
             service.off("languageUpdate", languageDeleteHandler);
         });
+
+        it("emits 'groupUpdate' event when a delete command for a group document is created", async () => {
+            const groupDoc = {
+                _id: "group-delete-event-test",
+                type: DocType.Group,
+                name: "Group to Delete",
+                acl: [],
+            };
+
+            await service.upsertDoc(groupDoc);
+
+            let deleteCmdEventReceived = false;
+            let receivedDeleteCmd: any;
+
+            const groupDeleteHandler = (update: any) => {
+                if (
+                    update.type === DocType.DeleteCmd &&
+                    update.docId === "group-delete-event-test"
+                ) {
+                    deleteCmdEventReceived = true;
+                    receivedDeleteCmd = update;
+                }
+            };
+
+            service.on("groupUpdate", groupDeleteHandler);
+
+            const docToDelete = {
+                _id: "group-delete-event-test",
+                type: DocType.Group,
+                name: "Group to Delete",
+                acl: [],
+                deleteReq: 1,
+            };
+
+            await service.upsertDoc(docToDelete);
+
+            await waitForExpect(() => {
+                expect(deleteCmdEventReceived).toBe(true);
+                expect(receivedDeleteCmd.type).toBe(DocType.DeleteCmd);
+                expect(receivedDeleteCmd.docId).toBe("group-delete-event-test");
+                expect(receivedDeleteCmd.docType).toBe(DocType.Group);
+                expect(receivedDeleteCmd.deleteReason).toBe(DeleteReason.Deleted);
+            });
+
+            service.off("groupUpdate", groupDeleteHandler);
+        });
     });
 
     describe("disconnect events", () => {

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -80,7 +80,7 @@ export type DbUpsertResult = {
  * @extends EventEmitter
  *
  * @fires DbService#update - Emitted when any valid document with a type field is updated in the database
- * @fires DbService#groupUpdate - Emitted when a group document is updated, used by the permission system to update access maps
+ * @fires DbService#groupUpdate - Emitted when a group document is updated, used by the permission system to update access maps. Also emitted with a `DeleteCmd` payload (docType === Group) when a group is deleted via the soft-delete flow, so the permission system can evict the entry.
  * @fires DbService#disconnect - Emitted when a previously-established DB connection is lost. Consumers should drop cached DTO state that may have diverged while disconnected.
  * @fires DbService#reconnect - Emitted after a disconnect has been followed by a successful reconnect. Consumers that need a populated cache to function should rehydrate here.
  *
@@ -218,11 +218,21 @@ export class DbService extends EventEmitter {
                         this.emit("languageUpdate", update.doc);
                     }
 
-                    // Emit delete commands for language documents
+                    // Emit delete commands for documents whose deletion is observed
+                    // by a typed cache (languages, groups). The DeleteCmd is the
+                    // only typed signal a hard-delete leaves in the change feed —
+                    // the subsequent CouchDB tombstone has no `type` field and is
+                    // dropped by the guard above — so cache consumers must reconcile
+                    // off the DeleteCmd, not the tombstone.
                     else if (update.doc.type === DocType.DeleteCmd) {
                         const doc = update.doc as DeleteCmdDto;
-                        if (doc.deleteReason === DeleteReason.Deleted)
-                            this.emit("languageUpdate", doc);
+                        if (doc.deleteReason === DeleteReason.Deleted) {
+                            if (doc.docType === DocType.Group) {
+                                this.emit("groupUpdate", doc);
+                            } else {
+                                this.emit("languageUpdate", doc);
+                            }
+                        }
                     }
                 }
 

--- a/api/src/permissions/permissions.service.spec.ts
+++ b/api/src/permissions/permissions.service.spec.ts
@@ -1,5 +1,5 @@
 import { PermissionSystem } from "./permissions.service";
-import { DocType, AclPermission } from "../enums";
+import { DocType, AclPermission, DeleteReason } from "../enums";
 import { createTestingModule } from "../test/testingModule";
 import waitForExpect from "wait-for-expect";
 import { GroupDto } from "../dto/GroupDto";
@@ -973,6 +973,53 @@ describe("PermissionService", () => {
                 ["group-public-content"],
             );
             expect(after[DocType.Language]?.includes(groupId)).toBe(true);
+        });
+
+        it("evicts a group from the cache when a DeleteCmd arrives via groupUpdate", () => {
+            // The hard-delete signal for a group reaches the permission system
+            // as a DeleteCmd payload on the groupUpdate event (the CouchDB
+            // tombstone for the group itself is filtered upstream because it
+            // has no `type` field). Verify the listener routes that payload to
+            // removeGroups so every API instance evicts the entry from its
+            // in-memory cache.
+            const groupId = "group-delete-via-deletecmd";
+
+            const initial: GroupDto = new GroupDto();
+            initial._id = groupId;
+            initial.type = DocType.Group;
+            initial.updatedTimeUtc = 1;
+            initial.name = "To be deleted";
+            initial.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+            PermissionSystem.upsertGroups([initial]);
+
+            expect(PermissionSystem.hasGroup(groupId)).toBe(true);
+            const before = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.View,
+                ["group-public-content"],
+            );
+            expect(before[DocType.Language]?.includes(groupId)).toBe(true);
+
+            testingModule.dbService.emit("groupUpdate", {
+                type: DocType.DeleteCmd,
+                docId: groupId,
+                docType: DocType.Group,
+                deleteReason: DeleteReason.Deleted,
+            });
+
+            expect(PermissionSystem.hasGroup(groupId)).toBe(false);
+            const after = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.View,
+                ["group-public-content"],
+            );
+            expect(after[DocType.Language]?.includes(groupId)).toBeFalsy();
         });
 
         it("removes a revoked ACL permission when the update arrives after a disconnect/reconnect cycle", () => {

--- a/api/src/permissions/permissions.service.spec.ts
+++ b/api/src/permissions/permissions.service.spec.ts
@@ -975,6 +975,147 @@ describe("PermissionService", () => {
             expect(after[DocType.Language]?.includes(groupId)).toBe(true);
         });
 
+        it("dispatches DeleteCmd entries to removeGroup when interleaved with upserts in upsertGroups", () => {
+            // upsertGroups accepts mixed payloads: GroupDto upserts and DeleteCmd
+            // entries are dispatched in arrival order. This is what lets the init
+            // replay drain a single queue without losing ordering between a hard
+            // delete and the upserts around it.
+            const keepId = "group-mixed-keep";
+            const deleteId = "group-mixed-delete";
+
+            const keep: GroupDto = new GroupDto();
+            keep._id = keepId;
+            keep.type = DocType.Group;
+            keep.updatedTimeUtc = 1;
+            keep.name = "Keep";
+            keep.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+
+            const toDelete: GroupDto = new GroupDto();
+            toDelete._id = deleteId;
+            toDelete.type = DocType.Group;
+            toDelete.updatedTimeUtc = 1;
+            toDelete.name = "Delete";
+            toDelete.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+
+            PermissionSystem.upsertGroups([
+                keep,
+                toDelete,
+                {
+                    type: DocType.DeleteCmd,
+                    docId: deleteId,
+                    docType: DocType.Group,
+                    deleteReason: DeleteReason.Deleted,
+                },
+            ]);
+
+            expect(PermissionSystem.hasGroup(keepId)).toBe(true);
+            expect(PermissionSystem.hasGroup(deleteId)).toBe(false);
+        });
+
+        it("preserves arrival order when a DeleteCmd precedes a re-creation upsert in the same upsertGroups call", () => {
+            // Re-creation scenario: a group is deleted and then immediately
+            // re-created within the same replay batch. The final state must be
+            // "present" — the upsert is the last operation and wins.
+            const groupId = "group-delete-then-recreate";
+
+            const initial: GroupDto = new GroupDto();
+            initial._id = groupId;
+            initial.type = DocType.Group;
+            initial.updatedTimeUtc = 1;
+            initial.name = "Initial";
+            initial.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+            PermissionSystem.upsertGroups([initial]);
+            expect(PermissionSystem.hasGroup(groupId)).toBe(true);
+
+            const recreated: GroupDto = new GroupDto();
+            recreated._id = groupId;
+            recreated.type = DocType.Group;
+            recreated.updatedTimeUtc = 3;
+            recreated.name = "Recreated";
+            recreated.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View, AclPermission.Edit],
+                },
+            ];
+
+            PermissionSystem.upsertGroups([
+                {
+                    type: DocType.DeleteCmd,
+                    docId: groupId,
+                    docType: DocType.Group,
+                    deleteReason: DeleteReason.Deleted,
+                },
+                recreated,
+            ]);
+
+            expect(PermissionSystem.hasGroup(groupId)).toBe(true);
+            const after = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.Edit,
+                ["group-public-content"],
+            );
+            expect(after[DocType.Language]?.includes(groupId)).toBe(true);
+        });
+
+        it("preserves arrival order when an upsert precedes a DeleteCmd for the same group in the same upsertGroups call", () => {
+            // Complement of the re-creation case: if a stale snapshot upsert
+            // arrives before a DeleteCmd in the same drain, the group must end
+            // up removed. This is the specific race the queue refactor exists
+            // to defend against.
+            const groupId = "group-upsert-then-delete";
+
+            const stale: GroupDto = new GroupDto();
+            stale._id = groupId;
+            stale.type = DocType.Group;
+            stale.updatedTimeUtc = 1;
+            stale.name = "Stale snapshot";
+            stale.acl = [
+                {
+                    type: DocType.Language,
+                    groupId: "group-public-content",
+                    permission: [AclPermission.View],
+                },
+            ];
+
+            PermissionSystem.upsertGroups([
+                stale,
+                {
+                    type: DocType.DeleteCmd,
+                    docId: groupId,
+                    docType: DocType.Group,
+                    deleteReason: DeleteReason.Deleted,
+                },
+            ]);
+
+            expect(PermissionSystem.hasGroup(groupId)).toBe(false);
+            const after = PermissionSystem.getAccessibleGroups(
+                [DocType.Language],
+                AclPermission.View,
+                ["group-public-content"],
+            );
+            expect(after[DocType.Language]?.includes(groupId)).toBeFalsy();
+        });
+
         it("evicts a group from the cache when a DeleteCmd arrives via groupUpdate", () => {
             // The hard-delete signal for a group reaches the permission system
             // as a DeleteCmd payload on the groupUpdate event (the CouchDB

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -1,6 +1,7 @@
 import { Uuid, DocType, AclPermission } from "../enums";
 import { GroupAclEntryDto } from "../dto/GroupAclEntryDto";
 import { GroupDto } from "../dto/GroupDto";
+import { DeleteCmdDto } from "../dto/DeleteCmdDto";
 import { DbService } from "../db/db.service";
 import { EventEmitter } from "node:events";
 
@@ -142,25 +143,23 @@ export class PermissionSystem extends EventEmitter {
         dbService = db;
 
         let initialized = false;
-        const updateQueue: any[] = [];
+        let updateQueue: (GroupDto | DeleteCmdDto)[] = [];
 
-        // groupUpdate carries both group upserts and DeleteCmd payloads (the
-        // CouchDB tombstone for the group itself has no `type` field and is
-        // filtered upstream). Both are dispatched by upsertGroups, so a single
-        // queue preserves arrival order across the init window — otherwise a
-        // DeleteCmd arriving during init would run against an empty groupMap
-        // (no-op) and then be re-added by the stale snapshot.
-        dbService.on("groupUpdate", (update: any) => {
+        dbService.on("groupUpdate", async (update: GroupDto | DeleteCmdDto) => {
             updateQueue.push(update);
-            if (initialized) PermissionSystem.upsertGroups(updateQueue);
+            if (initialized) {
+                PermissionSystem.upsertGroups(updateQueue);
+                updateQueue = [];
+            }
         });
 
         // Add existing groups to permission system
         const dbGroups = await dbService.getGroups();
         this.upsertGroups(dbGroups.docs);
 
-        // Replay events that arrived during the snapshot fetch.
+        // Add changes that might have occurred while the permission system was being initialized
         this.upsertGroups(updateQueue);
+        updateQueue = [];
         initialized = true;
     }
 

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -144,7 +144,14 @@ export class PermissionSystem extends EventEmitter {
         let initialized = false;
         let updateQueue: any[] = [];
 
-        dbService.on("groupUpdate", async (update: DocType.Group) => {
+        dbService.on("groupUpdate", async (update: any) => {
+            // A group deletion arrives here as a DeleteCmd payload (the CouchDB
+            // tombstone for the group itself has no type and is filtered upstream).
+            if (update?.type === DocType.DeleteCmd) {
+                PermissionSystem.removeGroups([update.docId]);
+                return;
+            }
+
             updateQueue.push(update);
             if (initialized) {
                 PermissionSystem.upsertGroups(updateQueue);

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -142,30 +142,46 @@ export class PermissionSystem extends EventEmitter {
         dbService = db;
 
         let initialized = false;
-        let updateQueue: any[] = [];
+        const updateQueue: any[] = [];
 
-        dbService.on("groupUpdate", async (update: any) => {
+        // Drain queued change-feed events in arrival order. Upserts and
+        // DeleteCmds share one queue so the post-snapshot replay preserves
+        // ordering — without this, a DeleteCmd arriving during the init
+        // window would run against an empty groupMap (no-op) and then be
+        // re-added by the stale snapshot.
+        const drainQueue = () => {
+            while (updateQueue.length > 0) {
+                if (updateQueue[0]?.type === DocType.DeleteCmd) {
+                    const cmd = updateQueue.shift();
+                    PermissionSystem.removeGroups([cmd.docId]);
+                } else {
+                    // Batch consecutive upserts so upsertGroup's parent-
+                    // lookahead within a batch still works.
+                    const batch: any[] = [];
+                    while (
+                        updateQueue.length > 0 &&
+                        updateQueue[0]?.type !== DocType.DeleteCmd
+                    ) {
+                        batch.push(updateQueue.shift());
+                    }
+                    PermissionSystem.upsertGroups(batch);
+                }
+            }
+        };
+
+        dbService.on("groupUpdate", (update: any) => {
             // A group deletion arrives here as a DeleteCmd payload (the CouchDB
             // tombstone for the group itself has no type and is filtered upstream).
-            if (update?.type === DocType.DeleteCmd) {
-                PermissionSystem.removeGroups([update.docId]);
-                return;
-            }
-
             updateQueue.push(update);
-            if (initialized) {
-                PermissionSystem.upsertGroups(updateQueue);
-                updateQueue = [];
-            }
+            if (initialized) drainQueue();
         });
 
         // Add existing groups to permission system
         const dbGroups = await dbService.getGroups();
         this.upsertGroups(dbGroups.docs);
 
-        // Add changes that might have occurred while the permission system was being initialized
-        this.upsertGroups(updateQueue);
-        updateQueue = [];
+        // Replay events that arrived during the snapshot fetch (in arrival order).
+        drainQueue();
         initialized = true;
     }
 

--- a/api/src/permissions/permissions.service.ts
+++ b/api/src/permissions/permissions.service.ts
@@ -144,44 +144,23 @@ export class PermissionSystem extends EventEmitter {
         let initialized = false;
         const updateQueue: any[] = [];
 
-        // Drain queued change-feed events in arrival order. Upserts and
-        // DeleteCmds share one queue so the post-snapshot replay preserves
-        // ordering — without this, a DeleteCmd arriving during the init
-        // window would run against an empty groupMap (no-op) and then be
-        // re-added by the stale snapshot.
-        const drainQueue = () => {
-            while (updateQueue.length > 0) {
-                if (updateQueue[0]?.type === DocType.DeleteCmd) {
-                    const cmd = updateQueue.shift();
-                    PermissionSystem.removeGroups([cmd.docId]);
-                } else {
-                    // Batch consecutive upserts so upsertGroup's parent-
-                    // lookahead within a batch still works.
-                    const batch: any[] = [];
-                    while (
-                        updateQueue.length > 0 &&
-                        updateQueue[0]?.type !== DocType.DeleteCmd
-                    ) {
-                        batch.push(updateQueue.shift());
-                    }
-                    PermissionSystem.upsertGroups(batch);
-                }
-            }
-        };
-
+        // groupUpdate carries both group upserts and DeleteCmd payloads (the
+        // CouchDB tombstone for the group itself has no `type` field and is
+        // filtered upstream). Both are dispatched by upsertGroups, so a single
+        // queue preserves arrival order across the init window — otherwise a
+        // DeleteCmd arriving during init would run against an empty groupMap
+        // (no-op) and then be re-added by the stale snapshot.
         dbService.on("groupUpdate", (update: any) => {
-            // A group deletion arrives here as a DeleteCmd payload (the CouchDB
-            // tombstone for the group itself has no type and is filtered upstream).
             updateQueue.push(update);
-            if (initialized) drainQueue();
+            if (initialized) PermissionSystem.upsertGroups(updateQueue);
         });
 
         // Add existing groups to permission system
         const dbGroups = await dbService.getGroups();
         this.upsertGroups(dbGroups.docs);
 
-        // Replay events that arrived during the snapshot fetch (in arrival order).
-        drainQueue();
+        // Replay events that arrived during the snapshot fetch.
+        this.upsertGroups(updateQueue);
         initialized = true;
     }
 
@@ -360,12 +339,19 @@ export class PermissionSystem extends EventEmitter {
     }
 
     /**
-     * Create or update groups from passed array of group database documents
+     * Create or update groups from passed array of group database documents.
+     * DeleteCmd payloads interleaved in the array trigger removal of the
+     * referenced group in arrival order.
      * @param groupDocs
      */
     static upsertGroups(groupDocs: Array<any>) {
         while (groupDocs.length > 0) {
-            this.upsertGroup(groupDocs.splice(0, 1)[0], groupDocs);
+            const doc = groupDocs.splice(0, 1)[0];
+            if (doc?.type === DocType.DeleteCmd) {
+                this.removeGroup(doc.docId);
+            } else if (doc) {
+                this.upsertGroup(doc, groupDocs);
+            }
         }
     }
 


### PR DESCRIPTION
The `groupUpdate` event now also emits a `DeleteCmd` payload when a group is soft-deleted. This allows the permission system to properly remove deleted groups from its access maps. The upstream filtering of CouchDB tombstones ensures that only `DeleteCmd` events are processed, as the tombstones themselves lack a `type` field.