### PR TITLE
Fix: Handle orphaned Auth0 cache keys gracefully

### DIFF
--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, DocType, setCustomHeader, type AuthProviderDto } from "luminary-shared";
 import type { App } from "vue";
 import type { Router } from "vue-router";
+import * as Sentry from "@sentry/vue";
 
 // Hoisted spies the mocked createAuth0 closes over. We assert against these to
 // verify what refreshTokenSilently passes to the Auth0 SDK.
@@ -16,6 +17,11 @@ const { mockGetAccessTokenSilently, mockHandleRedirectCallback, mockCreateAuth0 
 
 vi.mock("@auth0/auth0-vue", () => ({
     createAuth0: mockCreateAuth0,
+}));
+
+vi.mock("@sentry/vue", () => ({
+    captureMessage: vi.fn(),
+    captureException: vi.fn(),
 }));
 
 import {
@@ -327,6 +333,89 @@ describe("auth", () => {
             expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(2);
             expect(mockGetAccessTokenSilently.mock.calls[0]).toEqual([{ cacheMode: "off" }]);
             expect(mockGetAccessTokenSilently.mock.calls[1]).toEqual([{ cacheMode: "off" }]);
+        });
+    });
+
+    // Regression coverage for issue #1606 — "App: potential iPhone auth
+    // IndexedDB race condition". The pre-existing setupAuth cold-start
+    // branch called clearAuth0Cache() whenever resolveActiveProvider() came
+    // up empty, which conflates "Dexie doesn't have a matching provider doc
+    // right now" with "the user has no session intended." On iOS Safari we
+    // suspect IDB can be evicted while localStorage survives, which would
+    // make this defensive wipe destroy a valid session on every cold open.
+    // The hypothesis is unconfirmed in the field; the minimum-impact fix is
+    // to stop wiping the cache here (the server's provider_not_found
+    // connect_error path still cleans it up if the provider really is gone)
+    // and to send a Sentry message tagged with the orphan clientId so we
+    // can verify whether this state actually occurs in production.
+    describe("setupAuth — orphan Auth0 cache handling (issue #1606)", () => {
+        const appStub = { use: () => {} } as unknown as App<Element>;
+        const routerStub = { replace: () => Promise.resolve(undefined) } as unknown as Router;
+        const cacheKeyFor = (p: AuthProviderDto) =>
+            `@@auth0spajs@@::${p.clientId}::${p.audience}::openid profile email offline_access`;
+
+        beforeEach(() => {
+            mockGetAccessTokenSilently.mockReset();
+            mockHandleRedirectCallback.mockReset();
+            mockCreateAuth0.mockReset();
+            mockCreateAuth0.mockImplementation(() => ({
+                getAccessTokenSilently: mockGetAccessTokenSilently,
+                handleRedirectCallback: mockHandleRedirectCallback,
+                install: () => {},
+            }));
+            vi.mocked(Sentry.captureMessage).mockClear();
+        });
+
+        afterEach(() => {
+            setCustomHeader("Authorization", "");
+        });
+
+        it("leaves an orphan Auth0 cache key in place and reports it to Sentry", async () => {
+            // The suspect state: Auth0 session cached in localStorage, but
+            // no matching AuthProvider doc in Dexie. Previously setupAuth
+            // would wipe the cache here; now it must leave it alone and
+            // surface the state so we can confirm whether the iOS-eviction
+            // hypothesis is actually happening.
+            const cacheKey = cacheKeyFor(providerA);
+            const cacheValue = JSON.stringify({ body: {} });
+            localStorage.setItem(cacheKey, cacheValue);
+
+            await setupAuth(appStub, routerStub);
+
+            // Cache untouched — the whole point of the change.
+            expect(localStorage.getItem(cacheKey)).toBe(cacheValue);
+            // No Auth0 plugin install (we still don't know which provider
+            // this is), and no provider id header set.
+            expect(mockCreateAuth0).not.toHaveBeenCalled();
+            expect(activeProviderId.value).toBeNull();
+            // Sentry was told about the orphan, tagged so we can filter.
+            expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+            const [msg, ctx] = vi.mocked(Sentry.captureMessage).mock.calls[0];
+            expect(msg).toContain("Auth0 cache key present but no matching AuthProvider doc");
+            expect((ctx as { extra?: { clientId?: string } }).extra?.clientId).toBe(
+                providerA.clientId,
+            );
+            expect((ctx as { tags?: { issue?: string } }).tags?.issue).toBe("1606");
+        });
+
+        it("does not report or touch storage on a true cold start (no Auth0 cache at all)", async () => {
+            await setupAuth(appStub, routerStub);
+
+            expect(mockCreateAuth0).not.toHaveBeenCalled();
+            expect(Sentry.captureMessage).not.toHaveBeenCalled();
+            expect(activeProviderId.value).toBeNull();
+        });
+
+        it("happy path: when the provider doc is in Dexie, installs Auth0 and does NOT report", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(cacheKeyFor(providerA), JSON.stringify({ body: {} }));
+            mockGetAccessTokenSilently.mockResolvedValue("boot-token");
+
+            await setupAuth(appStub, routerStub);
+
+            expect(mockCreateAuth0).toHaveBeenCalledTimes(1);
+            expect(activeProviderId.value).toBe(providerA._id);
+            expect(Sentry.captureMessage).not.toHaveBeenCalled();
         });
     });
 });

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -77,6 +77,21 @@ export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
     return (doc as AuthProviderDto) ?? null;
 }
 
+/**
+ * Read the clientId out of Auth0's localStorage cache key, without touching
+ * IndexedDB. Returns null when there is no Auth0 cache present.
+ */
+function findActiveAuth0ClientId(): string | null {
+    if (typeof localStorage === "undefined") return null;
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (!key?.startsWith(AUTH0_CACHE_PREFIX)) continue;
+        const clientId = key.slice(AUTH0_CACHE_PREFIX.length).split("::")[0] || null;
+        if (clientId) return clientId;
+    }
+    return null;
+}
+
 function buildAuth0Options(p: ProviderConfig) {
     return {
         domain: p.domain,
@@ -105,10 +120,27 @@ let installedOauth: ReturnType<typeof createAuth0> | null = null;
 export async function setupAuth(app: App<Element>, router: Router): Promise<void> {
     const provider = await resolveActiveProvider();
     if (!provider) {
-        // Auth0 cache keys from a deleted provider (or a session that predates
-        // the provider doc landing in Dexie) will linger in localStorage
-        // forever without this — no other path cleans them up for a cold start.
-        clearAuth0Cache();
+        // We used to clearAuth0Cache() here to evict stale cache keys from a
+        // deleted provider. That conflates "Dexie doesn't have a matching
+        // AuthProvider doc right now" with "the user has no session," which
+        // is wrong when IndexedDB and localStorage have been evicted on
+        // different schedules (issue #1606 — suspected on iOS Safari but
+        // unconfirmed). Capture the orphan-cache state so we can tell from
+        // production whether the iOS-eviction hypothesis actually fires;
+        // otherwise leave the cache in place — the server-side
+        // `provider_not_found` connect_error path will wipe it if the
+        // provider really is gone.
+        const orphanClientId = findActiveAuth0ClientId();
+        if (orphanClientId) {
+            Sentry?.captureMessage(
+                "Auth bootstrap: Auth0 cache key present but no matching AuthProvider doc in Dexie",
+                {
+                    level: "warning",
+                    tags: { area: "auth", issue: "1606" },
+                    extra: { clientId: orphanClientId },
+                },
+            );
+        }
         return;
     }
 


### PR DESCRIPTION
Was not really able to reproduce nor was it reported by the user again. Opted for regression methods to be able to properly track this bug occurence

Previously, the application would aggressively clear the Auth0 cache if no matching provider was found in the database. This could lead to the accidental removal of a valid user session, particularly on iOS Safari where IndexedDB and localStorage might be evicted at different times.

This commit changes the behavior to:

- Log a Sentry message when an orphaned Auth0 cache key is detected, including the `clientId` for debugging.
- Avoid clearing the cache in this scenario, allowing the application to potentially recover the session.
- Rely on the server-side `provider_not_found` error to clear the cache if the provider is truly missing.

This change addresses issue #1606 and provides better visibility into potential race conditions during application startup.