### PR TITLE
APP: Refactor TopBar to use ResizeObserver

### DIFF
--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -3,7 +3,7 @@ import { ChevronLeftIcon } from "@heroicons/vue/24/solid";
 import ProfileMenu from "./ProfileMenu.vue";
 import { useRouter } from "vue-router";
 import DesktopMenu from "./DesktopMenu.vue";
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { getRouteHistory } from "@/router";
 import { useAuthWithPrivacyPolicy } from "@/composables/useAuthWithPrivacyPolicy";
 import { isConnected } from "luminary-shared";
@@ -45,33 +45,32 @@ const logoCss = computed(
     () => "--image-url: url(" + logo.value + "); --image-url-dark: url(" + logoDark.value + ");",
 );
 
-// Detect screen size on load and window resize
 const updateScreenSize = () => {
     if (!logoWidth.value) return;
     if (!logoContainer.value) return;
     isSmallScreen.value = logoWidth.value > logoContainer.value.clientWidth;
 };
 
+let resizeObserver: ResizeObserver | undefined;
+
 onMounted(() => {
-    if (!logoWidth.value) {
-        const img = new Image();
-        img.src = LOGO;
-        img.onload = () => {
-            if (!logoContainer.value) return;
-            logoWidth.value = (img.width * 32) / img.height; // 32px = tailwind h-8
-        };
+    const img = new Image();
+    img.src = LOGO;
+    img.onload = () => {
+        logoWidth.value = (img.width * 32) / img.height; // 32px = tailwind h-8
+        updateScreenSize();
+    };
+
+    // Observe the container so we re-measure whenever surrounding layout settles
+    // (i18n strings hydrating, ProfileMenu/avatar loading, viewport resize, etc.)
+    if (logoContainer.value) {
+        resizeObserver = new ResizeObserver(updateScreenSize);
+        resizeObserver.observe(logoContainer.value);
     }
+});
 
-    watch(
-        [logoWidth],
-        async () => {
-            await nextTick();
-            updateScreenSize();
-        },
-        { immediate: true },
-    );
-
-    window.addEventListener("resize", updateScreenSize);
+onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
 });
 
 const isPostAndNoHistory = computed(() => {

--- a/app/src/globalConfig.ts
+++ b/app/src/globalConfig.ts
@@ -81,7 +81,12 @@ export const isMac = computed(() => {
     if (uaDataPlatform) return uaDataPlatform.includes("mac");
 
     const ua = (navigator.userAgent || "").toLowerCase();
-    return ua.includes("mac os") || ua.includes("macintosh") || ua.includes("iphone") || ua.includes("ipad");
+    return (
+        ua.includes("mac os") ||
+        ua.includes("macintosh") ||
+        ua.includes("iphone") ||
+        ua.includes("ipad")
+    );
 });
 
 /**
@@ -435,6 +440,4 @@ export const fallbackImageUrls = loadFallbackImageUrls();
 /**
  * True while the app's Startup function is still running. Used to display the loading splash screen.
  */
-export const isAppLoading = ref(
-    !new URLSearchParams(window.location.search).has("nosplash"),
-);
+export const isAppLoading = ref(!new URLSearchParams(window.location.search).has("nosplash"));

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -85,6 +85,12 @@ const testI18n = createI18n({
 });
 config.global.plugins = [...(config.global.plugins || []), testI18n];
 
+window.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+}));
+
 window.matchMedia = vi.fn().mockImplementation((query) => {
     return {
         matches: false,


### PR DESCRIPTION
Replaced window resize listener with ResizeObserver for more robust screen size detection. This ensures the logo's small screen state is updated correctly even when only the container size changes without a viewport resize. Also removed unnecessary watch and nextTick.