### PR TITLE
feat: Return matched doc with search results

### DIFF
--- a/app/src/components/navigation/SearchModal.spec.ts
+++ b/app/src/components/navigation/SearchModal.spec.ts
@@ -13,6 +13,7 @@ import type { FtsSearchResult } from "luminary-shared";
 
 const routePushMock = vi.hoisted(() => vi.fn());
 const loadMoreMock = vi.hoisted(() => vi.fn());
+const cancelMock = vi.hoisted(() => vi.fn());
 
 /** Doc returned by db mock; _id/slug/title must match mockEnglishContentDto for assertions. */
 const searchMockDoc = vi.hoisted(() => ({
@@ -96,6 +97,7 @@ function setupFts(
         totalLoaded: ref(0),
         lastSearchedQuery: lastSearchedQueryRef,
         runSearch: runSearchMock,
+        cancel: cancelMock,
     } as any);
 
     return { resultsRef, isSearchingRef, hasMoreRef, lastSearchedQueryRef };
@@ -128,6 +130,7 @@ const fakeResult: FtsSearchResult = {
     docId: mockEnglishContentDto._id,
     score: 1.5,
     wordMatchScore: 1,
+    doc: searchMockDoc as any,
 };
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -137,6 +140,7 @@ describe("SearchButton", () => {
         setActivePinia(createTestingPinia());
         setupFts();
         loadMoreMock.mockReset();
+        cancelMock.mockReset();
         routePushMock.mockReset();
         window.localStorage.clear();
         window.sessionStorage.clear();
@@ -715,8 +719,8 @@ describe("SearchButton", () => {
 
     describe("Keyboard navigation", () => {
         const twoResults: FtsSearchResult[] = [
-            { docId: mockEnglishContentDto._id, score: 2, wordMatchScore: 1 },
-            { docId: mockEnglishContentDto._id, score: 1, wordMatchScore: 1 },
+            { docId: mockEnglishContentDto._id, score: 2, wordMatchScore: 1, doc: searchMockDoc as any },
+            { docId: mockEnglishContentDto._id, score: 1, wordMatchScore: 1, doc: searchMockDoc as any },
         ];
 
         async function setupWithTwoResults() {

--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -109,6 +109,7 @@ const {
     hasMore,
     lastSearchedQuery,
     runSearch,
+    cancel,
 } = ftsRet;
 
 const searchResultsContainerRef = ref<HTMLElement | null>(null);
@@ -263,26 +264,17 @@ type EnrichedResult = ContentDto & {
     languageName: string;
 };
 
-const resolvedDocs = ref<Map<string, ContentDto>>(new Map());
 const languageNames = ref<Map<string, string>>(new Map());
 
 watch(
     () => ftsResults.value as FtsSearchResult[],
     async (newResults) => {
-        if (!newResults.length) {
-            resolvedDocs.value = new Map();
-            return;
-        }
-        const docIds = newResults.map((r) => r.docId);
-        const docs = await db.docs.where("_id").anyOf(docIds).toArray();
+        if (!newResults.length) return;
 
-        const docMap = new Map<string, ContentDto>();
         const langIds = new Set<string>();
-        for (const doc of docs) {
-            docMap.set(doc._id, doc as ContentDto);
-            if ((doc as ContentDto).language) langIds.add((doc as ContentDto).language);
+        for (const r of newResults) {
+            if (r.doc.language) langIds.add(r.doc.language);
         }
-        resolvedDocs.value = docMap;
 
         if (langIds.size) {
             const langs = await db.docs
@@ -310,18 +302,15 @@ const highlightQuery = computed(() => {
 
 const results = computed<EnrichedResult[]>(() => {
     const query = highlightQuery.value;
-    return (ftsResults.value as FtsSearchResult[])
-        .map((r) => resolvedDocs.value.get(r.docId))
-        .filter((doc): doc is ContentDto => !!doc)
-        .map((doc) => ({
-            ...doc,
-            titleHighlight: applyTermHighlights(stripHtml(doc.title ?? ""), query),
-            highlight: createHighlight(doc, query),
-            authorHighlight: doc.author
-                ? applyTermHighlights(stripHtml(doc.author), query)
-                : undefined,
-            languageName: languageNames.value.get(doc.language) ?? "",
-        }));
+    return (ftsResults.value as FtsSearchResult[]).map(({ doc }) => ({
+        ...doc,
+        titleHighlight: applyTermHighlights(stripHtml(doc.title ?? ""), query),
+        highlight: createHighlight(doc, query),
+        authorHighlight: doc.author
+            ? applyTermHighlights(stripHtml(doc.author), query)
+            : undefined,
+        languageName: languageNames.value.get(doc.language) ?? "",
+    }));
 });
 const showResults = computed(() => results.value.length > 0);
 
@@ -367,8 +356,9 @@ watch(
         // Editing the query should cancel any selected result so Enter applies the search.
         if (newQuery !== oldQuery) selectedIndex.value = -1;
         if (!trimmed) {
+            // Cancel any in-flight search first so a slow previous run can't repopulate results.
+            cancel();
             ftsResults.value = [];
-            resolvedDocs.value = new Map();
             lastSearchedQuery.value = "";
             selectedIndex.value = -1;
         }
@@ -389,8 +379,8 @@ watch(isSearchOpen, (open) => {
         // Only clear results when they don't match the query we're about to show.
         // This keeps results in memory when reopening the modal for the same term.
         if (!q || lastSearchedQuery.value !== q) {
+            cancel();
             ftsResults.value = [];
-            resolvedDocs.value = new Map();
             lastSearchedQuery.value = "";
         }
     }

--- a/shared/src/fts/README.md
+++ b/shared/src/fts/README.md
@@ -53,11 +53,12 @@ const results = await ftsSearch({
 
 ### FtsSearchResult
 
-| Property         | Type     | Description                                      |
-| ---------------- | -------- | ------------------------------------------------ |
-| `docId`          | `string` | The document ID                                  |
-| `score`          | `number` | BM25 score plus word match bonus                 |
-| `wordMatchScore` | `number` | Boost-weighted count of full query words matched |
+| Property         | Type         | Description                                                          |
+| ---------------- | ------------ | -------------------------------------------------------------------- |
+| `docId`          | `string`     | The document ID                                                      |
+| `score`          | `number`     | BM25 score plus word match bonus                                     |
+| `wordMatchScore` | `number`     | Boost-weighted count of full query words matched                     |
+| `doc`            | `ContentDto` | The matched document — already loaded for scoring, so no refetch     |
 
 ## Architecture
 

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -139,7 +139,7 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
                 idf * ((tf * (bm25k1 + 1)) / (tf + bm25k1 * (1 - bm25b + bm25b * (dl / avgdl))));
         }
 
-        results.push({ docId, score, wordMatchScore: 0 });
+        results.push({ docId, score, wordMatchScore: 0, doc });
     });
 
     // Step 6: Boost-weighted full-word match scoring
@@ -148,12 +148,9 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
 
     if (queryWords.length > 0 && results.length > 0) {
         for (const result of results) {
-            const doc = docMap.get(result.docId);
-            if (!doc) continue;
-
             const wordMatchBonus = computeFieldWordMatchScore(
                 queryWords,
-                doc as Record<string, any>,
+                result.doc as Record<string, any>,
                 FTS_FIELDS,
             );
             result.wordMatchScore = wordMatchBonus;

--- a/shared/src/fts/types.ts
+++ b/shared/src/fts/types.ts
@@ -1,4 +1,4 @@
-import type { Uuid } from "../types";
+import type { ContentDto, Uuid } from "../types";
 
 /** Configuration for a single field to be indexed or searched */
 export type FtsFieldConfig = {
@@ -17,6 +17,8 @@ export type FtsSearchResult = {
     score: number;
     /** Boost-weighted count of full query words matched in document fields */
     wordMatchScore: number;
+    /** The matched document. Loaded by ftsSearch during scoring; returned so callers don't have to refetch. */
+    doc: ContentDto;
 };
 
 /** Search options */

--- a/shared/src/fts/useFtsSearch.spec.ts
+++ b/shared/src/fts/useFtsSearch.spec.ts
@@ -7,8 +7,13 @@ vi.mock("./ftsSearch", () => ({
 
 import { useFtsSearch } from "./useFtsSearch";
 import { ftsSearch } from "./ftsSearch";
+import type { FtsSearchResult } from "./types";
 
 const mockFtsSearch = vi.mocked(ftsSearch);
+
+function makeResult(docId: string, score = 1, wordMatchScore = 0): FtsSearchResult {
+    return { docId, score, wordMatchScore, doc: { _id: docId } as any };
+}
 
 describe("useFtsSearch", () => {
     beforeEach(() => {
@@ -39,7 +44,7 @@ describe("useFtsSearch", () => {
         const scope = effectScope();
         scope.run(() => {
             const queryRef = ref("quantum physics");
-            mockFtsSearch.mockResolvedValue([{ docId: "1", score: 1, wordMatchScore: 0 }]);
+            mockFtsSearch.mockResolvedValue([makeResult("1")]);
             useFtsSearch(queryRef, { debounceMs: 100 });
         });
 
@@ -90,11 +95,7 @@ describe("useFtsSearch", () => {
         scope.run(() => {
             const queryRef = ref("quantum physics test");
             // Return full page so hasMore = true
-            const fullPage = Array.from({ length: 20 }, (_, i) => ({
-                docId: `doc-${i}`,
-                score: 1,
-                wordMatchScore: 0,
-            }));
+            const fullPage = Array.from({ length: 20 }, (_, i) => makeResult(`doc-${i}`));
             mockFtsSearch.mockResolvedValue(fullPage);
             result = useFtsSearch(queryRef, { debounceMs: 50, pageSize: 20 });
         });
@@ -107,7 +108,7 @@ describe("useFtsSearch", () => {
         expect(result.totalLoaded.value).toBe(20);
 
         // Load more
-        mockFtsSearch.mockResolvedValue([{ docId: "doc-20", score: 0.5, wordMatchScore: 0 }]);
+        mockFtsSearch.mockResolvedValue([makeResult("doc-20", 0.5)]);
         result.loadMore();
         await vi.advanceTimersByTimeAsync(10);
 
@@ -141,7 +142,7 @@ describe("useFtsSearch", () => {
         let result: any;
         scope.run(() => {
             const queryRef = ref("quantum physics test");
-            mockFtsSearch.mockResolvedValue([{ docId: "1", score: 1, wordMatchScore: 0 }]);
+            mockFtsSearch.mockResolvedValue([makeResult("1")]);
             result = useFtsSearch(queryRef, { debounceMs: 50 });
         });
 
@@ -174,7 +175,7 @@ describe("useFtsSearch", () => {
         let result: any;
         scope.run(() => {
             const queryRef = ref("quantum physics test");
-            mockFtsSearch.mockResolvedValue([{ docId: "1", score: 1, wordMatchScore: 0 }]);
+            mockFtsSearch.mockResolvedValue([makeResult("1")]);
             result = useFtsSearch(queryRef, { debounceMs: "manual" });
         });
 
@@ -221,7 +222,7 @@ describe("useFtsSearch", () => {
         const langRef = ref("lang-eng");
         scope.run(() => {
             const queryRef = ref("quantum physics test");
-            mockFtsSearch.mockResolvedValue([{ docId: "1", score: 1, wordMatchScore: 0 }]);
+            mockFtsSearch.mockResolvedValue([makeResult("1")]);
             useFtsSearch(queryRef, { debounceMs: 50, languageId: langRef });
         });
 
@@ -250,6 +251,62 @@ describe("useFtsSearch", () => {
         await vi.advanceTimersByTimeAsync(200);
         // Search should not fire after dispose
         expect(mockFtsSearch).not.toHaveBeenCalled();
+    });
+
+    it("cancel() discards an in-flight search's results", async () => {
+        const scope = effectScope();
+        let result: any;
+        let resolveSearch: (v: ReturnType<typeof makeResult>[]) => void = () => {};
+        scope.run(() => {
+            const queryRef = ref("quantum physics test");
+            mockFtsSearch.mockReturnValue(new Promise((r) => (resolveSearch = r)));
+            result = useFtsSearch(queryRef, { debounceMs: "manual" });
+        });
+
+        result.runSearch();
+        await nextTick();
+        expect(result.isSearching.value).toBe(true);
+
+        // User clears the query / hits revert before the search resolves.
+        result.cancel();
+        expect(result.isSearching.value).toBe(false);
+
+        // The slow search now resolves — its results must be discarded.
+        resolveSearch([makeResult("stale")]);
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(result.results.value).toEqual([]);
+        scope.stop();
+    });
+
+    it("query change invalidates an in-flight search before debounce fires", async () => {
+        const scope = effectScope();
+        let result: any;
+        let resolveFirst: (v: ReturnType<typeof makeResult>[]) => void = () => {};
+        const queryRef = ref("first query");
+        scope.run(() => {
+            mockFtsSearch.mockReturnValueOnce(new Promise((r) => (resolveFirst = r)));
+            mockFtsSearch.mockResolvedValue([makeResult("new")]);
+            result = useFtsSearch(queryRef, { debounceMs: 50 });
+        });
+
+        // First debounced search starts and hangs.
+        await vi.advanceTimersByTimeAsync(60);
+        expect(result.isSearching.value).toBe(true);
+
+        // User keeps typing — query changes before the slow first search resolves.
+        queryRef.value = "second query";
+        await nextTick();
+
+        // Stale first search resolves; must be discarded.
+        resolveFirst([makeResult("stale")]);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(result.results.value).not.toContainEqual(expect.objectContaining({ docId: "stale" }));
+
+        // New debounced search proceeds normally.
+        await vi.advanceTimersByTimeAsync(60);
+        expect(result.results.value).toEqual([makeResult("new")]);
+        scope.stop();
     });
 
     it("reactive debounceMs ref restarts watcher on change", async () => {

--- a/shared/src/fts/useFtsSearch.ts
+++ b/shared/src/fts/useFtsSearch.ts
@@ -19,6 +19,8 @@ export type UseFtsSearchReturn = {
     lastSearchedQuery: Ref<string>;
     /** Run a search immediately (useful for manual mode and forcing refresh on reopen). */
     runSearch: () => void;
+    /** Invalidate any in-flight search and cancel a pending debounced run. Does not clear results. */
+    cancel: () => void;
 };
 
 /**
@@ -105,6 +107,16 @@ export function useFtsSearch(
         doSearch(q, 0, false);
     }
 
+    function cancel() {
+        // Bumping the generation invalidates any in-flight doSearch so its results are discarded.
+        searchGeneration++;
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = undefined;
+        }
+        isSearching.value = false;
+    }
+
     let stopQueryWatch: WatchStopHandle | null = null;
 
     function startQueryWatch() {
@@ -116,6 +128,9 @@ export function useFtsSearch(
             queryRef,
             (newQuery) => {
                 if (debounceTimer) clearTimeout(debounceTimer);
+                // Invalidate any in-flight search before the debounce, so a slow previous
+                // doSearch can't publish stale results after the query has changed.
+                searchGeneration++;
                 currentQuery = newQuery;
                 const d = getDebounce();
                 debounceTimer = setTimeout(() => {
@@ -158,5 +173,6 @@ export function useFtsSearch(
         totalLoaded,
         lastSearchedQuery,
         runSearch,
+        cancel,
     };
 }


### PR DESCRIPTION
The `ftsSearch` function now returns the matched `ContentDto` object along with the search result. This avoids the need for the client to refetch the document after a search, improving performance and simplifying the codebase.

The `FtsSearchResult` type has been updated to include the `doc` property.

The `SearchModal` component has been updated to utilize the `doc` property, removing the need to fetch documents separately.