### PR TITLE
APP: Refactor syncLocalChanges to drain queue sequentially

### DIFF
--- a/shared/src/rest/syncLocalChanges.spec.ts
+++ b/shared/src/rest/syncLocalChanges.spec.ts
@@ -4,7 +4,7 @@ import { ref } from "vue";
 import { AckStatus, ChangeReqDto, DocType, LocalChangeDto } from "../types";
 import { db, initDatabase } from "../db/database";
 import { getSocket, isConnected } from "../socket/socketio";
-import { initConfig } from "../config";
+import { changeReqErrors, initConfig } from "../config";
 import { Server } from "socket.io";
 import waitForExpect from "wait-for-expect";
 import * as RestApi from "../rest/RestApi";
@@ -60,6 +60,7 @@ describe("syncLocalChanges", () => {
 
         await db.docs.clear();
         await db.localChanges.clear();
+        changeReqErrors.value = [];
 
         // Make sure the connection state is clean for the next test.
         await waitForExpect(() => expect(isConnected.value).toBe(false));
@@ -219,6 +220,47 @@ describe("syncLocalChanges", () => {
             return JSON.parse(entry![1] as string).id;
         });
         expect(new Set(sentIds)).toEqual(new Set([10]));
+    });
+
+    it("surfaces an error to changeReqErrors after exhausting retries", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const failing: ChangeReqDto = {
+            id: 100,
+            doc: { _id: "fail-error", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        changeRequestMock
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined);
+
+        expect(changeReqErrors.value).toEqual([]);
+
+        await db.localChanges.put(failing);
+
+        await waitForExpect(() => {
+            expect(changeReqErrors.value.length).toBe(1);
+            expect(changeReqErrors.value[0]).toMatch(/refresh/i);
+        });
+    });
+
+    it("clears changeReqErrors on a successful ack", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        changeReqErrors.value = ["stale error from a previous attempt"];
+
+        changeRequestMock.mockResolvedValueOnce(ack(110));
+        await db.localChanges.put({
+            id: 110,
+            doc: { _id: "ok", type: DocType.Post, updatedTimeUtc: 1 },
+        } as ChangeReqDto);
+
+        await waitForExpect(async () => {
+            expect(await db.localChanges.count()).toBe(0);
+            expect(changeReqErrors.value).toEqual([]);
+        });
     });
 
     it("self-heals a transient failure within the retry cap and keeps draining", async () => {

--- a/shared/src/rest/syncLocalChanges.spec.ts
+++ b/shared/src/rest/syncLocalChanges.spec.ts
@@ -348,7 +348,8 @@ describe("syncLocalChanges", () => {
         await wait(200);
         expect(changeRequestMock).toHaveBeenCalledTimes(1);
 
-        // Release the first one — drain should pick up c2 in the same pass.
+        // Release the first one — the c1 ack mutates the queue, refiring the
+        // watcher, which drains c2.
         changeRequestMock.mockResolvedValueOnce(ack(40));
         resolveFirst(ack(40));
 

--- a/shared/src/rest/syncLocalChanges.spec.ts
+++ b/shared/src/rest/syncLocalChanges.spec.ts
@@ -3,19 +3,19 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { ref } from "vue";
 import { AckStatus, ChangeReqDto, DocType, LocalChangeDto } from "../types";
 import { db, initDatabase } from "../db/database";
-import { getSocket } from "../socket/socketio";
+import { getSocket, isConnected } from "../socket/socketio";
 import { initConfig } from "../config";
 import { Server } from "socket.io";
 import waitForExpect from "wait-for-expect";
 import * as RestApi from "../rest/RestApi";
 import { useDexieLiveQuery } from "../util";
-import { processChangeReqLock, syncLocalChanges } from "./syncLocalChanges";
+import { syncLocalChanges } from "./syncLocalChanges";
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const changeRequestMock = vi.fn();
 
-describe("localChanges", () => {
+describe("syncLocalChanges", () => {
     const socketServer = new Server(12344);
 
     beforeAll(async () => {
@@ -23,51 +23,25 @@ describe("localChanges", () => {
             cms: true,
             docsIndex: "parentId, language, [type+docType]",
             syncList: [
-                {
-                    type: DocType.Tag,
-                    syncPriority: 2,
-                    skipWaitForLanguageSync: true,
-                },
-                {
-                    type: DocType.Post,
-                    syncPriority: 2,
-                    skipWaitForLanguageSync: true,
-                },
-                {
-                    type: DocType.Redirect,
-                    syncPriority: 2,
-                    skipWaitForLanguageSync: true,
-                },
-                {
-                    type: DocType.Language,
-                    syncPriority: 1,
-                    skipWaitForLanguageSync: true,
-                },
-                {
-                    type: DocType.Group,
-                    syncPriority: 1,
-                    skipWaitForLanguageSync: true,
-                },
-                {
-                    type: DocType.User,
-                    sync: false,
-                },
+                { type: DocType.Tag, syncPriority: 2, skipWaitForLanguageSync: true },
+                { type: DocType.Post, syncPriority: 2, skipWaitForLanguageSync: true },
+                { type: DocType.Redirect, syncPriority: 2, skipWaitForLanguageSync: true },
+                { type: DocType.Language, syncPriority: 1, skipWaitForLanguageSync: true },
+                { type: DocType.Group, syncPriority: 1, skipWaitForLanguageSync: true },
+                { type: DocType.User, sync: false },
             ],
             apiUrl: "http://localhost:12344",
             appLanguageIdsAsRef: ref([]),
         });
 
-        // Initialize the IndexedDB database
         await initDatabase();
 
-        // initialize the socket client
         const socket = getSocket();
 
         vi.spyOn(RestApi, "getRest").mockReturnValue({
             changeRequest: changeRequestMock,
         } as unknown as any);
 
-        // Initialize syncLocalChanges since we're mocking getRest()
         const localChanges = useDexieLiveQuery(
             () => db.localChanges.toArray() as unknown as Promise<LocalChangeDto[]>,
             { initialValue: [] as unknown as LocalChangeDto[] },
@@ -78,259 +52,439 @@ describe("localChanges", () => {
     });
 
     afterEach(async () => {
-        vi.clearAllMocks();
+        // Reset (not just clear) so any leftover mockResolvedValueOnce/mockImplementationOnce
+        // entries from a previous test don't bleed into the next one.
+        changeRequestMock.mockReset();
         getSocket().disconnect();
         socketServer.removeAllListeners();
 
         await db.docs.clear();
         await db.localChanges.clear();
+
+        // Make sure the connection state is clean for the next test.
+        await waitForExpect(() => expect(isConnected.value).toBe(false));
     });
 
     afterAll(async () => {
         vi.restoreAllMocks();
-
-        // Clear the database after each test
         await db.docs.clear();
         await db.localChanges.clear();
     });
 
-    // No global lock mutation; let implementation manage it.
-
-    it("sends a change request if there are local changes", async () => {
-        // Simulate server connection
+    const connect = () => {
         socketServer.on("connection", (socket) => {
             socket.emit("clientConfig", {});
         });
         getSocket({ reconnect: true });
+    };
 
-        // Add a local change
-        const localChange = {
+    const ack = (id: number, status: AckStatus = AckStatus.Accepted) => ({ id, ack: status });
+
+    // --- Core behaviour preserved from the previous implementation ---
+
+    it("sends a change request when there are local changes and we are online", async () => {
+        connect();
+
+        const localChange: ChangeReqDto = {
             id: 1234,
             doc: { _id: "test-doc", type: DocType.Post, updatedTimeUtc: 1234 },
         };
-
-        // Ack response so item removed
-        changeRequestMock.mockResolvedValueOnce({ id: 1234, ack: AckStatus.Accepted });
+        changeRequestMock.mockResolvedValueOnce(ack(1234));
 
         await db.localChanges.put(localChange);
 
-        // Assert that the changeRequestMock was called with the correct data
         await waitForExpect(async () => {
             expect(changeRequestMock).toHaveBeenCalled();
-
             const formData = changeRequestMock.mock.calls[0][0] as FormData;
-            const entries = [...formData.entries()];
-            expect(entries).toEqual(
+            expect([...formData.entries()]).toEqual(
                 expect.arrayContaining([
-                    [
-                        "changeRequest__json",
-                        JSON.stringify({
-                            id: 1234,
-                            doc: { _id: "test-doc", type: "post", updatedTimeUtc: 1234 },
-                        }),
-                    ],
+                    ["changeRequest__json", JSON.stringify(localChange)],
                 ]),
             );
         });
     });
 
-    it("handles acks for changes", async () => {
-        changeRequestMock.mockResolvedValueOnce({ id: 1234, ack: AckStatus.Accepted });
-
-        // Create a local change
+    it("removes the local change from the queue once acked", async () => {
+        changeRequestMock.mockResolvedValueOnce(ack(1234));
         await db.localChanges.put({
-            docId: "",
             id: 1234,
             doc: { _id: "test-doc", type: DocType.Post, updatedTimeUtc: 1234 },
         });
-        const localChange = await db.localChanges.get(1234);
-        expect(localChange).toBeDefined();
+        expect(await db.localChanges.get(1234)).toBeDefined();
 
-        // Mock the ack from the server
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-
-        getSocket({ reconnect: true });
+        connect();
 
         await waitForExpect(async () => {
-            // Check if the local change was removed
-            const res = await db.localChanges.get(1234);
-            expect(res).toBeUndefined();
+            expect(await db.localChanges.get(1234)).toBeUndefined();
             expect(await db.localChanges.count()).toBe(0);
         });
     });
 
-    it("will immediately sync when online", async () => {
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-
-        // Connect to the server
-        getSocket({ reconnect: true });
-
-        const localChange = {
-            docId: "1234",
+    it("queues changes while offline and drains them on reconnect", async () => {
+        const localChange: ChangeReqDto = {
             id: 1234,
             doc: { _id: "test-doc", type: DocType.Post, updatedTimeUtc: 1234 },
         };
+        changeRequestMock.mockResolvedValueOnce(ack(1234));
 
-        // Create a local change
-        changeRequestMock.mockResolvedValueOnce({ id: localChange.id, ack: AckStatus.Accepted });
         await db.localChanges.put(localChange);
 
-        await waitForExpect(async () => {
-            expect(changeRequestMock).toHaveBeenCalled();
-            expect(await db.localChanges.count()).toBe(0);
-        });
-
-        // Check if the server received the change request
-        await waitForExpect(async () => {
-            const formData = changeRequestMock.mock.calls[0][0] as any;
-            const entries = [...formData.entries()];
-            expect(entries).toEqual(
-                expect.arrayContaining([["changeRequest__json", JSON.stringify(localChange)]]),
-            );
-        });
-    });
-
-    it("will start syncing when coming online after being offline", async () => {
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-
-        const localChange = {
-            id: 1234,
-            doc: { _id: "test-doc", type: DocType.Post, updatedTimeUtc: 1234 },
-        };
-
-        // Store while offline
-        changeRequestMock.mockResolvedValueOnce({ id: localChange.id, ack: AckStatus.Accepted });
-        await db.localChanges.put(localChange);
-        const stored = await db.localChanges.get(1234);
-        expect(stored).toBeDefined();
-
-        // Ensure not synced before connecting
-        await wait(500);
+        // Nothing should be sent while offline.
+        await wait(300);
         expect(changeRequestMock).not.toHaveBeenCalled();
 
-        // Now connect
-        getSocket({ reconnect: true });
-
-        // Wait and validate sync
-        await waitForExpect(async () => {
-            expect(changeRequestMock).toHaveBeenCalled();
-
-            const formData = changeRequestMock.mock.calls[0][0] as any;
-            const entries = [...formData.entries()];
-            expect(entries).toEqual(
-                expect.arrayContaining([["changeRequest__json", JSON.stringify(localChange)]]),
-            );
-            expect(await db.localChanges.count()).toBe(0);
-        });
-    });
-
-    it("will not sync via the watcher if the processChangeReqLock is on", async () => {
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-
-        // Connect to the server
-        getSocket({ reconnect: true });
-
-        // Create multiple local changes
-        const localChange1: ChangeReqDto = {
-            id: 1234,
-            doc: { _id: "test-doc", type: DocType.Post, updatedTimeUtc: 1234 },
-        };
-        const localChange2: ChangeReqDto = {
-            id: 1235,
-            doc: { _id: "test-doc2", type: DocType.Post, updatedTimeUtc: 1234 },
-        };
-        await db.localChanges.bulkPut([localChange1, localChange2]);
-
-        // Check that the server should not receive the second localChange, but only the first
-        await wait(2000);
-        await waitForExpect(async () => {
-            expect(changeRequestMock).not.toHaveBeenCalledWith({ id: 1235 });
-        });
-    });
-
-    it("syncs pending offline change after reconnect", async () => {
-        // Arrange: simulate prior state with lock engaged while offline
-        getSocket().disconnect();
-        processChangeReqLock.value = true;
-
-        const localChange = {
-            id: 7777,
-            doc: { _id: "race-doc", type: DocType.Post, updatedTimeUtc: Date.now() },
-        } as ChangeReqDto;
-        changeRequestMock.mockResolvedValueOnce({ id: localChange.id, ack: AckStatus.Accepted });
-        await db.localChanges.put(localChange);
-        expect(await db.localChanges.get(localChange.id)).toBeDefined();
-
-        // Act: reconnect (isConnected watcher releases the lock and triggers attemptSync directly)
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-        getSocket({ reconnect: true });
+        connect();
 
         await waitForExpect(async () => {
-            expect(changeRequestMock).toHaveBeenCalled();
-            const formData = changeRequestMock.mock.calls[0][0] as FormData;
-            const entries = [...formData.entries()];
-            expect(entries).toEqual(
-                expect.arrayContaining([["changeRequest__json", JSON.stringify(localChange)]]),
-            );
-            expect(await db.localChanges.count()).toBe(0);
-        });
-    });
-
-    it("releases the lock and resumes attempts after a failed push", async () => {
-        socketServer.on("connection", (socket) => {
-            socket.emit("clientConfig", {});
-        });
-        getSocket({ reconnect: true });
-
-        // Let the reconnect watcher settle the lock before queuing changes,
-        // otherwise a late isConnected change races our localChanges mutation
-        // and the second watcher re-triggers the push.
-        await waitForExpect(() => {
-            expect(processChangeReqLock.value).toBe(false);
-        });
-
-        const failingChange: ChangeReqDto = {
-            id: 8888,
-            doc: { _id: "fail-doc", type: DocType.Post, updatedTimeUtc: Date.now() },
-        };
-
-        // First push: no ack (HTTP failure surfaces as undefined from http.post).
-        changeRequestMock.mockResolvedValueOnce(undefined);
-
-        await db.localChanges.put(failingChange);
-
-        // After the failure the lock must be released so a subsequent
-        // localChanges mutation can drive another attempt.
-        await waitForExpect(() => {
             expect(changeRequestMock).toHaveBeenCalledTimes(1);
-            expect(processChangeReqLock.value).toBe(false);
+            expect(await db.localChanges.count()).toBe(0);
         });
-        expect(await db.localChanges.get(failingChange.id)).toBeDefined();
+    });
 
-        // A new local change mutation triggers the watcher and re-attempts the
-        // queue head — this time with an accepted ack that drains it.
-        changeRequestMock.mockResolvedValueOnce({
-            id: failingChange.id,
-            ack: AckStatus.Accepted,
-        });
-        const followupChange: ChangeReqDto = {
-            id: 8889,
-            doc: { _id: "followup-doc", type: DocType.Post, updatedTimeUtc: Date.now() },
+    // --- New: drain loop processes the whole queue without per-item re-entry ---
+
+    it("drains multiple queued changes sequentially in a single pass", async () => {
+        const c1: ChangeReqDto = {
+            id: 1,
+            doc: { _id: "a", type: DocType.Post, updatedTimeUtc: 1 },
         };
-        await db.localChanges.put(followupChange);
+        const c2: ChangeReqDto = {
+            id: 2,
+            doc: { _id: "b", type: DocType.Post, updatedTimeUtc: 2 },
+        };
+        const c3: ChangeReqDto = {
+            id: 3,
+            doc: { _id: "c", type: DocType.Post, updatedTimeUtc: 3 },
+        };
+        changeRequestMock
+            .mockResolvedValueOnce(ack(1))
+            .mockResolvedValueOnce(ack(2))
+            .mockResolvedValueOnce(ack(3));
+
+        await db.localChanges.bulkPut([c1, c2, c3]);
+
+        connect();
 
         await waitForExpect(async () => {
-            expect(await db.localChanges.get(failingChange.id)).toBeUndefined();
+            expect(changeRequestMock).toHaveBeenCalledTimes(3);
+            expect(await db.localChanges.count()).toBe(0);
         });
+
+        // Order should be FIFO — first call carries c1, then c2, then c3.
+        const sentIds = changeRequestMock.mock.calls.map((call) => {
+            const fd = call[0] as FormData;
+            const entry = [...fd.entries()].find(([k]) => k === "changeRequest__json");
+            return JSON.parse(entry![1] as string).id;
+        });
+        expect(sentIds).toEqual([1, 2, 3]);
+    });
+
+    // --- Failure / recovery semantics ---
+
+    it("retries the head 3 times on non-ack, then bails without touching the rest", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const c1: ChangeReqDto = {
+            id: 10,
+            doc: { _id: "x", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        const c2: ChangeReqDto = {
+            id: 11,
+            doc: { _id: "y", type: DocType.Post, updatedTimeUtc: 2 },
+        };
+
+        // All three attempts on c1 return no ack. After the cap, drain bails
+        // without ever touching c2.
+        changeRequestMock
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined);
+
+        await db.localChanges.bulkPut([c1, c2]);
+
+        await waitForExpect(() => {
+            expect(changeRequestMock).toHaveBeenCalledTimes(3);
+        });
+
+        // Drain should not keep retrying past the cap.
+        await wait(300);
+        expect(changeRequestMock).toHaveBeenCalledTimes(3);
+        expect(await db.localChanges.count()).toBe(2);
+
+        // Every call was for c1 — c2 was never attempted.
+        const sentIds = changeRequestMock.mock.calls.map((call) => {
+            const fd = call[0] as FormData;
+            const entry = [...fd.entries()].find(([k]) => k === "changeRequest__json");
+            return JSON.parse(entry![1] as string).id;
+        });
+        expect(new Set(sentIds)).toEqual(new Set([10]));
+    });
+
+    it("self-heals a transient failure within the retry cap and keeps draining", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const c1: ChangeReqDto = {
+            id: 15,
+            doc: { _id: "flaky", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        const c2: ChangeReqDto = {
+            id: 16,
+            doc: { _id: "next", type: DocType.Post, updatedTimeUtc: 2 },
+        };
+
+        // c1: two failures then a success on the third attempt.
+        // c2: succeeds first try. attempts counter must reset after c1 acks.
+        changeRequestMock
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(ack(15))
+            .mockResolvedValueOnce(ack(16));
+
+        await db.localChanges.bulkPut([c1, c2]);
+
+        await waitForExpect(async () => {
+            expect(changeRequestMock).toHaveBeenCalledTimes(4);
+            expect(await db.localChanges.count()).toBe(0);
+        });
+    });
+
+    it("retries the failed item on the next localChanges mutation", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const failing: ChangeReqDto = {
+            id: 20,
+            doc: { _id: "fail", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        // Three non-acks burn through the retry cap.
+        changeRequestMock
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined);
+
+        await db.localChanges.put(failing);
+
+        await waitForExpect(() => expect(changeRequestMock).toHaveBeenCalledTimes(3));
+        expect(await db.localChanges.get(failing.id)).toBeDefined();
+
+        // New mutation -> watcher fires -> drain re-enters with a fresh attempt
+        // counter; this time both acked.
+        changeRequestMock
+            .mockResolvedValueOnce(ack(20))
+            .mockResolvedValueOnce(ack(21));
+
+        await db.localChanges.put({
+            id: 21,
+            doc: { _id: "next", type: DocType.Post, updatedTimeUtc: 2 },
+        } as ChangeReqDto);
+
+        await waitForExpect(async () => {
+            expect(await db.localChanges.count()).toBe(0);
+        });
+    });
+
+    it("retries the failed item on reconnect", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const failing: ChangeReqDto = {
+            id: 30,
+            doc: { _id: "fail-r", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        // Burn through the cap so drain stops on its own.
+        changeRequestMock
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined);
+
+        await db.localChanges.put(failing);
+
+        await waitForExpect(() => expect(changeRequestMock).toHaveBeenCalledTimes(3));
+        expect(await db.localChanges.get(failing.id)).toBeDefined();
+
+        // Disconnect then reconnect — the isConnected watcher should re-enter drain.
+        getSocket().disconnect();
+        await waitForExpect(() => expect(isConnected.value).toBe(false));
+
+        changeRequestMock.mockResolvedValueOnce(ack(30));
+        connect();
+
+        await waitForExpect(async () => {
+            expect(await db.localChanges.get(failing.id)).toBeUndefined();
+        });
+    });
+
+    // --- Re-entrancy and concurrency ---
+
+    it("does not start a concurrent drain when mutations land mid-flight", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        let resolveFirst: (v: unknown) => void = () => {};
+        changeRequestMock.mockImplementationOnce(
+            () => new Promise((resolve) => (resolveFirst = resolve)),
+        );
+
+        const c1: ChangeReqDto = {
+            id: 40,
+            doc: { _id: "slow", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        await db.localChanges.put(c1);
+
+        // Wait for the first push to be in flight.
+        await waitForExpect(() => expect(changeRequestMock).toHaveBeenCalledTimes(1));
+
+        // Queue another change while the first is still pending. The watcher
+        // will fire but the running guard should keep us at one in-flight push.
+        const c2: ChangeReqDto = {
+            id: 41,
+            doc: { _id: "follow", type: DocType.Post, updatedTimeUtc: 2 },
+        };
+        changeRequestMock.mockResolvedValueOnce(ack(41));
+        await db.localChanges.put(c2);
+
+        await wait(200);
+        expect(changeRequestMock).toHaveBeenCalledTimes(1);
+
+        // Release the first one — drain should pick up c2 in the same pass.
+        changeRequestMock.mockResolvedValueOnce(ack(40));
+        resolveFirst(ack(40));
+
+        await waitForExpect(async () => {
+            expect(changeRequestMock).toHaveBeenCalledTimes(2);
+            expect(await db.localChanges.count()).toBe(0);
+        });
+    });
+
+    it("stops the drain loop when the connection drops mid-pass", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const c1: ChangeReqDto = {
+            id: 50,
+            doc: { _id: "p1", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        const c2: ChangeReqDto = {
+            id: 51,
+            doc: { _id: "p2", type: DocType.Post, updatedTimeUtc: 2 },
+        };
+
+        let resolveFirst: (v: unknown) => void = () => {};
+        changeRequestMock.mockImplementationOnce(
+            () => new Promise((resolve) => (resolveFirst = resolve)),
+        );
+
+        await db.localChanges.bulkPut([c1, c2]);
+
+        await waitForExpect(() => expect(changeRequestMock).toHaveBeenCalledTimes(1));
+
+        // Disconnect before the first request resolves; ack still arrives.
+        getSocket().disconnect();
+        await waitForExpect(() => expect(isConnected.value).toBe(false));
+
+        resolveFirst(ack(50));
+
+        // c1 is acked & removed, but c2 must NOT be pushed while offline.
+        await waitForExpect(async () => {
+            expect(await db.localChanges.get(50)).toBeUndefined();
+        });
+        await wait(200);
+        expect(changeRequestMock).toHaveBeenCalledTimes(1);
+        expect(await db.localChanges.get(51)).toBeDefined();
+    });
+
+    // --- Throw recovery: the running flag must reset on any exception ---
+
+    it("recovers when the api call rejects (running flag resets)", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        changeRequestMock.mockRejectedValueOnce(new Error("boom"));
+
+        const c1: ChangeReqDto = {
+            id: 60,
+            doc: { _id: "throws", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        await db.localChanges.put(c1);
+
+        // Wait for the throwing call to settle.
+        await waitForExpect(() => expect(changeRequestMock).toHaveBeenCalledTimes(1));
+        await wait(50);
+        expect(await db.localChanges.get(60)).toBeDefined();
+
+        // Next mutation must drive a new drain — that only works if the running
+        // flag was reset by the finally block.
+        changeRequestMock
+            .mockResolvedValueOnce(ack(60))
+            .mockResolvedValueOnce(ack(61));
+        await db.localChanges.put({
+            id: 61,
+            doc: { _id: "after", type: DocType.Post, updatedTimeUtc: 2 },
+        } as ChangeReqDto);
+
+        await waitForExpect(async () => {
+            expect(await db.localChanges.count()).toBe(0);
+        });
+    });
+
+    it("recovers when applyLocalChangeAck rejects (running flag resets)", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        const applySpy = vi
+            .spyOn(db, "applyLocalChangeAck")
+            .mockRejectedValueOnce(new Error("dexie blew up"));
+
+        changeRequestMock.mockResolvedValueOnce(ack(70));
+        const c1: ChangeReqDto = {
+            id: 70,
+            doc: { _id: "ack-throw", type: DocType.Post, updatedTimeUtc: 1 },
+        };
+        await db.localChanges.put(c1);
+
+        await waitForExpect(() => expect(applySpy).toHaveBeenCalledTimes(1));
+        await wait(50);
+
+        // The first change is still in the queue because the ack write failed.
+        expect(await db.localChanges.get(70)).toBeDefined();
+
+        // After restoring normal behaviour, a new mutation must trigger drain
+        // again — proving the running flag was reset by finally.
+        applySpy.mockRestore();
+        changeRequestMock
+            .mockResolvedValueOnce(ack(70))
+            .mockResolvedValueOnce(ack(71));
+
+        await db.localChanges.put({
+            id: 71,
+            doc: { _id: "after-throw", type: DocType.Post, updatedTimeUtc: 2 },
+        } as ChangeReqDto);
+
+        await waitForExpect(async () => {
+            expect(await db.localChanges.count()).toBe(0);
+        });
+    });
+
+    // --- Idle conditions ---
+
+    it("does nothing when there are no local changes", async () => {
+        connect();
+        await waitForExpect(() => expect(isConnected.value).toBe(true));
+
+        await wait(200);
+        expect(changeRequestMock).not.toHaveBeenCalled();
+    });
+
+    it("does nothing while offline even with queued changes", async () => {
+        await db.localChanges.put({
+            id: 80,
+            doc: { _id: "offline-only", type: DocType.Post, updatedTimeUtc: 1 },
+        } as ChangeReqDto);
+
+        await wait(300);
+        expect(changeRequestMock).not.toHaveBeenCalled();
+        expect(await db.localChanges.get(80)).toBeDefined();
     });
 });

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -8,40 +8,26 @@ import { changeReqErrors, changeReqWarnings } from "../config";
 
 let running = false;
 
-/**
- * Drain pending local changes one-at-a-time while online. Exits on empty
- * queue, disconnect, or a non-ack response. The watcher re-enters on the
- * next localChanges mutation or reconnect.
- *
- * We read the head of the queue from the db (not the ref) so that we see
- * the result of `applyLocalChangeAck` immediately — the Dexie live query
- * refreshes async, so the ref would be one step behind inside the loop.
- */
 async function drain() {
     if (running) return;
     running = true;
-    let attempts = 0;
     try {
-        while (isConnected.value) {
-            const change = (await db.localChanges.toCollection().first()) as
-                | LocalChangeDto
-                | undefined;
-            if (!change) return;
+        const change = (await db.localChanges.toCollection().first()) as LocalChangeDto | undefined;
+        if (!change) return;
 
-            const formData = new LFormData();
-            formData.append("changeRequest", change);
+        const formData = new LFormData();
+        formData.append("changeRequest", change);
 
+        for (let attempts = 0; attempts < 3; attempts++) {
+            if (!isConnected.value) return;
             const res = (await getRest().changeRequest(formData)) as ChangeReqAckDto | undefined;
-            if (!res) {
-                if (++attempts >= 3) return;
-                await new Promise((r) => setTimeout(r, 100));
-                continue;
+            if (res) {
+                changeReqWarnings.value = [];
+                changeReqErrors.value = [];
+                await db.applyLocalChangeAck(res, change);
+                return;
             }
-            attempts = 0;
-
-            changeReqWarnings.value = [];
-            changeReqErrors.value = [];
-            await db.applyLocalChangeAck(res, change);
+            if (attempts < 2) await new Promise((r) => setTimeout(r, 100));
         }
     } finally {
         running = false;
@@ -52,6 +38,7 @@ export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
     watch(
         [isConnected, localChanges],
         () => {
+            if (!isConnected.value || localChanges.value.length === 0) return;
             drain().catch((err) => console.error("syncLocalChanges drain error:", err));
         },
         { immediate: true },

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -29,20 +29,31 @@ export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
             if (running) return;
             running = true;
             try {
-                const change = (await db.localChanges.toCollection().first()) as
-                    | LocalChangeDto
-                    | undefined;
-                if (!change) return;
+                while (isConnected.value) {
+                    const change = (await db.localChanges.toCollection().first()) as
+                        | LocalChangeDto
+                        | undefined;
+                    if (!change) return;
 
-                for (let attempt = 0; attempt < 3; attempt++) {
-                    if (!isConnected.value) return;
-                    if (await send(change)) return;
-                    if (attempt < 2) await new Promise((r) => setTimeout(r, 100));
+                    let sent = false;
+                    for (let attempt = 0; attempt < 3; attempt++) {
+                        if (!isConnected.value) return;
+                        if (await send(change)) {
+                            sent = true;
+                            break;
+                        }
+                        if (attempt < 2) await new Promise((r) => setTimeout(r, 100));
+                    }
+
+                    // The head failed every attempt; stop without touching the rest of
+                    // the queue so order is preserved and we don't hammer the API.
+                    if (!sent) {
+                        changeReqErrors.value.push(
+                            "Unable to submit saved changes. Please refresh the page to try again.",
+                        );
+                        return;
+                    }
                 }
-
-                changeReqErrors.value.push(
-                    "Unable to submit saved changes. Please refresh the page to try again.",
-                );
             } catch (err) {
                 console.error("syncLocalChanges error:", err);
             } finally {

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -8,38 +8,50 @@ import { changeReqErrors, changeReqWarnings } from "../config";
 
 let running = false;
 
-async function drain() {
-    if (running) return;
-    running = true;
-    try {
-        const change = (await db.localChanges.toCollection().first()) as LocalChangeDto | undefined;
-        if (!change) return;
-
-        const formData = new LFormData();
-        formData.append("changeRequest", change);
-
-        for (let attempts = 0; attempts < 3; attempts++) {
-            if (!isConnected.value) return;
-            const res = (await getRest().changeRequest(formData)) as ChangeReqAckDto | undefined;
-            if (res) {
-                changeReqWarnings.value = [];
-                changeReqErrors.value = [];
-                await db.applyLocalChangeAck(res, change);
-                return;
-            }
-            if (attempts < 2) await new Promise((r) => setTimeout(r, 100));
-        }
-    } finally {
-        running = false;
+async function attemptSend(
+    change: LocalChangeDto,
+    formData: LFormData,
+    attempts: number,
+): Promise<void> {
+    const res = (await getRest().changeRequest(formData)) as ChangeReqAckDto | undefined;
+    if (res) {
+        changeReqWarnings.value = [];
+        changeReqErrors.value = [];
+        await db.applyLocalChangeAck(res, change);
+        return;
     }
+    if (attempts >= 2) {
+        changeReqErrors.value.push(
+            "Unable to save changes. Please refresh the page and try again.",
+        );
+        return;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+    return attemptSend(change, formData, attempts + 1);
 }
 
 export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
     watch(
         [isConnected, localChanges],
-        () => {
+        async () => {
             if (!isConnected.value || localChanges.value.length === 0) return;
-            drain().catch((err) => console.error("syncLocalChanges drain error:", err));
+            if (running) return;
+            running = true;
+            try {
+                const change = (await db.localChanges.toCollection().first()) as
+                    | LocalChangeDto
+                    | undefined;
+                if (!change) return;
+
+                const formData = new LFormData();
+                formData.append("changeRequest", change);
+
+                await attemptSend(change, formData, 0);
+            } catch (err) {
+                console.error("syncLocalChanges error:", err);
+            } finally {
+                running = false;
+            }
         },
         { immediate: true },
     );

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -8,26 +8,17 @@ import { changeReqErrors, changeReqWarnings } from "../config";
 
 let running = false;
 
-async function attemptSend(
-    change: LocalChangeDto,
-    formData: LFormData,
-    attempts: number,
-): Promise<void> {
+async function send(change: LocalChangeDto): Promise<boolean> {
+    const formData = new LFormData();
+    formData.append("changeRequest", change);
+
     const res = (await getRest().changeRequest(formData)) as ChangeReqAckDto | undefined;
-    if (res) {
-        changeReqWarnings.value = [];
-        changeReqErrors.value = [];
-        await db.applyLocalChangeAck(res, change);
-        return;
-    }
-    if (attempts >= 2) {
-        changeReqErrors.value.push(
-            "Unable to save changes. Please refresh the page and try again.",
-        );
-        return;
-    }
-    await new Promise((r) => setTimeout(r, 100));
-    return attemptSend(change, formData, attempts + 1);
+    if (!res) return false;
+
+    changeReqWarnings.value = [];
+    changeReqErrors.value = [];
+    await db.applyLocalChangeAck(res, change);
+    return true;
 }
 
 export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
@@ -43,10 +34,15 @@ export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
                     | undefined;
                 if (!change) return;
 
-                const formData = new LFormData();
-                formData.append("changeRequest", change);
+                for (let attempt = 0; attempt < 3; attempt++) {
+                    if (!isConnected.value) return;
+                    if (await send(change)) return;
+                    await new Promise((r) => setTimeout(r, 100));
+                }
 
-                await attemptSend(change, formData, 0);
+                changeReqErrors.value.push(
+                    "Unable to save changes. Please refresh the page and try again.",
+                );
             } catch (err) {
                 console.error("syncLocalChanges error:", err);
             } finally {

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -1,4 +1,4 @@
-import { ref, watch, type Ref } from "vue";
+import { watch, type Ref } from "vue";
 import { isConnected } from "../socket/socketio";
 import { getRest } from "./RestApi";
 import { ChangeReqAckDto, LocalChangeDto } from "../types";
@@ -6,67 +6,54 @@ import { db } from "../db/database";
 import { LFormData } from "../util/LFormData";
 import { changeReqErrors, changeReqWarnings } from "../config";
 
-/**
- * Lock to prevent multiple change requests from being processed at the same time
- * This is set to true when a change request is being processed and false when it is done
- * as change requests are asynchronous operations that can take time to complete.
- */
-export const processChangeReqLock = ref(false); // start unlocked so first change can go through
+let running = false;
 
 /**
- * Handle change request acknowledgements from the api
- * @param ack ack from api
- * @param localChange the local change that was sent (for reference)
+ * Drain pending local changes one-at-a-time while online. Exits on empty
+ * queue, disconnect, or a non-ack response. The watcher re-enters on the
+ * next localChanges mutation or reconnect.
+ *
+ * We read the head of the queue from the db (not the ref) so that we see
+ * the result of `applyLocalChangeAck` immediately — the Dexie live query
+ * refreshes async, so the ref would be one step behind inside the loop.
  */
-async function handleAck(ack: ChangeReqAckDto, localChange: LocalChangeDto) {
-    // Clear previous warnings and errors
-    changeReqWarnings.value = [];
-    changeReqErrors.value = [];
+async function drain() {
+    if (running) return;
+    running = true;
+    let attempts = 0;
+    try {
+        while (isConnected.value) {
+            const change = (await db.localChanges.toCollection().first()) as
+                | LocalChangeDto
+                | undefined;
+            if (!change) return;
 
-    await db.applyLocalChangeAck(ack, localChange);
+            const formData = new LFormData();
+            formData.append("changeRequest", change);
 
-    // Release lock; watcher will notice localChanges updated (Dexie live query) and proceed
-    processChangeReqLock.value = false;
-}
+            const res = (await getRest().changeRequest(formData)) as ChangeReqAckDto | undefined;
+            if (!res) {
+                if (++attempts >= 3) return;
+                await new Promise((r) => setTimeout(r, 100));
+                continue;
+            }
+            attempts = 0;
 
-/**
- * Push a single local change to the api
- * @param localChange the local change to push
- */
-async function pushLocalChange(localChange: LocalChangeDto) {
-    const formData = new LFormData();
-    formData.append("changeRequest", localChange);
-
-    const res = await getRest().changeRequest(formData);
-
-    if (res) handleAck(res as ChangeReqAckDto, localChange);
-    // Release the lock on a failed/non-acked push so the queue isn't stalled
-    // indefinitely. Recovery happens on the next localChanges mutation or
-    // reconnect (which both fire the watcher); we deliberately don't auto-retry
-    // here to avoid hot-looping on a persistently rejected change.
-    else processChangeReqLock.value = false;
+            changeReqWarnings.value = [];
+            changeReqErrors.value = [];
+            await db.applyLocalChangeAck(res, change);
+        }
+    } finally {
+        running = false;
+    }
 }
 
 export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
-    const attemptSync = () => {
-        if (!isConnected.value) return;
-        if (localChanges.value.length === 0) return;
-        if (processChangeReqLock.value) return; // already processing a change request
-        // Acquire lock synchronously so concurrent watcher triggers bail out
-        processChangeReqLock.value = true;
-        pushLocalChange(localChanges.value[0]);
-    };
-
-    watch([isConnected, localChanges], attemptSync, { immediate: true });
-
-    watch(isConnected, (connected) => {
-        if (!connected) {
-            // Prevent new processing while offline (existing in-flight may still resolve)
-            processChangeReqLock.value = true;
-            return;
-        }
-        // When coming online, allow processing and attempt immediately
-        processChangeReqLock.value = false;
-        attemptSync();
-    });
+    watch(
+        [isConnected, localChanges],
+        () => {
+            drain().catch((err) => console.error("syncLocalChanges drain error:", err));
+        },
+        { immediate: true },
+    );
 }

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -37,7 +37,7 @@ export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
                 for (let attempt = 0; attempt < 3; attempt++) {
                     if (!isConnected.value) return;
                     if (await send(change)) return;
-                    await new Promise((r) => setTimeout(r, 100));
+                    if (attempt < 2) await new Promise((r) => setTimeout(r, 100));
                 }
 
                 changeReqErrors.value.push(

--- a/shared/src/rest/syncLocalChanges.ts
+++ b/shared/src/rest/syncLocalChanges.ts
@@ -41,7 +41,7 @@ export function syncLocalChanges(localChanges: Ref<LocalChangeDto[]>) {
                 }
 
                 changeReqErrors.value.push(
-                    "Unable to save changes. Please refresh the page and try again.",
+                    "Unable to submit saved changes. Please refresh the page to try again.",
                 );
             } catch (err) {
                 console.error("syncLocalChanges error:", err);


### PR DESCRIPTION
The `syncLocalChanges` function has been refactored to sequentially process local changes from the database when the application is online. This change removes the `processChangeReqLock` and introduces a `drain` function that reads the head of the queue directly from the database to ensure it's always up-to-date. The watcher now triggers the `drain` function when connectivity or the local changes array changes.