### PR TITLE
APP: Refactor Sentry initialization

### DIFF
--- a/app/src/globalConfig.ts
+++ b/app/src/globalConfig.ts
@@ -7,28 +7,8 @@ import {
     type Uuid,
     type ContentDto,
 } from "luminary-shared";
-import { computed, ref, watch, type App } from "vue";
+import { computed, ref, watch } from "vue";
 import { loadFallbackImageUrls } from "./util/loadFallbackImages";
-
-export let Sentry: typeof import("@sentry/vue") | null = null;
-
-export async function initSentry(app: App) {
-    if (!import.meta.env.PROD) return;
-
-    try {
-        Sentry = await import("@sentry/vue");
-        Sentry.init({
-            app,
-            dsn: import.meta.env.VITE_SENTRY_DSN,
-            integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
-        });
-
-        // TEMPORARY: confirm Sentry is initialised and ingest is working. Remove once verified.
-        Sentry.captureMessage("Sentry initialised", "info");
-    } catch (e) {
-        console.error("Failed to initialize Sentry:", e);
-    }
-}
 
 export const appName = import.meta.env.VITE_APP_NAME;
 export const apiUrl = import.meta.env.VITE_API_URL;

--- a/app/src/globalConfig.ts
+++ b/app/src/globalConfig.ts
@@ -7,19 +7,27 @@ import {
     type Uuid,
     type ContentDto,
 } from "luminary-shared";
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, type App } from "vue";
 import { loadFallbackImageUrls } from "./util/loadFallbackImages";
 
 export let Sentry: typeof import("@sentry/vue") | null = null;
 
-if (import.meta.env.PROD) {
-    import("@sentry/vue")
-        .then((sentryModule) => {
-            Sentry = sentryModule;
-        })
-        .catch((e) => {
-            console.error("Failed to initialize Sentry:", e);
+export async function initSentry(app: App) {
+    if (!import.meta.env.PROD) return;
+
+    try {
+        Sentry = await import("@sentry/vue");
+        Sentry.init({
+            app,
+            dsn: import.meta.env.VITE_SENTRY_DSN,
+            integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
         });
+
+        // TEMPORARY: confirm Sentry is initialised and ingest is working. Remove once verified.
+        Sentry.captureMessage("Sentry initialised", "info");
+    } catch (e) {
+        console.error("Failed to initialize Sentry:", e);
+    }
 }
 
 export const appName = import.meta.env.VITE_APP_NAME;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -14,7 +14,7 @@ import {
 import { useNotificationStore } from "./stores/notification";
 import { DocType, getSocket, init, warmMangoCaches, serverError } from "luminary-shared";
 import { loadPlugins } from "./util/pluginLoader";
-import { appLanguageIdsAsRef, initLanguage, isAppLoading, Sentry } from "./globalConfig";
+import { appLanguageIdsAsRef, initLanguage, isAppLoading, Sentry, initSentry } from "./globalConfig";
 import { apiUrl } from "./globalConfig";
 import { initAppTitle, initI18n } from "./i18n";
 import { initAnalytics } from "./analytics";
@@ -34,13 +34,7 @@ if (import.meta.env.VITE_FAV_ICON) {
     }
 }
 
-if (import.meta.env.PROD && Sentry) {
-    Sentry.init({
-        app,
-        dsn: import.meta.env.VITE_SENTRY_DSN,
-        integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
-    });
-}
+initSentry(app);
 
 async function Startup() {
     // Pre-warm Mango query caches from localStorage before any queries run.

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -14,12 +14,13 @@ import {
 import { useNotificationStore } from "./stores/notification";
 import { DocType, getSocket, init, warmMangoCaches, serverError } from "luminary-shared";
 import { loadPlugins } from "./util/pluginLoader";
-import { appLanguageIdsAsRef, initLanguage, isAppLoading, Sentry, initSentry } from "./globalConfig";
+import { appLanguageIdsAsRef, initLanguage, isAppLoading } from "./globalConfig";
 import { apiUrl } from "./globalConfig";
 import { initAppTitle, initI18n } from "./i18n";
 import { initAnalytics } from "./analytics";
 import { initSync, initAuthLangSync } from "./sync";
 import { APP_DOCS_INDEX } from "./docsIndex";
+import { initSentry, Sentry } from "@/util/initSentry";
 
 export const app = createApp(App);
 

--- a/app/src/sync.ts
+++ b/app/src/sync.ts
@@ -9,7 +9,9 @@ import {
     sync,
     type AccessMap,
 } from "luminary-shared";
-import { appLanguageIdsAsRef, Sentry } from "./globalConfig";
+import { appLanguageIdsAsRef } from "./globalConfig";
+import { Sentry } from "./util/initSentry";
+
 import _ from "lodash";
 
 export const syncIterators = ref<{ language: number; content: number }>({
@@ -160,7 +162,6 @@ export function initSync() {
                     Sentry?.captureException(err);
                 });
             }
-
         },
         { immediate: true },
     );

--- a/app/src/util/initSentry.ts
+++ b/app/src/util/initSentry.ts
@@ -1,0 +1,21 @@
+import { type App } from "vue";
+
+export let Sentry: typeof import("@sentry/vue") | null = null;
+
+export async function initSentry(app: App) {
+    if (!import.meta.env.PROD) return;
+
+    try {
+        Sentry = await import("@sentry/vue");
+        Sentry.init({
+            app,
+            dsn: import.meta.env.VITE_SENTRY_DSN,
+            integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
+        });
+
+        // TEMPORARY: confirm Sentry is initialised and ingest is working. Remove once verified.
+        Sentry.captureMessage("Sentry initialised", "info");
+    } catch (e) {
+        console.error("Failed to initialize Sentry:", e);
+    }
+}

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -85,11 +85,12 @@ const testI18n = createI18n({
 });
 config.global.plugins = [...(config.global.plugins || []), testI18n];
 
-window.ResizeObserver = vi.fn().mockImplementation(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-}));
+class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
 window.matchMedia = vi.fn().mockImplementation((query) => {
     return {


### PR DESCRIPTION
Move Sentry initialization to a dedicated async function in globalConfig.ts and call it in main.ts. This improves the organization and makes Sentry initialization more flexible.