### PR TITLE
Fix: Skip stale deleteCmd when local doc is newer

### DIFF
--- a/api/src/changeRequests/documentProcessing/processContentDto.ts
+++ b/api/src/changeRequests/documentProcessing/processContentDto.ts
@@ -12,6 +12,10 @@ import { computeFtsData } from "../../util/ftsIndexing";
  * @param db
  */
 export default async function processContentDto(doc: ContentDto, db: DbService) {
+    // Server-controlled field; clients must not set it. Cleared here so any forged value
+    // is dropped before persistence — only the unpublish path in DbService is allowed to set it.
+    delete doc.statusChangeDeleteCmdId;
+
     doc.slug = await validateSlug(doc.slug, doc._id, db);
 
     const parentQuery = await db.getDoc(doc.parentId);

--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -6,6 +6,7 @@ import { PostDto } from "../dto/PostDto";
 import waitForExpect from "wait-for-expect";
 import { DeleteCmdDto } from "../dto/DeleteCmdDto";
 import { SearchOptions } from "./db.searchFunctions";
+import processContentDto from "../changeRequests/documentProcessing/processContentDto";
 
 describe("DbService", () => {
     let service: DbService;
@@ -1259,6 +1260,79 @@ describe("DbService", () => {
 
                 const deleteCmdAfter = await service.executeFindQuery(deleteCmdQuery);
                 expect(deleteCmdAfter.docs.length).toBe(0);
+            });
+
+            it("sets statusChangeDeleteCmdId on the draft doc when content is unpublished", async () => {
+                const contentDocId = "delete-test-statusChange-trackingField-set";
+
+                const publishedDoc = {
+                    _id: contentDocId,
+                    testData: "test123",
+                    type: DocType.Content,
+                    status: "published",
+                    memberOf: ["group-public-content"],
+                };
+                await service.upsertDoc(publishedDoc);
+
+                const draftDoc = { ...publishedDoc, status: "draft" };
+                await service.upsertDoc(draftDoc);
+
+                const persistedDraft = (await service.getDoc(contentDocId)).docs[0];
+                expect(persistedDraft.statusChangeDeleteCmdId).toBeDefined();
+
+                const trackedCmd = (await service.getDoc(persistedDraft.statusChangeDeleteCmdId))
+                    .docs[0];
+                expect(trackedCmd).toBeDefined();
+                expect(trackedCmd.type).toBe(DocType.DeleteCmd);
+                expect(trackedCmd.docId).toBe(contentDocId);
+                expect(trackedCmd.deleteReason).toBe(DeleteReason.StatusChange);
+            });
+
+            it("deletes the tracked deleteCmd by primary key on republish and clears the tracking field", async () => {
+                const contentDocId = "delete-test-statusChange-trackingField-republish";
+
+                const publishedDoc = {
+                    _id: contentDocId,
+                    testData: "test123",
+                    type: DocType.Content,
+                    status: "published",
+                    memberOf: ["group-public-content"],
+                };
+                await service.upsertDoc(publishedDoc);
+                await service.upsertDoc({ ...publishedDoc, status: "draft" });
+
+                const draftAfterUnpublish = (await service.getDoc(contentDocId)).docs[0];
+                const trackedCmdId = draftAfterUnpublish.statusChangeDeleteCmdId;
+                expect(trackedCmdId).toBeDefined();
+
+                // Republish
+                await service.upsertDoc({ ...publishedDoc, testData: "test123-republished" });
+
+                const republished = (await service.getDoc(contentDocId)).docs[0];
+                expect(republished.statusChangeDeleteCmdId).toBeUndefined();
+
+                const trackedCmdAfter = await service.getDoc(trackedCmdId);
+                expect(trackedCmdAfter.docs.length).toBe(0);
+            });
+
+            it("ignores client-provided statusChangeDeleteCmdId on a change request", async () => {
+                const contentDocId = "delete-test-statusChange-trackingField-forged";
+
+                const forgedDoc: any = {
+                    _id: contentDocId,
+                    type: DocType.Content,
+                    parentId: "post-blog1",
+                    language: "lang-eng",
+                    status: "draft",
+                    slug: "trackingfield-forged-test-slug",
+                    title: "Test",
+                    memberOf: ["group-public-content"],
+                    statusChangeDeleteCmdId: "forged-id-the-client-set",
+                };
+
+                await processContentDto(forgedDoc, service);
+
+                expect(forgedDoc.statusChangeDeleteCmdId).toBeUndefined();
             });
 
             it("generates a delete instruction for a 'deleted' reason when a document is upserted with a deleteReq, and deletes the document itself", async () => {

--- a/api/src/db/db.service.ts
+++ b/api/src/db/db.service.ts
@@ -410,30 +410,24 @@ export class DbService extends EventEmitter {
                 });
             }
 
-            // Cleanup obsolete delete commands when switching content from draft to published.
-            // Without this, older `DeleteReason.StatusChange` deleteCmd documents may still exist in the DB,
-            // which would cause non-CMS clients to delete the document even though it is published again.
+            // Cleanup the obsolete StatusChange deleteCmd when switching content from draft to
+            // published. The deleteCmd's `_id` is tracked on the draft doc itself
+            // (`statusChangeDeleteCmdId`), so we can delete it by primary key — strongly consistent.
+            // Pre-fix orphan deleteCmds (no tracking field) are handled by a one-time schema
+            // upgrade in `schemaUpgrade/v15.ts`.
             if (
                 existing &&
                 doc.type === DocType.Content &&
                 (existing as ContentDto).status === PublishStatus.Draft &&
                 (doc as ContentDto).status === PublishStatus.Published
             ) {
-                const query: nano.MangoQuery = {
-                    selector: {
-                        type: DocType.DeleteCmd,
-                        docId: (existing as ContentDto)._id,
-                        deleteReason: DeleteReason.StatusChange,
-                    },
-                    limit: Number.MAX_SAFE_INTEGER,
-                };
-
-                const res: any = await this.db.find(query);
-                const deleteCmdDocs: any[] = res.docs || [];
-
-                for (const cmd of deleteCmdDocs) {
-                    await this.deleteDoc(cmd._id);
+                const trackedId = (existing as ContentDto).statusChangeDeleteCmdId;
+                if (trackedId) {
+                    await this.deleteDoc(trackedId);
                 }
+
+                // Don't carry the field forward onto the republished doc.
+                delete (doc as ContentDto).statusChangeDeleteCmdId;
             }
 
             // Generate delete command if the document's status has changed to draft
@@ -443,11 +437,14 @@ export class DbService extends EventEmitter {
                 (existing as ContentDto).status === PublishStatus.Published &&
                 (doc as ContentDto).status === PublishStatus.Draft
             ) {
-                await this.insertDeleteCmd({
+                const result = await this.insertDeleteCmd({
                     reason: DeleteReason.StatusChange,
                     doc: doc as ContentDto,
                     prevDoc: existing as _contentBaseDto,
                 });
+                // Track the deleteCmd ID on the draft so a future republish can delete it by
+                // primary key (strongly consistent) instead of relying on an unindexed Mango find.
+                (doc as ContentDto).statusChangeDeleteCmdId = result.id;
             }
         }
 

--- a/api/src/db/db.upgrade.spec.ts
+++ b/api/src/db/db.upgrade.spec.ts
@@ -22,6 +22,10 @@ jest.mock("./schemaUpgrade/v14", () => ({
     __esModule: true,
     default: jest.fn().mockResolvedValue(undefined),
 }));
+jest.mock("./schemaUpgrade/v15", () => ({
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+}));
 
 import { upgradeDbSchema } from "./db.upgrade";
 import v9 from "./schemaUpgrade/v9";
@@ -30,6 +34,7 @@ import v11 from "./schemaUpgrade/v11";
 import v12 from "./schemaUpgrade/v12";
 import v13 from "./schemaUpgrade/v13";
 import v14 from "./schemaUpgrade/v14";
+import v15 from "./schemaUpgrade/v15";
 
 describe("upgradeDbSchema", () => {
     const mockDb = {} as any;
@@ -47,6 +52,7 @@ describe("upgradeDbSchema", () => {
         expect(v12).toHaveBeenCalledWith(mockDb);
         expect(v13).toHaveBeenCalledWith(mockDb);
         expect(v14).toHaveBeenCalledWith(mockDb);
+        expect(v15).toHaveBeenCalledWith(mockDb);
     });
 
     it("should re-throw error and log it when an upgrade function fails", async () => {

--- a/api/src/db/db.upgrade.ts
+++ b/api/src/db/db.upgrade.ts
@@ -5,6 +5,7 @@ import v11 from "./schemaUpgrade/v11";
 import v12 from "./schemaUpgrade/v12";
 import v13 from "./schemaUpgrade/v13";
 import v14 from "./schemaUpgrade/v14";
+import v15 from "./schemaUpgrade/v15";
 
 /**
  * Upgrade the database schema
@@ -18,6 +19,7 @@ export async function upgradeDbSchema(db: DbService) {
         await v12(db);
         await v13(db);
         await v14(db);
+        await v15(db);
     } catch (error) {
         console.error("Database schema upgrade failed:", error);
         throw error; // Re-throw to prevent schema version from being updated

--- a/api/src/db/schemaUpgrade/v15.ts
+++ b/api/src/db/schemaUpgrade/v15.ts
@@ -1,0 +1,97 @@
+import { DbService } from "../db.service";
+import { DeleteReason, DocType, PublishStatus } from "../../enums";
+
+/**
+ * Upgrade the database schema from version 14 to 15.
+ *
+ * Reconciles `StatusChange` deleteCmd documents with their target Content documents:
+ *
+ *   - Deletes orphan `StatusChange` deleteCmds whose target content is Published
+ *     (republished without the deleteCmd ever being cleaned up) or whose target
+ *     content has been hard-deleted.
+ *   - Backfills `statusChangeDeleteCmdId` on Draft content docs so the runtime
+ *     republish path can delete the deleteCmd by primary key (no Mango fallback needed).
+ *   - Deletes duplicate `StatusChange` deleteCmds for the same content doc — the
+ *     content tracks one ID; any extras are stale leaks.
+ *
+ * Caveat: this is a point-in-time reconciliation. A rare `insertDoc` conflict-retry
+ * race at runtime (concurrent unpublish + republish on the same content) can still
+ * create new orphans because the surrounding `upsertDoc` decision is made against
+ * the pre-conflict `existing` snapshot. The client-side timestamp guard in
+ * `shared/src/db/database.ts` prevents user-visible harm if that happens.
+ */
+export default async function (db: DbService) {
+    try {
+        const schemaVersion = await db.getSchemaVersion();
+        // Accept 13 or 14 — v14 is reserved by a parallel branch. Once that lands and bumps
+        // the schema to 14, v15 will pick up from there; until then v15 runs straight after v13.
+        if (schemaVersion !== 13 && schemaVersion !== 14) {
+            console.info(
+                `Skipping schema upgrade v15: current version is ${schemaVersion}, expected 13 or 14`,
+            );
+            return;
+        }
+
+        console.info(`Upgrading database schema from version ${schemaVersion} to 15`);
+
+        let deletedOrphans = 0;
+        let backfilled = 0;
+        let alreadyTracked = 0;
+        // Per content doc: the deleteCmd `_id` we have already kept/backfilled.
+        const trackedByContentId = new Map<string, string>();
+
+        await db.processAllDocs([DocType.DeleteCmd], async (cmd: any) => {
+            if (!cmd || cmd.deleteReason !== DeleteReason.StatusChange) return;
+
+            const contentRes = await db.getDoc(cmd.docId);
+            const content = contentRes.docs[0];
+
+            // Target content is gone (hard-deleted) — the StatusChange cmd is orphaned.
+            if (!content) {
+                await db.deleteDoc(cmd._id);
+                deletedOrphans++;
+                return;
+            }
+
+            // Target content is Published — the cmd was never cleaned up on republish.
+            if (content.status === PublishStatus.Published) {
+                await db.deleteDoc(cmd._id);
+                deletedOrphans++;
+                return;
+            }
+
+            // Target content is Draft: keep exactly one deleteCmd per content doc.
+            const trackedOnContent: string | undefined = content.statusChangeDeleteCmdId;
+            const trackedThisRun = trackedByContentId.get(content._id);
+
+            if (trackedOnContent === cmd._id || trackedThisRun === cmd._id) {
+                alreadyTracked++;
+                trackedByContentId.set(content._id, cmd._id);
+                return;
+            }
+
+            if (trackedOnContent || trackedThisRun) {
+                // Content already tracks a different deleteCmd. This one is a duplicate.
+                await db.deleteDoc(cmd._id);
+                deletedOrphans++;
+                return;
+            }
+
+            // Content has no tracking field yet — backfill it.
+            content.statusChangeDeleteCmdId = cmd._id;
+            await db.insertDoc(content);
+            trackedByContentId.set(content._id, cmd._id);
+            backfilled++;
+        });
+
+        console.info(
+            `StatusChange deleteCmd reconciliation: ${deletedOrphans} orphan(s) deleted, ${backfilled} backfilled on draft docs, ${alreadyTracked} already-tracked`,
+        );
+
+        await db.setSchemaVersion(15);
+        console.info(`Database schema upgrade from version ${schemaVersion} to 15 completed successfully`);
+    } catch (error) {
+        console.error("Database schema upgrade to version 15 failed:", error);
+        throw error;
+    }
+}

--- a/api/src/dto/ContentDto.ts
+++ b/api/src/dto/ContentDto.ts
@@ -183,4 +183,9 @@ export class ContentDto extends _contentBaseDto {
     @IsNumber()
     @Expose()
     wordCount?: number;
+
+    @IsOptional() // Server-controlled: set by the API on unpublish, cleared on republish. Sanitized from incoming change requests.
+    @IsString()
+    @Expose()
+    statusChangeDeleteCmdId?: Uuid;
 }

--- a/shared/src/db/database.spec.ts
+++ b/shared/src/db/database.spec.ts
@@ -963,6 +963,7 @@ describe("Database", async () => {
                     type: DocType.DeleteCmd,
                     docId: mockEnglishContentDto._id,
                     deleteReason: "deleted",
+                    updatedTimeUtc: mockEnglishContentDto.updatedTimeUtc + 1,
                 } as DeleteCmdDto,
             ]);
 
@@ -983,6 +984,7 @@ describe("Database", async () => {
                     type: DocType.DeleteCmd,
                     docId: mockEnglishContentDto._id,
                     deleteReason: "statusChange",
+                    updatedTimeUtc: mockEnglishContentDto.updatedTimeUtc + 1,
                 } as DeleteCmdDto,
             ]);
 
@@ -1003,6 +1005,7 @@ describe("Database", async () => {
                     type: DocType.DeleteCmd,
                     docId: mockEnglishContentDto._id,
                     deleteReason: "statusChange",
+                    updatedTimeUtc: mockEnglishContentDto.updatedTimeUtc + 1,
                 } as DeleteCmdDto,
             ]);
 
@@ -1023,6 +1026,7 @@ describe("Database", async () => {
                     docId: mockEnglishContentDto._id,
                     deleteReason: "permissionChange",
                     newMemberOf: ["inaccessible-group"],
+                    updatedTimeUtc: mockEnglishContentDto.updatedTimeUtc + 1,
                 } as DeleteCmdDto,
             ]);
 
@@ -1054,6 +1058,7 @@ describe("Database", async () => {
                     docId: mockEnglishContentDto._id,
                     deleteReason: "permissionChange",
                     newMemberOf: ["group-public-content"],
+                    updatedTimeUtc: mockEnglishContentDto.updatedTimeUtc + 1,
                 } as DeleteCmdDto,
             ]);
 
@@ -1061,6 +1066,156 @@ describe("Database", async () => {
             expect(deletedDoc).toBeDefined();
 
             accessMap.value = {};
+        });
+
+        describe("stale deleteCmd timestamp guard", () => {
+            const localTime = 2000;
+            const olderTime = 1000;
+            const equalTime = localTime;
+
+            it("skips deleteCmd with reason 'deleted' when local doc is newer", async () => {
+                await db.docs.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: localTime },
+                ]);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-stale-1",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "deleted",
+                        updatedTimeUtc: olderTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeDefined();
+                expect(doc?.updatedTimeUtc).toBe(localTime);
+            });
+
+            it("skips deleteCmd with reason 'statusChange' when local doc is newer (non-CMS)", async () => {
+                config.cms = false;
+                await db.docs.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: localTime },
+                ]);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-stale-2",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "statusChange",
+                        updatedTimeUtc: olderTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeDefined();
+                expect(doc?.updatedTimeUtc).toBe(localTime);
+            });
+
+            it("skips deleteCmd with reason 'permissionChange' when local doc is newer", async () => {
+                await db.docs.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: localTime },
+                ]);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-stale-3",
+                        type: DocType.DeleteCmd,
+                        docType: DocType.Post,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "permissionChange",
+                        newMemberOf: ["inaccessible-group"],
+                        updatedTimeUtc: olderTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeDefined();
+                expect(doc?.updatedTimeUtc).toBe(localTime);
+            });
+
+            it("skips deleteCmd when timestamps are equal (treats ties as superseded)", async () => {
+                await db.docs.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: localTime },
+                ]);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-stale-4",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "deleted",
+                        updatedTimeUtc: equalTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeDefined();
+            });
+
+            it("applies deleteCmd when local doc is older than the deleteCmd", async () => {
+                await db.docs.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: olderTime },
+                ]);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-fresh-1",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "deleted",
+                        updatedTimeUtc: localTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeUndefined();
+            });
+
+            it("applies deleteCmd when local doc is absent (no-op without error)", async () => {
+                await db.docs.delete(mockEnglishContentDto._id);
+
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-absent-1",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "deleted",
+                        updatedTimeUtc: localTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeUndefined();
+            });
+
+            it("preserves republished content when stale statusChange deleteCmd arrives in a later sync batch (bug repro)", async () => {
+                config.cms = false;
+                const republishedTime = 3000;
+                const staleUnpublishTime = 2000;
+
+                // Catch-up content sync: newer republished content arrives first
+                await db.bulkPut([
+                    { ...mockEnglishContentDto, updatedTimeUtc: republishedTime },
+                ]);
+
+                // Catch-up deleteCmd sync: stale unpublish deleteCmd arrives after
+                await db.bulkPut([
+                    {
+                        _id: "delete-cmd-bug-repro",
+                        type: DocType.DeleteCmd,
+                        docId: mockEnglishContentDto._id,
+                        deleteReason: "statusChange",
+                        updatedTimeUtc: staleUnpublishTime,
+                    } as DeleteCmdDto,
+                ]);
+
+                const doc = await db.get<ContentDto>(mockEnglishContentDto._id);
+                expect(doc).toBeDefined();
+                expect(doc?.updatedTimeUtc).toBe(republishedTime);
+            });
         });
 
         it("can delete related content documents when a parent document is deleted locally through marking a document with deleteReq: 1", async () => {

--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -280,12 +280,28 @@ class Database extends Dexie {
      * Bulk insert documents into the database, and delete documents that are marked for deletion.
      */
     async bulkPut(docs: BaseDocumentDto[]) {
-        const toDeleteIds = docs
-            .filter((doc) => {
-                if (doc.type !== DocType.DeleteCmd) return false;
-                return this.validateDeleteCommand(doc as DeleteCmdDto);
+        const candidateDeleteCmds = docs.filter(
+            (doc) =>
+                doc.type === DocType.DeleteCmd &&
+                this.validateDeleteCommand(doc as DeleteCmdDto),
+        ) as DeleteCmdDto[];
+
+        // Bulk-fetch target docs once, then skip any deleteCmd whose target is already
+        // at-or-newer than the deleteCmd itself (e.g. unpublish-then-republish race).
+        const targetIds = candidateDeleteCmds.map((cmd) => cmd.docId);
+        const existing = targetIds.length > 0 ? await this.docs.bulkGet(targetIds) : [];
+        const existingById = new Map<string, BaseDocumentDto>();
+        for (const d of existing) {
+            if (d) existingById.set(d._id, d);
+        }
+
+        const toDeleteIds = candidateDeleteCmds
+            .filter((cmd) => {
+                const local = existingById.get(cmd.docId);
+                if (!local) return true;
+                return local.updatedTimeUtc < cmd.updatedTimeUtc;
             })
-            .map((doc) => (doc as DeleteCmdDto).docId);
+            .map((cmd) => cmd.docId);
 
         if (toDeleteIds.length > 0) {
             await this.docs.bulkDelete(toDeleteIds);

--- a/shared/src/types/dto.ts
+++ b/shared/src/types/dto.ts
@@ -110,6 +110,7 @@ export type ContentDto = ContentBaseDto & {
     ftsTokenCount?: number;
     copyright?: string;
     wordCount?: number;
+    statusChangeDeleteCmdId?: Uuid;
 };
 
 export type ContentParentDto = ContentBaseDto & {

--- a/shared/src/util/ApiLiveQuery/applySocketData.spec.ts
+++ b/shared/src/util/ApiLiveQuery/applySocketData.spec.ts
@@ -47,12 +47,19 @@ describe("applySocketData", () => {
 
     it("removes documents marked for deletion", () => {
         const destination = ref<BaseDocumentDto[]>([
-            { _id: "1", type: DocType.Post } as BaseDocumentDto,
+            { _id: "1", type: DocType.Post, updatedTimeUtc: 1000 } as BaseDocumentDto,
             { _id: "2", type: DocType.Tag } as BaseDocumentDto,
         ]);
 
         const data: ApiQueryResult<BaseDocumentDto> = {
-            docs: [{ _id: "1", type: DocType.DeleteCmd, docId: "1" } as DeleteCmdDto],
+            docs: [
+                {
+                    _id: "1",
+                    type: DocType.DeleteCmd,
+                    docId: "1",
+                    updatedTimeUtc: 2000,
+                } as DeleteCmdDto,
+            ],
         };
 
         vi.mocked(db.validateDeleteCommand).mockReturnValue(true);
@@ -60,6 +67,33 @@ describe("applySocketData", () => {
         applySocketData(data, destination, {});
 
         expect(destination.value).toEqual([{ _id: "2", type: DocType.Tag }]);
+    });
+
+    it("skips stale deleteCmd when local doc has a newer updatedTimeUtc (republish race)", () => {
+        const destination = ref<BaseDocumentDto[]>([
+            { _id: "1", type: DocType.Post, updatedTimeUtc: 3000 } as BaseDocumentDto,
+            { _id: "2", type: DocType.Tag } as BaseDocumentDto,
+        ]);
+
+        const data: ApiQueryResult<BaseDocumentDto> = {
+            docs: [
+                {
+                    _id: "delete-cmd-1",
+                    type: DocType.DeleteCmd,
+                    docId: "1",
+                    updatedTimeUtc: 2000,
+                } as DeleteCmdDto,
+            ],
+        };
+
+        vi.mocked(db.validateDeleteCommand).mockReturnValue(true);
+
+        applySocketData(data, destination, {});
+
+        expect(destination.value).toEqual([
+            { _id: "1", type: DocType.Post, updatedTimeUtc: 3000 },
+            { _id: "2", type: DocType.Tag },
+        ]);
     });
 
     it("filters out delete commands from the result", () => {

--- a/shared/src/util/ApiLiveQuery/applySocketData.ts
+++ b/shared/src/util/ApiLiveQuery/applySocketData.ts
@@ -32,12 +32,14 @@ export function applySocketData<T extends BaseDocumentDto>(
     destination: Ref<Array<T> | undefined>,
     query: ApiSearchQuery,
 ) {
-    // Delete documents that are marked for deletion
+    // Delete documents that are marked for deletion. Skip any deleteCmd whose target is already
+    // at-or-newer than the deleteCmd itself (e.g. unpublish-then-republish race).
     const toDeleteIds = (data.docs as unknown as Array<DeleteCmdDto>)
         .filter((doc) => {
             if (doc.type !== DocType.DeleteCmd) return false;
-
-            return db.validateDeleteCommand(doc);
+            if (!db.validateDeleteCommand(doc)) return false;
+            const local = destination.value?.find((d) => d._id === doc.docId);
+            return !local || local.updatedTimeUtc < doc.updatedTimeUtc;
         })
         .map((doc) => doc.docId);
 


### PR DESCRIPTION
Guards against an unpublish-then-republish race where a stale deleteCmd arrives in a later sync batch after the republished content, preventing the newer doc from being incorrectly removed.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>