### PR TITLE
Update document timestamp on schema upgrade

### DIFF
--- a/api/src/db/schemaUpgrade/v14.ts
+++ b/api/src/db/schemaUpgrade/v14.ts
@@ -18,6 +18,8 @@ export default async function (db: DbService) {
                 if (!doc) return;
                 if (!doc.averageReadingSpeed) {
                     doc.averageReadingSpeed = 200;
+                    // Bump updatedTimeUtc so clients sync the new reading speed
+                    doc.updatedTimeUtc = Date.now();
                     await db.insertDoc(doc);
                     languagesWithoutSpeed++;
                 }
@@ -32,6 +34,8 @@ export default async function (db: DbService) {
 
                 if (doc.wordCount !== newWordCount) {
                     doc.wordCount = newWordCount;
+                    // Bump updatedTimeUtc so clients sync the new word count (reading time)
+                    doc.updatedTimeUtc = Date.now();
                     await db.insertDoc(doc);
                     contentUpdated++;
                 }


### PR DESCRIPTION
Ensures clients sync updated reading speed and word count metadata by bumping the updatedTimeUtc field.
Update document timestamp on schema upgrade

Force client synchronization of modified documents by updating updatedTimeUtc when reading speed or word counts are changed.