### PR TITLE
CMS: Prevent offline redirection on initial route load

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -68,10 +68,8 @@ setTimeout(() => {
 }, 5000);
 
 watch(
-    [isConnected, isAuthenticated, isAppLoading],
+    [isConnected, isAuthenticated],
     () => {
-        if (isAppLoading.value) return;
-
         if (isConnected.value && !isAuthenticated.value) {
             useNotificationStore().addNotification({
                 id: "accountBanner",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -68,8 +68,10 @@ setTimeout(() => {
 }, 5000);
 
 watch(
-    [isConnected, isAuthenticated],
+    [isConnected, isAuthenticated, isAppLoading],
     () => {
+        if (isAppLoading.value) return;
+
         if (isConnected.value && !isAuthenticated.value) {
             useNotificationStore().addNotification({
                 id: "accountBanner",

--- a/app/src/globalConfig.ts
+++ b/app/src/globalConfig.ts
@@ -154,13 +154,8 @@ export const initLanguage = () => {
             { deep: true },
         );
 
-        // If user already has preferred languages, resolve immediately
-        if (appLanguageIdsAsRef.value.length > 0) {
-            resolve();
-            return;
-        }
-
-        // Initialize preferred language when CMS languages are available
+        // Wait for cmsLanguages to populate before resolving so the i18n watcher
+        // has loaded translations by the time the splash screen ends.
         const unwatchCmsLanguages = watch(
             cmsLanguages,
             (_languages) => {


### PR DESCRIPTION
Added a check for START_LOCATION to avoid showing an error notification when the app first loads in an offline state. Added a watcher to redirect users if the connection is lost while viewing an online-only page.