### PR TITLE
 Add Claude Code agentic context and skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx vitest:*)",
+      "Bash(npm view:*)"
+    ]
+  }
+}

--- a/.claude/skills/add-schema-upgrade/SKILL.md
+++ b/.claude/skills/add-schema-upgrade/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: add-schema-upgrade
+description: Generate a new database schema upgrade (vN.ts) — file boilerplate, wiring into db.upgrade.ts chain, README update, and seeding-doc sync. Use when the user asks to "add a schema upgrade", "bump the schema version", "migrate existing docs for X", or has changed a doc shape that needs backfilling on existing databases.
+---
+
+# add-schema-upgrade
+
+Schema upgrades migrate existing CouchDB data on API startup. They are sequenced (`v9 → v10 → … → vN`), idempotent (no-op if the DB is already at or past their target), and **not run by tests** — seeding data must already match the latest schema.
+
+## Background to read first
+
+If you haven't already, read `api/src/db/schemaUpgrade/README.md`. It documents when to create / when not to / how to remove old upgrades. The current baseline at time of writing is **v15**.
+
+## When to use this — and when not to
+
+**Use this skill when:**
+- Adding a required field to an existing doc type (existing docs need a backfill default).
+- Renaming or changing the shape of an existing field.
+- Backfilling derived data (e.g. v13 backfilled server-side FTS, v15 reconciled deleteCmd tracking).
+- Forcing a re-sync of doc shape changes — bump `updatedTimeUtc` on affected docs and the next sync round delivers the new shape to all clients. (Per user feedback, this is the preferred strategy over client-side reshape migrations.)
+
+**Do NOT use this for:**
+- Adding an *optional* field — handle with code defaults.
+- Adding a new doc type — existing data isn't affected.
+- Changing views/indexes — that's design docs, handled by `upsertDesignDocs`.
+- Config changes — env vars or settings docs.
+
+## Procedure
+
+### 1. Determine N+1
+
+List the existing upgrades and identify the highest version:
+
+```sh
+ls /Users/dirk/projects/bccsa/luminary/api/src/db/schemaUpgrade/v*.ts
+```
+
+The next version is `N+1` where N is the highest existing. Read `api/src/db/db.upgrade.ts` to confirm the current chain — the highest `vN` imported there is authoritative.
+
+### 2. Create `vN+1.ts`
+
+Use `api/src/db/schemaUpgrade/v15.ts` as the template. Required structure:
+
+```ts
+import { DbService } from "../db.service";
+// import any enums you need
+
+/**
+ * Upgrade the database schema from version <N> to <N+1>.
+ *
+ * <Brief description of what this migration does and why.>
+ */
+export default async function (db: DbService) {
+    try {
+        const schemaVersion = await db.getSchemaVersion();
+        if (schemaVersion !== <N>) {
+            console.info(
+                `Skipping schema upgrade v<N+1>: current version is ${schemaVersion}, expected <N>`,
+            );
+            return;
+        }
+
+        console.info(`Upgrading database schema from version ${schemaVersion} to <N+1>`);
+
+        // Migration work here. Common patterns:
+        //   - db.processAllDocs([DocType.X], async (doc) => { ... await db.insertDoc(doc); });
+        //   - Bump updatedTimeUtc on affected docs to force re-sync to clients.
+
+        await db.setSchemaVersion(<N+1>);
+        console.info(`Database schema upgrade from version ${schemaVersion} to <N+1> completed successfully`);
+    } catch (error) {
+        console.error("Database schema upgrade to version <N+1> failed:", error);
+        throw error;
+    }
+}
+```
+
+Rules:
+
+- The `schemaVersion !== N` guard is **mandatory**. Without it, re-running on an already-upgraded DB corrupts data.
+- The `setSchemaVersion(N+1)` call must be the **last** thing before the return. If the migration partially completes and throws, the version stays at N so the next startup retries from the same point.
+- Wrap in `try/catch` and re-throw — the outer `upgradeDbSchema` needs the throw to halt API startup.
+- For doc-shape changes that need to reach existing clients: instead of a complex client-side migration, just bump `updatedTimeUtc` on the affected docs (`await db.insertDoc(doc)` after reshaping). Per the user's stored preference, this is the canonical approach.
+
+### 3. Wire into `db.upgrade.ts`
+
+Edit `api/src/db/db.upgrade.ts`:
+
+```ts
+import vN1 from "./schemaUpgrade/vN+1";  // add the import alongside the existing ones
+
+export async function upgradeDbSchema(db: DbService) {
+    try {
+        await v9(db);
+        await v10(db);
+        // ...
+        await vN(db);
+        await vN1(db);          // add at the end of the chain
+    } catch (error) {
+        console.error("Database schema upgrade failed:", error);
+        throw error;
+    }
+}
+```
+
+Order matters — append at the end. The guard inside each upgrade makes them safely re-runnable, but the chain order is the source of truth for sequencing.
+
+### 4. Update the README
+
+Edit `api/src/db/schemaUpgrade/README.md`:
+
+- Update the **Current Baseline** version line.
+- Add an entry under **Current Upgrades** describing what `vN+1` does and why. Use the existing v13/v15 entries as the template — one short paragraph.
+
+### 5. Update seeding docs (if doc shapes changed)
+
+Tests do not run upgrades — they seed from `api/src/db/seedingDocs/*.json` and assume the seed data is in the latest schema. If `vN+1` adds a required field to an existing doc type:
+
+```sh
+ls /Users/dirk/projects/bccsa/luminary/api/src/db/seedingDocs/
+```
+
+For each seeding doc of the affected type, add the new field with a sensible default. Otherwise existing tests will fail with validation errors at startup.
+
+### 6. Mirror DTO if needed
+
+If `vN+1` adds or reshapes a field, the DTO must reflect it too — invoke `/sync-dtos` (or do the equivalent: edit `api/src/dto/<Name>Dto.ts` and `shared/src/types/dto.ts`).
+
+### 7. Test (locally, not e2e)
+
+Run `npm run test` in `api/` — confirms the seeding docs validate and existing tests still pass. Do NOT run e2e/playwright — user-driven.
+
+For the upgrade itself: there is `api/src/db/db.upgrade.spec.ts`. Add a test there if the migration logic is non-trivial. Mirror the pattern of existing tests.
+
+### 8. Report
+
+- File created: `api/src/db/schemaUpgrade/vN+1.ts`
+- Wired in: `api/src/db/db.upgrade.ts` (import + chain entry)
+- README updated: baseline bumped + new entry added
+- Seeding docs: list of files updated (or "none needed")
+- DTOs mirrored: yes/no
+- Tests: pass / failed (with details)
+
+## What this skill is NOT
+
+- Not a code reviewer. Don't pass judgement on the migration logic itself — the user owns the data transformation.
+- Not a production deploy gate. Bumping the baseline + removing old upgrades is a separate process documented in `schemaUpgrade/README.md` ("When to Remove Old Schema Upgrades").
+- Not for design-doc changes. Those are not schema upgrades.

--- a/.claude/skills/add-sync-query/SKILL.md
+++ b/.claude/skills/add-sync-query/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: add-sync-query
+description: Walk through adding a new Mango sync query end-to-end — the design doc (CouchDB index), the validator allowlist, the consumer's syncList registration, and the watcher in app/src/sync.ts or cms/src/sync.ts. Use when the user wants to "sync a new doc type", "add a Mango sync query", "register X in syncList", or hits a "sync query rejected by template" error.
+---
+
+# add-sync-query
+
+Adding a sync target touches four places. Miss any one and either (a) the API rejects the query, (b) CouchDB does a full table scan, or (c) the client never asks for the data in the first place. This is a multi-file procedure with strict naming conventions.
+
+## The four places
+
+1. **Design doc** in `api/src/db/designDocs/sync-<type>-index.json` (and usually a sibling `sync-<type>-deleteCmd-index.json` for the delete-cmd column).
+2. **Validator allowlist** in `api/src/db/MongoQueryTemplates/validators/sync.ts` — only matters if you need new selector fields beyond the existing allowlist (`updatedTimeUtc`, `type`, `memberOf`, `parentType`, `language`, `docType`).
+3. **Consumer syncList** — register the doc type in `shared/`'s init config (passed in via `app/src/main.ts` / `cms/src/main.ts`).
+4. **Watcher** in `app/src/sync.ts` or `cms/src/sync.ts` — adds the actual `sync({...})` call gated on permissions/connectivity.
+
+## Procedure
+
+### 1. Decide the doc type and column shape
+
+Establish before writing files:
+
+- DocType (e.g. `Post`, `Tag`, `Language`, or something new you're adding).
+- Is it a "content" type (sharded by language, has a parentType)? Or a top-level type?
+- CMS or App or both?
+- Does it need a sibling `DeleteCmd` column? **Top-level types and Content types both do.**
+
+### 2. Add the design doc(s)
+
+Use `api/src/db/designDocs/sync-tag-index.json` as the canonical template:
+
+```json
+{
+  "_id": "_design/sync-<type>-index",
+  "language": "query",
+  "views": {
+    "sync-<type>-index": {
+      "map": {
+        "fields": { "updatedTimeUtc": "desc" },
+        "partial_filter_selector": { "type": { "$eq": "<type-string>" } }
+      },
+      "reduce": "_count",
+      "options": { "def": { "fields": ["updatedTimeUtc"] } }
+    }
+  }
+}
+```
+
+Rules:
+
+- File name **must** be `sync-<type>-index.json`. The validator regex requires `use_index` to start with `sync-` and end with `-index`.
+- For content-type docs (parentType + language), include those in the `fields` array and adjust the partial_filter_selector. Check `sync-post-content-index.json` for the template.
+- For DeleteCmd docs, also add `sync-<type>-deleteCmd-index.json` — see `sync-tag-deleteCmd-index.json`.
+
+Design docs are picked up at API startup by `upsertDesignDocs(dbService)` in `main.ts`. After adding a JSON file, the API must be restarted for the index to materialize.
+
+### 3. Verify the validator accepts your query shape
+
+Open `api/src/db/MongoQueryTemplates/validators/sync.ts` and confirm:
+
+- Your selector uses only allowed keys: `updatedTimeUtc`, `type`, `memberOf`, `parentType`, `language`, `docType`. Adding a new selector key requires extending `allowedSelectorKeys` here.
+- The query has `limit`, `sort: [{ updatedTimeUtc: "desc" }]`, and a `use_index` matching `sync-*-index`.
+- `selector.type !== "user"` (User syncing is explicitly disallowed).
+
+If the user is asking for a fundamentally new query shape (e.g. sorting by something other than `updatedTimeUtc`), this validator is the gate — extending it is a significant change that needs review, not a quick edit.
+
+### 4. Register in the consumer's syncList
+
+The `syncList` is passed into `init()` from `app/src/main.ts` and `cms/src/main.ts` via the `SharedConfig`. Find the array (it's typically passed inline) and add an entry for the new type:
+
+```ts
+{ type: DocType.<NewType>, syncPriority: <N>, contentOnly: <true|false> }
+```
+
+- `syncPriority`: lower numbers sync first; mirror what existing similar types use.
+- `contentOnly: true`: for types where docs live under a parent and are sharded by language (Content).
+
+For the CMS, there's an exception pattern for `AutoGroupMappings` (in `cms/src/sync.ts`) — listed but `sync: false`. Use it as a reference if the new type is editable-only and never mirrored into Dexie.
+
+### 5. Wire up the watcher in `<consumer>/src/sync.ts`
+
+The watcher decides *when* to call `sync()`. Two iterators exist:
+
+- `language` iterator — only `AuthProvider` and `Language` docs (the bootstrap layer). New types almost never go here.
+- `content` iterator — everything else; ticks on accessMap, isConnected, and (app only) appLanguages change. New types go here.
+
+Add a block following the existing pattern (see `app/src/sync.ts`):
+
+```ts
+if (access[DocType.<NewType>] && access[DocType.<NewType>].length) {
+    sync({
+        type: DocType.<NewType>,
+        memberOf: access[DocType.<NewType>],
+        // for Content types only:
+        // subType: DocType.<NewType>,
+        // languages: appLanguageIdsAsRef.value,
+        limit: 100,
+        cms: false,  // CMS side passes cms: true so QueryService skips published/expiry filters
+    }).catch((err) => {
+        Sentry?.captureException(err);
+    });
+}
+```
+
+For DeleteCmd: this is **not** a separate `sync()` call from the consumer. `Content` syncs pass `includeDeleteCmds: false` in the CMS (the parent-type sync already handles it). Top-level types pass `includeDeleteCmds: true` (the default).
+
+### 6. Sanity checks before reporting
+
+Run these in parallel via the shell:
+
+- Confirm the new design doc(s) parse: `python3 -c "import json; json.load(open('api/src/db/designDocs/sync-<type>-index.json'))"` (or `jq . <file>` if jq is available).
+- Grep for the new DocType in `app/src/sync.ts` / `cms/src/sync.ts` to confirm the watcher is registered.
+- Grep for the new use_index name in the sync code to confirm it matches the file name exactly.
+
+### 7. Report
+
+- Files added/changed (with paths).
+- Reminder: API needs restart for the new design doc to materialize the index.
+- Reminder: if shared changed, run `/rebuild-shared`.
+- Confirm: validator either accepts unchanged OR was extended (and explain why).
+
+## What this skill is NOT
+
+- Not a query author. The user provides the query intent; this skill is the wiring.
+- Not a perf review. If the user expects high-volume sync, point them at `shared/src/rest/sync2/README.md`.
+- Not a Vitest harness. Sync tests touch CouchDB and are user-driven.

--- a/.claude/skills/diff-vs-main/SKILL.md
+++ b/.claude/skills/diff-vs-main/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: diff-vs-main
+description: Summarize what the current branch changes versus origin/main (committed + uncommitted) and flag cross-package contract risks specific to this monorepo. Use when the user asks "what's different from main", "what would this PR contain", "diff against main", "review my branch", or anything similar before opening or refining a PR.
+---
+
+# diff-vs-main
+
+Produce a tight pre-PR summary: what changed against `origin/main`, what risks the change introduces given this repo's cross-package contracts, and what looks untested.
+
+## What this skill is NOT
+
+- Not a code review — don't critique style, naming, or correctness line-by-line. Use `/code-review` for that.
+- Not a PR creator — don't push, don't open a PR. Just report.
+- Not a test runner — flag untested areas; don't run e2e/playwright (user runs those).
+
+## Procedure
+
+### 1. Gather state (run in parallel)
+
+Run these in a single message, all parallel:
+
+- `git fetch origin main --quiet` — needed because local `main` may be stale.
+- `git status --short` — uncommitted changes.
+- `git rev-parse --abbrev-ref HEAD` — current branch name.
+- `git log origin/main..HEAD --oneline` — commits ahead of origin/main.
+- `git diff origin/main...HEAD --stat` — committed file-level stats.
+- `git diff --stat` — unstaged stats.
+- `git diff --cached --stat` — staged stats.
+
+If `git fetch` fails (offline, no remote), fall back to local `main` and **say so in the report**.
+
+### 2. Get the actual diffs
+
+Once you know which files changed, fetch the diffs you need:
+
+- `git diff origin/main...HEAD -- <files>` for committed changes.
+- `git diff -- <files>` + `git diff --cached -- <files>` for working-tree changes.
+
+Don't dump the entire diff into context if it's large. Read selectively: enough to understand intent and spot the risks below. If a file's diff is huge (>500 lines), summarize from the stat + spot-read the most important hunks.
+
+### 3. Check cross-package contracts
+
+This monorepo has known seams that break silently when one side changes without the other. **Check each of these against the changed-file list and flag mismatches:**
+
+| If this changed… | …also expect a change in | Reason |
+|---|---|---|
+| `api/src/dto/**` (DTO fields) | `shared/src/types/dto.ts` | DTOs are mirrored; API and clients must agree on shape. |
+| `shared/src/types/dto.ts` | `api/src/dto/**` | Same — bidirectional. |
+| `api/src/util/ftsIndexing.ts` | `shared/src/fts/ftsSearch.ts` | FTS field config + boosts must stay identical (ADR 0009). |
+| `shared/src/fts/ftsSearch.ts` | `api/src/util/ftsIndexing.ts` | Same — bidirectional. |
+| New Mango sync queries in `app/` or `cms/` | `api/src/db/designDocs/sync-*-index.json` + check passes `api/src/db/MongoQueryTemplates/validators/sync.ts` | New sync queries need a matching index and validator entry. |
+| `api/src/auth/**` `AuthFailureReason` codes / payloads | `app/src/main.ts` + `cms/src/main.ts` `connect_error` handler | Failure codes drive client-side eviction / silent refresh. |
+| `shared/src/**` (any) | App/CMS rebuild + re-install with `--install-links` | Consumers link against `shared/dist`; stale dist = stale behavior. Flag if a shared change exists and `app/package-lock.json`/`cms/package-lock.json` weren't touched, OR remind user to rebuild + reinstall before testing. |
+| `api/src/db/schemaUpgrade/**` | `_schemas.schemaVersion` bump (visible in the same file) | Schema upgrades must bump the version on success. |
+| `api/src/db/MongoQueryTemplates/**` (new template) | Identifier referenced from a client `useDexieLiveQuery` / `ApiLiveQuery` | Otherwise the template is dead code. |
+
+Don't invent additional contracts — only flag the ones in this table.
+
+### 4. Check for untested areas
+
+For each changed source file (excluding config, docs, markdown):
+
+- Look for a sibling `*.spec.ts` / `*.test.ts` or a `__tests__/` directory.
+- If neither the test file itself nor a sibling test was modified, list the file under "untested".
+
+Exclusions (don't flag as untested):
+- `*/main.ts`, `*/auth.ts`, `*/guards/**`, `*/analytics.ts` in `app/` and `cms/` (excluded from coverage by config).
+- `api/src/db/schemaUpgrade/**` (excluded from API coverage).
+- Pure type-only files (`*.d.ts`, files containing only `export type`/`export interface`).
+- `*.md`, `*.json`, `*.yml`, `*.config.ts`, `Dockerfile`, etc.
+
+### 5. Report
+
+Output in this exact structure. Keep each section terse — bullet points, not paragraphs.
+
+```
+Branch: <name>  vs  origin/main
+Commits ahead: <N>   Files changed: <N committed> + <N uncommitted>
+
+## Changes by package
+- api/        — <N files>: <one-line gist>
+- shared/     — <N files>: <one-line gist>
+- app/        — <N files>: <one-line gist>
+- cms/        — <N files>: <one-line gist>
+- (skip packages with no changes)
+
+## Cross-package risks
+- <risk 1, citing the rule from the table and the file:line that triggered it>
+- <risk 2…>
+- (or: "None detected" if clean)
+
+## Untested
+- <file path> — <one-line note on what's new>
+- (or: "All changed files have adjacent test edits")
+
+## Notes
+- <only include if something is worth surfacing: stale fetch, huge diff skipped, etc.>
+```
+
+If the report finds zero changes (`git diff origin/main...HEAD` is empty and working tree is clean), say so in one line and stop.
+
+## Tone
+
+This is a sanity check, not an audit. Bullets, file paths, line numbers. No prose padding. No "looks good!" — just the facts; the user will decide what's good.

--- a/.claude/skills/explain-permission/SKILL.md
+++ b/.claude/skills/explain-permission/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: explain-permission
+description: Trace why a user can or cannot perform a given action on a given doc type — walking through their group membership, the ACL entries on those groups, the resulting AccessMap, and the verifyAccess decision. Use when the user asks "why can/can't user X do Y to a Z", "permission seems wrong", "ACL not taking effect", "explain access for…", or similar.
+---
+
+# explain-permission
+
+The Luminary permission system has four layers, and the answer to "why was access granted/denied" almost always lives in one of them. This skill walks them in order and reports where the decision was made.
+
+## The four layers
+
+1. **User → Groups** (`User.memberOf`): which groups the user is in.
+2. **Group ACL entries** (`Group.acl[]`): each entry is `{ type: DocType, groupId: Uuid, permission: AclPermission[] }` — saying "members of *this* group get *these permissions* on docs of *this type* in *that group*".
+3. **AccessMap derivation** (`PermissionSystem.getAccessMap(userGroups)`): builds `Map<groupId, Map<DocType, Map<AclPermission, boolean>>>` by walking the ACL graph including nested-group inheritance.
+4. **verifyAccess decision** (`PermissionSystem.verifyAccess(groups, docType, permission, userGroups, "any"|"all")`): the call site that consults the AccessMap with the doc's own `memberOf` and chooses any/all semantics.
+
+The bug is almost always at layer 2 or 3 — wrong ACL entry, or unexpected inheritance. Layer 1 is usually obvious, layer 4 is usually right.
+
+## What you need from the user before starting
+
+- **The user** (email or user id, or just "the test user").
+- **The action** (`View`, `Edit`, `Translate`, `Publish`, `Assign`, `Delete`).
+- **The doc type** (e.g. `Post`, `Content`, `Group`).
+- The **doc id** or its `memberOf` group(s) if known.
+- Whether they're using **api-side** evaluation (change request rejection) or **client-side** (UI disabled / sync filtered).
+
+If the report is "test user can't see something they should", that's `View` on the doc type, observed client-side.
+
+## Procedure
+
+### 1. Locate the User doc
+
+The user's group membership is on their User doc. Find it via:
+
+- email — `email-type-index.json` design doc supports this query
+- externalUserId / providerId — `externalUserId-type-index.json`
+
+Read `User.memberOf` (an array of group IDs). That's layer 1.
+
+### 2. Read the AccessMap (if running)
+
+If the API is running and the user is logged in, their AccessMap is the source of truth. It's delivered via Socket.io's `clientConfig` event and lives in the client's `localStorage` (`accessMap` key managed by `useLocalStorage` in `shared/src/permissions/permissions.ts`).
+
+Client-side check (user to run, in DevTools):
+
+```js
+JSON.parse(localStorage.getItem("accessMap"))
+```
+
+The structure is `{ [groupId]: { [docType]: { [permission]: boolean } } }`. If the user's `accessMap` has `{ <docMemberOfGroupId>: { <DocType>: { View: true } } }`, View is granted. If not, denied.
+
+### 3. Read the Group docs to understand layer 2
+
+For each group in `User.memberOf`, fetch the Group doc:
+
+```sh
+curl -u admin:<pw> http://localhost:5984/<db>/<groupId>
+```
+
+Inspect `Group.acl[]`. Each entry says: "members of `this.groupId` (the entry's groupId) get `this.permission` on `this.type` docs that belong to this Group doc."
+
+Trace:
+
+- The doc the user is acting on belongs to group **G** (in its `memberOf`).
+- The user is a member of group **U1, U2…**.
+- Look at **G**'s `acl[]`. Is there an entry with `groupId ∈ {U1, U2, …}` and `type = <DocType>` and `permission ⊇ [<requested>]`?
+- If yes → granted.
+- If no → check inherited access. Group nesting: G's parent groups' ACL entries (`G.memberOf`) also apply. Walk up.
+
+### 4. Server-side: replay verifyAccess
+
+For change-request validation, the entry point is `PermissionSystem.verifyAccess(doc.memberOf, docType, permission, user.memberOf, "any" | "all")`.
+
+- `"any"` mode: granted if any of the doc's memberOf groups grants the user permission.
+- `"all"` mode: granted only if all of them do.
+
+For tag assignment, the check is `"all"` against `tags` — the user must have View on every tag.
+
+Search `api/src/changeRequests/validateChangeRequestAccess.ts` for the exact `verifyAccess` call relevant to the doc type to find the mode used.
+
+### 5. Common gotchas
+
+Flag any of these if you spot them:
+
+- **AccessMap is stale.** If the user's groups changed but they haven't reconnected, their AccessMap is the old one. The fix is a Socket.io reconnect (the server replaces the map wholesale on `clientConfig`).
+- **`PermissionSystem` not initialized.** `PermissionSystem.init(dbService)` runs at API boot. If a test forgot to await it, all `verifyAccess` calls return false.
+- **Anonymous user.** `AuthIdentityService.resolveOrDefault` returns an anonymous identity with `getDefaultGroups()` if no token. Check `getDefaultGroups` to see what anonymous users can do.
+- **`accessMapToGroups` for sync filtering** — it's the inverse: given a permission, returns the groups the user has it on, per docType. Used by `QueryService` to inject `memberOf.$in` into sync queries. If a doc isn't syncing, this is the layer that filters it out.
+
+## Report structure
+
+```
+User: <email / id>
+Action: <permission> on <DocType>
+Doc memberOf: [<group ids, with names if known>]
+User memberOf: [<group ids, with names if known>]
+
+Trace:
+  User groups:           <list>
+  Doc lives in groups:   <list>
+  Relevant ACL entries:  
+    - Group <docGroup> grants <permission> on <DocType> to <granteeGroup>  (user is member?  YES/NO)
+    - ...
+  Inherited via nesting? <yes/no, path>
+  
+Decision: GRANTED / DENIED
+Reason: <one-line>
+
+If decision contradicts user's expectation, check:
+  - AccessMap freshness (reconnect)
+  - verifyAccess mode (any/all) at the call site: <file:line>
+  - getDefaultGroups (anonymous path)
+```
+
+## What this skill is NOT
+
+- Not a permission editor. The user owns ACL changes.
+- Not a User doc creator. Don't add anyone to a group.
+- Not for storage permissions. S3 bucket access is encoded on `Storage` docs and checked via the `View` permission on those — same mechanism, but if the user asks about bucket access specifically, mention `api/src/endpoints/storageStatus.controller.ts`.

--- a/.claude/skills/pr-body/SKILL.md
+++ b/.claude/skills/pr-body/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pr-body
+description: Generate a PR title and body from the current branch's diff against origin/main. Use when the user asks to "draft a PR body", "write a PR description", "PR title for this branch", or is about to open a PR and wants the description prepared.
+---
+
+# pr-body
+
+Generate a PR title + body from the current branch's diff vs `origin/main`. Output ready-to-paste markdown matching the conventions used in recent merges on `main`.
+
+This is a **drafting** skill — it produces text. It does **not** push, create the PR, or run `gh pr create`. The user reviews and runs the create command themselves (or asks you to in a follow-up).
+
+## What you need from the user
+
+Usually nothing — just run. But if the branch is on `main` or has zero commits ahead of `origin/main`, ask: "There's nothing to PR yet — did you mean a different branch?" and stop.
+
+## Procedure
+
+### 1. Gather state
+
+Run in parallel:
+
+- `git fetch origin main --quiet` (skip silently if offline; note in report)
+- `git rev-parse --abbrev-ref HEAD` — current branch
+- `git log origin/main..HEAD --oneline` — commits in this PR
+- `git diff origin/main...HEAD --stat` — file-level change scope
+- `git log -20 --pretty=format:"%s" main` — recent merged PR titles, to match style
+
+### 2. Read recent merged-PR titles to match style
+
+The first 5-20 commit subjects from `git log main` show the project's title conventions. Common patterns in this repo (observed from recent commits):
+
+- Prefix with the package: `APP:`, `CMS:`, `API:`, `Shared:`. Example: "APP: add a trigger field to indicate if dom has been populated (#1635)".
+- Sentence case after the prefix.
+- "Fix:" prefix (no package) for cross-cutting fixes: "Fix: Skip stale deleteCmd when local doc is newer (#1628)".
+- Trailing `(#NNNN)` is added by GitHub on merge — don't include it in the draft.
+
+Pick the convention that matches what *this* branch touches. If it touches one package, prefix with that package. If multiple, no prefix or use the dominant one.
+
+### 3. Read the actual diff
+
+Use `git diff origin/main...HEAD -- <files>` for the files in the stat. Read enough to understand the *why* of each change, not just the *what*. Goals:
+
+- One-sentence summary of what the PR does.
+- 2-5 bullets of substantive changes (skip trivial reformats, lint fixes).
+- Any non-obvious decisions or trade-offs to surface.
+- Test coverage notes.
+
+Don't include the raw diff in the PR body. Reviewers click "Files changed" for that.
+
+### 4. Compose the body
+
+Output exactly this structure (use the project's style — no marketing copy, no "this PR introduces…"):
+
+```
+<Title — see step 2 conventions, <70 chars, no trailing period>
+
+## Summary
+- <one-line of what this delivers, written from the user/system perspective>
+- <one-line of how (high level approach), if non-obvious>
+- <one-line of any tradeoff or follow-up worth flagging>
+
+## Changes
+- <file or area> — <what changed and why>
+- <file or area> — <what changed and why>
+- (3-5 bullets max; bundle small related edits)
+
+## Test plan
+- [ ] <test step 1 — describe an observable behaviour to verify>
+- [ ] <test step 2>
+- [ ] <test step 3>
+- (3-5 items; one per behaviour, not one per file)
+
+<Optional sections, only if applicable:>
+
+## Cross-package contracts touched
+- DTO mirror: <api/X vs shared/Y — confirmed in sync>
+- FTS config: <api/util/ftsIndexing.ts and shared/fts/ftsSearch.ts — both updated>
+- New sync query: <design doc + validator updated>
+
+## Notes
+- <anything that helps the reviewer but doesn't fit above — e.g. "depends on PR #N", "requires API restart for new design doc">
+```
+
+### 5. Self-check before reporting
+
+- Title under 70 chars.
+- Summary bullets describe *outcomes*, not file lists.
+- Test plan items are *behaviours*, not "run tests" (that's a CI concern).
+- "Cross-package contracts" section only present if the diff actually touched those seams (use the same checks from `/diff-vs-main`).
+- No marketing language ("seamless", "powerful", "robust"). No `🤖 Generated…` trailer. The user adds those if they want.
+
+### 6. Output and stop
+
+Print the full PR body in a fenced markdown block so the user can copy it. End with one line telling them how to use it:
+
+```
+Paste this into a `gh pr create --title "<title>" --body "..."` invocation, or copy into the GitHub PR composer.
+```
+
+Do not actually run `gh pr create`. Do not push.
+
+## What this skill is NOT
+
+- Not a PR opener. The user reviews and submits.
+- Not a code reviewer. Don't critique the diff — describe it.
+- Not a diff dumper. The PR body summarizes; the diff itself is one click away.
+- Not for issue templates. Use the issue templates in `.github/ISSUE_TEMPLATE/` for those.
+
+## Pair with `/diff-vs-main`
+
+For a sanity check on the branch before drafting, run `/diff-vs-main` first — it flags cross-package contract risks that may belong in the "Notes" section here.

--- a/.claude/skills/prep-task/SKILL.md
+++ b/.claude/skills/prep-task/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: prep-task
+description: Before starting a non-trivial change, surface relevant memories, ADRs, recent commits in the area, and sibling code patterns so the work starts well-grounded. Use when the user asks to "prep for X", "set me up to work on X", "what should I know before changing Y", or at the start of a session focused on a specific feature area.
+---
+
+# prep-task
+
+Survey the context around a task **before** starting it. The goal is to surface known constraints (memories), prior decisions (ADRs), recent activity (git log), and existing patterns to match (sibling code) — so you don't repeat mistakes the user has already corrected, contradict an ADR, or re-invent a convention that already exists nearby.
+
+This is a **read-only orientation** step. No edits. Output is a context briefing the user can scan in under 30 seconds.
+
+## What you need from the user
+
+The task in a sentence. Examples:
+
+- "I want to add a new search filter for tag pinning."
+- "Refactor how the CMS notification store debounces toasts."
+- "Add an endpoint for batch image upload."
+
+If the task is unclear or scope-less ("clean up the codebase"), ask for one specific area before proceeding — this skill is for focused changes, not blanket work.
+
+## Procedure
+
+Run these searches in parallel — they are independent.
+
+### 1. Check memories
+
+Read `/Users/dirk/.claude/projects/-Users-dirk-projects-bccsa-luminary/memory/MEMORY.md` and identify memories likely relevant to the task:
+
+- `feedback_*` entries about *how* to do similar work (e.g. minimal implementation, schema upgrade strategy, no in-memory caches).
+- `project_*` entries about ongoing work in the same area.
+- `user_*` entries about the user's preferences/constraints.
+
+For each match, read the full memory file (linked from MEMORY.md). Surface the relevant ones in the briefing — quote the rule and its **Why**.
+
+Per the global instructions: a memory naming a specific file/function is a *historical* claim. Before saying "X is in file Y", verify Y still exists and contains X. Don't recommend from stale memory.
+
+### 2. Find relevant ADRs
+
+```sh
+ls /Users/dirk/projects/bccsa/luminary/docs/adr/
+```
+
+Read titles. For any with keywords matching the task domain (auth, sync, FTS, monorepo, backwards compatibility, branching, design guidelines, z-index), open the ADR and skim. Surface ones that constrain the task.
+
+Common ones to consider:
+
+- ADR 0005 — Backwards compatibility (anything API-shaped).
+- ADR 0009 — Server-side FTS (anything content-search-shaped).
+- ADR 0003 — Branching (anything release-shaped).
+
+### 3. Recent activity in the area
+
+```sh
+git log --oneline -20 -- <plausible-files-or-dirs>
+git log --oneline --all -20 --grep="<keyword>"
+```
+
+Replace `<plausible-files-or-dirs>` with the directory the task touches (e.g. `app/src/components/Search`, `api/src/endpoints`). Replace `<keyword>` with the task's main noun (e.g. "tag", "fts", "schema").
+
+Surface commits from the last ~30 days that touch the same code paths. They tell you what's volatile and what the latest patterns are.
+
+### 4. Sibling code patterns
+
+For the task's specific surface:
+
+- **Adding a new endpoint?** Read one similar endpoint controller + service in `api/src/endpoints/` end-to-end.
+- **Adding a Vue page?** Look at the page nearest in concept under `app/src/pages/` (or `cms/src/pages/`) — note the `__tests__/` colocation pattern.
+- **Adding a sync query?** Read the most-similar existing watcher in `app/src/sync.ts` or `cms/src/sync.ts`.
+- **New DTO field?** Read the DTO file on both sides (`api/src/dto/`, `shared/src/types/dto.ts`).
+- **Schema upgrade?** Read the most recent `vN.ts` as the canonical template.
+
+Capture the convention to match — file naming, test colocation, imports — so the new code blends in.
+
+### 5. Sub-package CLAUDE.md
+
+If the task is squarely in one package, read that package's `CLAUDE.md`:
+
+- `api/CLAUDE.md`, `app/CLAUDE.md`, `cms/CLAUDE.md`, `shared/CLAUDE.md`.
+
+These have the package-specific gotchas (e.g. shared's `vitest.setup.ts` failing on Dexie index warnings; api's strict-null-checks-off; app's render-state contract for prerender).
+
+### 6. Cross-package risks
+
+If the task plausibly touches contracts in the root `CLAUDE.md` table (DTO mirror, FTS, sync indexes, auth codes, schema upgrade), flag them up front so the user remembers to do the matching edits.
+
+## Report structure
+
+```
+Task: <restate the task in one sentence>
+Touches: <packages — api / app / cms / shared / playwright-tests>
+
+## Relevant memories
+- <name>: <rule> — Why: <reason>
+- (or "None applicable")
+
+## Relevant ADRs
+- 000X — <title>: <one-line constraint it imposes on this task>
+- (or "None applicable")
+
+## Recent activity in the area
+- <hash> <date> — <subject>
+- <hash> <date> — <subject>
+- (last 3-5 commits in the same files/area)
+
+## Patterns to match
+- <file:> — <convention to follow, e.g. "tests live in __tests__/ sibling folder">
+- <file:> — <pattern, e.g. "all DTOs use @Expose() on persisted fields">
+
+## Cross-package contracts at risk
+- <e.g. "Will touch api/src/dto/PostDto.ts — also edit shared/src/types/dto.ts (PostDto type)">
+- (or "None expected")
+
+## Suggested first step
+- <one concrete file to open / sketch to draw / question to resolve before coding>
+```
+
+Keep each section terse — bullets, not paragraphs. The user is about to start work; don't drown them in pre-reading.
+
+## What this skill is NOT
+
+- Not an implementation. Briefing only.
+- Not a planning doc. No multi-week roadmaps. The output is "what to read before touching the keyboard".
+- Not a memory writer. Read memories; don't update them here (the conversation will surface new ones naturally).
+- Not exhaustive. If a section turns up nothing relevant, say "None applicable" and move on — don't pad.

--- a/.claude/skills/rebuild-shared/SKILL.md
+++ b/.claude/skills/rebuild-shared/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: rebuild-shared
+description: Rebuild luminary-shared and reinstall it in app/ and cms/ via --install-links so the consumers pick up local changes. Use when the user has edited files in shared/ and wants to test or run the app/cms against the new code, or asks to "rebuild shared", "sync shared into app/cms", "after changing shared what do I do", or similar.
+---
+
+# rebuild-shared
+
+Build `shared/` and reinstall it into `app/` and `cms/` so consumers see the local changes. Without this, the consumers keep using the cached `shared/dist/` from `node_modules/luminary-shared/` and your edits do nothing at runtime.
+
+## Why `--install-links` is non-negotiable
+
+Plain `npm install ../shared` symlinks the package — Dexie loses its package boundary and **IndexedDB reactivity breaks silently**. Always use `--install-links`. This is also why this repo's setup wizard and post-checkout hook use it.
+
+## Procedure
+
+### 1. Confirm scope
+
+Check which consumers are present before rebuilding. Run in parallel:
+
+- `ls /Users/dirk/projects/bccsa/luminary/shared/package.json` — confirm shared exists
+- `ls /Users/dirk/projects/bccsa/luminary/app/package.json` — confirm app exists
+- `ls /Users/dirk/projects/bccsa/luminary/cms/package.json` — confirm cms exists
+- `git -C /Users/dirk/projects/bccsa/luminary/shared status --short` — confirm there actually are local changes worth rebuilding (skip rebuild if clean and the user didn't insist)
+
+### 2. Build shared
+
+```sh
+cd /Users/dirk/projects/bccsa/luminary/shared && npm run build
+```
+
+This runs `vue-tsc + vite build` → `dist/`. If type-check fails, **stop**. Report the type errors to the user — don't reinstall a broken build.
+
+### 3. Reinstall in app and cms
+
+Run **sequentially** (they read the same `shared/dist/`, but parallelizing here gains nothing and complicates failure attribution):
+
+```sh
+cd /Users/dirk/projects/bccsa/luminary/app && npm install --install-links ../shared
+cd /Users/dirk/projects/bccsa/luminary/cms && npm install --install-links ../shared
+```
+
+Use `npm install --install-links ../shared` — not `npm ci`. `npm ci` would wipe and reinstall the whole tree from `package-lock.json`, which is slow and unnecessary.
+
+If a consumer has uncommitted lockfile changes after this, that's expected — the lockfile records the new tarball hash from the local build. Don't revert it.
+
+### 4. Verify and report
+
+```sh
+ls /Users/dirk/projects/bccsa/luminary/app/node_modules/luminary-shared/dist/index.js
+ls /Users/dirk/projects/bccsa/luminary/cms/node_modules/luminary-shared/dist/index.js
+```
+
+Both should exist with a fresh mtime. Report:
+
+- Shared build: OK / failed
+- App reinstall: OK / failed
+- CMS reinstall: OK / failed
+
+If the dev server for `app/` or `cms/` is already running, remind the user it needs to be restarted — Vite caches the resolved package between starts.
+
+## What this skill is NOT
+
+- Not a test runner. Don't run vitest after reinstall unless asked.
+- Not a dev-server starter. Use `/run` or `app/`'s `npm run dev` for that.
+- Not for production builds. This is the local-dev install-link path only.

--- a/.claude/skills/sync-dtos/SKILL.md
+++ b/.claude/skills/sync-dtos/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: sync-dtos
+description: Mirror DTO field changes between api/src/dto/*.ts (class-based, decorator-validated) and shared/src/types/dto.ts (plain TypeScript types). Use when the user adds, renames, or removes a field on a document DTO on one side, or asks "keep DTOs in sync", "mirror DTO change", "I added X to ContentDto", or similar.
+---
+
+# sync-dtos
+
+The API and the shared client library each define their own DTO shape for every document type. They must agree on field names, optionality, and types. This contract is the single most-likely-to-drift seam in this monorepo.
+
+## The two sides
+
+| Side | Location | Style |
+|---|---|---|
+| API | `api/src/dto/<Name>Dto.ts` (one class per file) | `class XxxDto extends _baseDto` with `class-validator` decorators (`@IsString`, `@IsOptional`, etc.) and `@Expose()` from `class-transformer` |
+| Shared | `shared/src/types/dto.ts` (all types in one file) | Plain TypeScript `type XxxDto = BaseDocumentDto & { ... }` |
+
+They differ in style, not in semantics. A field added on one side must appear on the other.
+
+## Who owns what
+
+The API is authoritative for fields **it sets**, not the client. The client is authoritative for nothing — even fields it originates on a change request still flow through API validation. Server-set fields you must NOT make required on the client write path: `parent*`, `availableTranslations`, `fts`, `ftsTokenCount`, `statusChangeDeleteCmdId`.
+
+## Procedure
+
+### 1. Identify the change
+
+From the current diff (or the user's description), determine:
+
+- Which DTO changed? (e.g. `ContentDto`, `PostDto`, `LanguageDto`, `DeleteCmdDto`)
+- Which side did the change land on first? (api or shared)
+- What is the change? (add field, remove field, rename, type change, optionality change)
+
+If the change is unclear, read the file on the side that was edited.
+
+### 2. Locate the counterpart
+
+- API DTO → `api/src/dto/<Name>Dto.ts`
+- Shared DTO → `shared/src/types/dto.ts` — search within that single file for `type <Name>Dto`
+
+If the API DTO extends `_contentBaseDto` or `_baseDto`, the shared counterpart usually extends `ContentBaseDto` or `BaseDocumentDto`. Some fields live on the base type, not the child — check both.
+
+### 3. Mirror the change
+
+Map between the two styles:
+
+| API (class) | Shared (type) |
+|---|---|
+| `@IsNotEmpty() @IsString() @Expose() name: string;` | `name: string;` |
+| `@IsOptional() @IsString() @Expose() author?: string;` | `author?: string;` |
+| `@IsEnum(PublishStatus) @Expose() status: PublishStatus;` | `status: PublishStatus;` |
+| `@IsArray() @Expose() tags: Uuid[];` | `tags: Uuid[];` |
+| `@IsNumber() @Expose() publishDate?: number;` | `publishDate?: number;` |
+| Nested DTO: `@Type(() => ImageDto) @Expose() image: ImageDto;` | `image: ImageDto;` (and import `ImageDto`) |
+
+Rules:
+
+- **Required vs optional must match.** Mismatch = silent runtime breakage. The decorator pair `@IsNotEmpty()` (or absent `@IsOptional()`) → no `?` in shared.
+- **Enums must point at the same enum.** API imports from `api/src/enums.ts`, shared imports from `shared/src/types/enum.ts`. The string values must match; the user is responsible for keeping the enums themselves in sync (a separate concern).
+- **Every persisted API field must have `@Expose()`.** `instanceToPlain` drops un-exposed fields on write, so a missing `@Expose()` on a new field means it never reaches the DB. Flag this if you see a new field on the API side without it.
+- **Don't forget the `import` line in `shared/src/types/dto.ts`** if you reference a new enum or nested type. The file is one big block; missing imports break the whole build.
+
+### 4. Cross-check related files
+
+If the field is on `ContentDto`, also check:
+
+- `api/src/util/ftsIndexing.ts` — if the new field is text content, it may need to be indexed. Search the file for the existing fields (title/summary/text/author) to find the field config.
+- `shared/src/fts/ftsSearch.ts` — same config must match (ADR 0009).
+
+If the field affects sync filtering, check the `sync.ts` validator (`api/src/db/MongoQueryTemplates/validators/sync.ts`) — new selector fields require allowlist updates.
+
+### 5. Report
+
+Output:
+
+- The exact lines added/changed on each side, with file paths and line numbers.
+- Any cross-checks performed (FTS, sync validator).
+- A reminder: if shared/ was edited, `/rebuild-shared` is needed before app/cms pick up the change.
+
+Don't run tests; don't push. Just mirror, then report.
+
+## What this skill is NOT
+
+- Not a DTO designer. The user decides the field shape; this skill mirrors a decided change.
+- Not a schema upgrader. New required fields on existing docs need `/add-schema-upgrade` separately.
+- Not an enum mirror. Enum changes in `api/src/enums.ts` and `shared/src/types/enum.ts` are a related but separate concern — flag if they mismatch, but don't auto-edit unless the user asks.

--- a/.claude/skills/trace-sync/SKILL.md
+++ b/.claude/skills/trace-sync/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: trace-sync
+description: Investigation playbook for why a document isn't syncing to a client (app or CMS) as expected. Walks the full sync path — syncList registration, permissions, connectivity, design docs, socket rooms, bulkPut filters. Use when the user reports "doc X isn't showing up", "sync seems stuck", "I edited X in the CMS but the app doesn't see it", or similar.
+---
+
+# trace-sync
+
+A doc not showing up at the client can be any of ~8 different things. This skill walks them in order of probability, narrowing down where the chain breaks.
+
+This is **read-only investigation**. Don't edit code, don't restart services, don't bump versions. Report findings; let the user fix.
+
+## What you need from the user before starting
+
+Ask if any are missing:
+
+- Which **client**? App or CMS.
+- Which **doc type**? (`Post`, `Tag`, `Content`, `Language`, etc.)
+- A specific **doc id** if they have one.
+- What they **expected** vs **observed**. ("New post not visible" vs "edits to existing post not reflecting" vs "doc disappeared".)
+- Are they **online**? Sync only happens when `isConnected` is true.
+
+## The chain (walk in order)
+
+### 1. Is the doc type in the consumer's syncList?
+
+Check `app/src/sync.ts` (or `cms/src/sync.ts`) for a `sync({ type: DocType.<X>, ... })` call. If the doc type isn't listed, it's not synced — full stop.
+
+For Content docs, check the parent type (Post/Tag) and confirm the parent's content sync block exists.
+
+### 2. Is there a design doc for it on the API?
+
+```sh
+ls api/src/db/designDocs/sync-<type>-index.json
+```
+
+If missing, sync requests for this type will either fail validation (`use_index` mismatch) or hit a full table scan. Look for warnings in API logs about missing indexes.
+
+### 3. Does the user have View permission?
+
+The sync filter is `access[DocType.<X>]` from `getAccessibleGroups(AclPermission.View)`. Walk:
+
+- What groups is the user a member of? Check `User.memberOf` on their User doc.
+- What ACL entries do those groups have for this doc type? Check the Group docs' `acl` field.
+- Does the `accessMap` in the client's localStorage contain the expected `{ groupId: { docType: { View: true } } }`?
+
+If no View grant: nothing will sync. This is by design.
+
+For Content docs, the permission is checked against the **parent's** type (Post/Tag), not Content. `QueryService.accessMapToGroups` resolves this.
+
+### 4. Is the client actually connected?
+
+- `isConnected` ref from shared. False → all sync skipped, `setCancelSync(true)` called.
+- Check for `connect_error` events. The most common cause is `auth_failed` (`AuthFailureReason`). In `app/src/main.ts` and `cms/src/main.ts` there's a handler that catches `provider_not_found`, `token_invalid`, etc. and triggers eviction/refresh.
+
+### 5. Did the doc reach IndexedDB?
+
+In the browser DevTools (user-side investigation; you can only describe how):
+
+- Open Application → IndexedDB → `luminary` → `docs` table.
+- Search for the doc id. If present, the sync delivered it — the bug is in display/query.
+- If absent: sync did not deliver. Continue down the chain.
+
+Also check `localChanges` table — if the doc was edited by this client and the change is pending upload, it's stuck there until the next `syncLocalChanges` run.
+
+### 6. Did the server-side stale-delete guard drop it?
+
+`shared/src/db/database.ts`'s `bulkPut` skips deletes whose target doc is already newer in local storage. If the user is seeing a delete not propagate, this is the most likely cause — but it's an intentional guard against stale `DeleteCmd` overwriting fresh edits.
+
+### 7. Is the doc in the right group's memberOf?
+
+For server-side sourcing: the doc must have `memberOf: [<groupId>]` matching a group the user can View. Content docs inherit `memberOf` from their parent (Post/Tag).
+
+Check via the API:
+
+```sh
+curl -u admin:<pw> http://localhost:5984/<db>/<docId>
+```
+
+(User runs this — you can describe the command.)
+
+### 8. Socket room delivery (for live updates only)
+
+For real-time updates (not initial sync), the doc flows through Socket.io rooms `${docType}-${groupId}`. The server emits to the room when `DbService` fires an `update` event. If the user is missing **live** updates but a manual refresh works, the issue is room membership — check what rooms the client joined on `joinSocketGroups` (server-side `socketio.ts`).
+
+### 9. CMS-specific: language scoping
+
+The CMS sync `content` iterator only ticks when at least one CMS language is selected (`cmsLanguageIdsAsRef.value.length > 0`). If a CMS user reports no Content syncing, check whether they've picked a language.
+
+The App equivalent is `appLanguageIdsAsRef` — also required to be non-empty before content syncs.
+
+## Procedure
+
+1. Confirm scope with the user (see "What you need from the user").
+2. Walk the chain in order. For each step, either:
+   - Read the relevant file / state to verify.
+   - Or describe to the user what they should check (DevTools, CouchDB).
+3. Stop at the first broken link. Report what's broken and where.
+
+Don't keep walking past a confirmed break — fix proposals belong in a follow-up, not this skill.
+
+## Report structure
+
+```
+Doc type: <X>   Client: <app|cms>
+Symptom: <what the user reported>
+
+Chain walk:
+  [1] syncList registration ........ OK / MISSING (in <file>:<line>)
+  [2] design doc .................. OK / MISSING (api/src/db/designDocs/sync-<x>-index.json)
+  [3] View permission ............. OK / DENIED (user is in groups <a,b>; doc's memberOf is <c>)
+  [4] isConnected ................. true / false (last error: <…>)
+  [5] reached IndexedDB ........... unknown — user to check DevTools
+  [6] stale-delete guard .......... — / triggered (see shared/src/db/database.ts:bulkPut)
+  [7] memberOf alignment .......... OK / mismatch
+  [8] socket room ................. — (only matters for live updates)
+  [9] language scope (CMS) ........ N/A / OK / no language selected
+
+Conclusion: <one-line diagnosis>
+Suggested next step: <one-line next action for the user>
+```
+
+Don't fix. Just diagnose.
+
+## What this skill is NOT
+
+- Not a code editor. Diagnose only.
+- Not a CouchDB admin tool. You can describe queries, but the user runs them.
+- Not for performance issues. If sync is slow but eventually delivers, the diagnosis is in `shared/src/rest/sync2/README.md`, not here.

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,3 @@ node_modules
 *.bkp
 
 stats.html
-
-.agent
-CLAUDE.md
-.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+Luminary is an offline-first content platform. The repo is a monorepo with no root `package.json` and no workspace tooling — each package installs and builds independently:
+
+- `api/` — NestJS 10 + Fastify backend over CouchDB (via `nano`) + S3/MinIO. See `api/CLAUDE.md`.
+- `shared/` — `luminary-shared` lib (IndexedDB/Dexie, REST + Socket.io, sync engine, FTS, permissions, Vue composables). Consumed by `app/` and `cms/` via `file:../shared`. See `shared/CLAUDE.md`.
+- `app/` — Offline-first Vue 3 PWA (Vite, port 4174). See `app/CLAUDE.md`.
+- `cms/` — Vue 3 CMS SPA (Vite, port 4175). See `cms/CLAUDE.md`.
+- `playwright-tests/` — Standalone E2E suite targeting **deployed** environments. Not wired into any package build. See `playwright-tests/README.md`.
+- `docs/` — ADRs (`docs/adr/`) and architecture diagrams.
+
+**Always read the relevant subpackage's `CLAUDE.md` before working there.** This file only covers cross-package concerns.
+
+## Local setup
+
+The wizard `./scripts/automate-luminary.sh setup` provisions CouchDB + MinIO containers, writes `.env` files, and installs in the correct order. For manual installs, the order matters:
+
+```sh
+cd shared && npm ci && npm run build      # must build first — app/cms link against dist/
+cd ../app && npm ci --install-links       # --install-links is required (symlinks break Dexie reactivity)
+cd ../cms && npm ci --install-links
+cd ../api && npm ci
+```
+
+After editing `shared/`, rebuild it (`npm run build` in `shared/`) and re-run `npm install --install-links ../shared` in `app/` and/or `cms/`. The `scripts/post-checkout` git hook prompts to do this automatically on branch switch — install it with `cp scripts/post-checkout .git/hooks/post-checkout && chmod +x .git/hooks/post-checkout`.
+
+## Default local ports
+
+3000 (api), 4174 (app), 4175 (cms), 5984 (CouchDB), 9000/9001 (MinIO S3 + console).
+
+## Cross-package contracts
+
+These are the seams that bite when you change one side and forget the other:
+
+- **DTO mirror.** `api/src/dto/*` mirrors `shared/src/types/dto.ts`. Field changes must land in both. The API is authoritative for server-set fields (`parent*`, `availableTranslations`, `fts`, `ftsTokenCount`, `statusChangeDeleteCmdId`).
+- **FTS field config.** `api/src/util/ftsIndexing.ts` and `shared/src/fts/ftsSearch.ts` use identical boost/field configuration (title=3.0, summary=1.5, text=1.0, author=1.0). Change both or search relevance silently diverges (ADR 0009).
+- **Sync query validation.** New Mango sync queries in `app/` or `cms/` require a matching `api/src/db/designDocs/sync-*-index.json` design doc **and** must pass `api/src/db/MongoQueryTemplates/validators/sync.ts` (rejects unknown keys, enforces `use_index` shape and `memberOf.$elemMatch.$in`, disallows syncing `user` docs).
+- **Auth failure codes.** `AuthFailureReason` codes (`provider_not_found`, `token_invalid`, …) emitted by `api/src/socketio.ts` and the REST `AuthGuard` drive client-side eviction and silent-refresh logic in `app/src/main.ts` and `cms/src/main.ts`. The handler is registered **before** `setupAuth()` in both clients — don't reorder.
+- **Backwards compatibility.** Cross-version contracts (API ↔ deployed clients) are governed by ADR 0005 (`docs/adr/0005-backwards-compatibility.md`). The `apiVersion` validation in `api/src/validation/apiVersion.ts` is the gate.
+
+## Workflow conventions
+
+- **Branching:** single `main` branch for both staging and production (ADR 0003). Auto-deploys to staging; production is manual. Hide unfinished work behind feature flags rather than long-lived branches.
+- **ADRs:** in `docs/adr/`. Use `adr new <title>` (requires [adr-tools](https://github.com/npryce/adr-tools)) for new ones.
+- **E2E / Playwright runs are owned by the user — do not invoke them.** This applies to `playwright-tests/`, the `cms/` package's own Playwright e2e, and any DB/S3-dependent tests in `api/`. CI for E2E uses `scripts/start-couchdb-in-ci.sh` and `scripts/start-minio-in-ci.sh`.
+- **CI:** `.github/workflows/` has one unit-test workflow per package (`api-unit-tests.yml`, `shared-unit-tests.yml`, etc.) plus `e2e-tests.yml`. Each runs only on its own package's path changes.
+
+## When changes span multiple packages
+
+Touching DTOs, FTS, sync queries, or auth payloads almost always means a coordinated edit across `api/` + `shared/` (and sometimes `app/`/`cms/`). Build order for verifying locally: `shared` → `api` → `app`/`cms`. If `shared/` changed, the `--install-links` re-install in consumers is mandatory — without it the consumers will still see the old `dist/`.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository context
+
+This is the `api/` package of the Luminary monorepo (sibling packages: `app/`, `cms/`, `shared/`, `playwright-tests/`, `docs/`). NestJS 10 + Fastify backend over CouchDB (via `nano`) with S3/MinIO for binary storage. Provides the sync, change-request, query, search, and storage-status endpoints that the `app/` PWA and `cms/` SPA depend on, plus a Socket.io gateway that pushes live document updates.
+
+E2E/Playwright runs are owned by the user — do not invoke them. Tests requiring CouchDB or S3 are also user-driven; CI uses `scripts/start-couchdb-in-ci.sh` and `scripts/start-minio-in-ci.sh` for the containers.
+
+## Prerequisites
+
+Tests and dev require a running CouchDB and S3-compatible store. See `README.md` for the docker commands. Copy `.env.example` → `.env` and `.env.test.example` → `.env.test` before first run.
+
+## Commands
+
+Run from `api/`:
+
+- `npm run start:dev` (or `npm run dev`) — Nest watch mode, default port 3000
+- `npm run start:prod` — production mode (logs go to a tailable `api.log` instead of stdout)
+- `npm run seed` — runs `main.ts` with `seed` arg: applies design docs and seeding docs from `src/db/seedingDocs/*.json`, then exits
+- `npm run auth-setup` — interactive script to add/modify auth providers (see `AUTH_SETUP.md`)
+- `npm run test` — Jest via `dotenv-cli` loading `.env.test`. Targeted runs: `npm test -- src/path/file.spec.ts -t "name"`. Use `npm run test:detect` to find open handles.
+- `npm run test:cov` — coverage; `db/schemaUpgrade/` and `test/` are excluded
+- `npm run lint` / `npm run lint:fix`
+- `npm run typecheck` — `tsc --noEmit`
+
+Node 20 (`.node-version`). `tsconfig.json` has `strictNullChecks: false` and `noImplicitAny: false` — be deliberate about null guards.
+
+## Architecture
+
+### Bootstrap (`src/main.ts`)
+
+Order-sensitive — read `main.ts` before reordering anything:
+
+1. `upsertDesignDocs(dbService)` — pushes CouchDB views/indexes from `src/db/designDocs/*.json`. New indexes go here; the sync-query template validator (`db/MongoQueryTemplates/validators/sync.ts`) requires `use_index` to be `sync-*-index`.
+2. If invoked with `seed` arg: `upsertSeedingDocs`, then `process.exit(0)` — the rest of bootstrap is skipped.
+3. `PermissionSystem.init(dbService)` — builds the in-memory permission graph from Group docs and subscribes to `groupUpdate` events.
+4. `S3Service.initializeChangeListener(dbService)` — wires the singleton S3 client cache to DB change events and disconnects.
+5. `upgradeDbSchema(dbService)` — runs schema upgrades sequentially (see below).
+6. CORS allowlist from `CORS_ORIGIN` env (JSON-parsed); allowed headers include `X-Query` (custom GET-body wrapper) and `x-auth-provider-id` (multi-provider auth header).
+
+### Data layer (`src/db/db.service.ts`)
+
+`DbService` extends `EventEmitter`. The CouchDB `_changes` feed is the single source of update events; it starts immediately on construction and resumes from the last delivered `seq` (initially `"now"`) so reconnects don't replay history that consumers already loaded via their own snapshot queries. The advance happens **after** listeners run so a mid-handler crash re-delivers on next connect.
+
+Events you must observe in any cache or in-memory state:
+
+- `update` — every typed doc change. Caches subscribe here for updates.
+- `groupUpdate` — group docs and group-`DeleteCmd`s. Used by `PermissionSystem` to update the access graph.
+- `languageUpdate` — language docs and language-`DeleteCmd`s. Used by `QueryService` for the in-memory languages list.
+- `disconnect` / `reconnect` — emitted only on a real connected→disconnected transition (not on initial connect). **In-memory caches built from DTOs must clear on `disconnect` and rehydrate on `reconnect`** — otherwise changes during the outage are lost. Examples: `QueryService.languages`, `AuthIdentityService.providerCache` / `autoGroupMappingsCache` / `jwksClients`, `S3Service.clearCache()`.
+
+Writes go through `upsertDoc(doc)` which auto-generates `DeleteCmd` docs when `memberOf` changes or `deleteReq` is set. `insertDoc` retries on `Document update conflict` with jittered backoff. `executeFindQuery` is the only path that calls `nano`'s `db.find` directly — all permission/expiry/status filtering happens upstream of it.
+
+### Schema upgrades (`src/db/schemaUpgrade/`)
+
+`db.upgrade.ts` chains `v9..v15` in order; each upgrade reads `_schemas.schemaVersion`, no-ops if not at its expected version, and bumps the version on success. See `schemaUpgrade/README.md` for the full lifecycle (when to add, when to remove). Current baseline: v13+; tests start at the seeded version and **do not run upgrades** — seeding data must already be in the latest schema. When changing doc shapes, prefer bumping `updatedTimeUtc` in a schemaUpgrade over shipping a client-side migration.
+
+### Permissions (`src/permissions/permissions.service.ts`)
+
+`PermissionSystem` is a static class with an in-memory graph of groups, ACL entries, and inherited access. Key entry points:
+
+- `PermissionSystem.init(db)` — boot-time hydration; subscribes to `groupUpdate`.
+- `PermissionSystem.verifyAccess(groups, docType, permission, userGroups, "any"|"all")` — the workhorse for change-request validation.
+- `PermissionSystem.accessMapToGroups(accessMap, permission, docTypes)` — used by Socket.io to compute room membership and by `QueryService` to filter results.
+
+`AccessMap` is `Map<groupId, Map<DocType, Map<AclPermission, boolean>>>` and is built per-user from their group membership. It is delivered to clients on socket connect (`clientConfig` event) and replaces theirs wholesale.
+
+### Auth (`src/auth/`)
+
+Multi-provider OIDC. `AuthProvider` documents in the DB define each provider (domain, audience, client ID, claim mappings); the client sends an `x-auth-provider-id` header alongside the `Authorization: Bearer …` token. `AuthIdentityService.resolveOrDefault(token, providerId)` returns either an authenticated `JwtUserDetails` or an anonymous identity with `getDefaultGroups()`. JWKS clients are cached per-domain; the cache invalidates on `AuthProvider` doc updates.
+
+**Failure-reason codes** (`AuthFailureReason`) are critical for client behavior: `provider_not_found` tells the client to evict its cached provider doc and re-pick; `token_invalid` triggers a similar eviction so Dexie can resync. The Socket.io gateway in `socketio.ts` injects these into `connect_error` payloads; the REST `AuthGuard` does the equivalent via `UnauthorizedException`.
+
+The `JwtModule` is registered globally in `app.module.ts`. Group-membership and identity claims are derived from arrow-function strings in `JWT_MAPPINGS` env var — these are `eval`-equivalent so the env value is trusted config.
+
+### Socket.io (`src/socketio.ts`)
+
+One room per `${docType}-${groupId}`. On `joinSocketGroups`, the server emits a `clientConfig` (max upload sizes + accessMap) then joins the user to every room their accessMap grants View on, plus the matching `deleteCmd-${groupId}` rooms. `DbService` `update` events fan out to the appropriate rooms by resolving the doc's groups (for Content: via its parent's `memberOf`; for Change docs: via the embedded `changes` payload). Auth happens in a Socket.io middleware before the connection is accepted.
+
+### Endpoints (`src/endpoints/`)
+
+- `POST /changerequest` (`changeRequest.controller.ts`) — handles JSON and multipart (Fastify `request.parts()`). For multipart, file buffers are matched into `BINARY_REF-{uuid}` placeholders in the JSON payload by `util/patchFileData.ts`. `util/removeDangerousKeys.ts` strips prototype-pollution keys before any further processing. Dispatches by `doc.type` through `changeRequests/documentProcessing/process*Dto.ts`.
+- `POST /query` (`query.controller.ts` + `query.service.ts`) — Mango queries. **Every body is matched against a template** under `src/db/MongoQueryTemplates/validators/<identifier>.ts` (the `body.identifier` field). Templates reject unknown keys and use function validators (e.g., `sync.ts` enforces sort/use_index shape, mandatory `memberOf.$elemMatch.$in`, and disallows syncing `user` docs). `BYPASS_TEMPLATE_VALIDATION=true` is a dev/test escape hatch — never in prod. `QueryService` injects permission filters and (when `cms !== true`) published/expiry filters before passing to `executeFindQuery`.
+- `GET /search` (`search.controller.ts`) — read-only search using the `X-Query` header (JSON wrapper because GET has no body); `xQuery()` parses+validates via `class-validator`.
+- `GET /storage/storagestatus` (`storageStatus.controller.ts`) — bucket connectivity probe; requires `View` on the `Storage` doc.
+
+All endpoints use `AuthGuard` and validate `apiVersion` via `validation/apiVersion.ts`. Backwards compatibility policy: ADR 0005.
+
+### Change-request processing (`src/changeRequests/`)
+
+`processChangeRequest.ts` is the pipeline:
+
+1. `validateChangeRequest` runs `class-validator` decorators on the appropriate DTO.
+2. `validateChangeRequestAccess` enforces permission rules per doc type (covers Edit/Translate/Publish/Assign/Delete, ACL changes on Group docs, default-language changes on Language docs, tag-assignment checks). Read this file before changing permission semantics.
+3. A doc-type-specific `process*Dto` finalizes the document (image processing, FTS indexing, language file generation, S3 uploads, etc.).
+4. `db.upsertDoc(doc)` writes and emits.
+
+`util/ftsIndexing.ts` computes server-side trigram FTS for Content docs as part of `processContentDto`. **Boost/field config must stay identical** to `shared/src/fts/ftsSearch.ts` — when you change one, change both (ADR 0009).
+
+### S3 (`src/s3/s3.service.ts`)
+
+`S3Service` is a static-method-driven singleton cache keyed by `bucketId`. Instances expire after 10 min of inactivity (`cleanupStaleInstances`); on DB `disconnect` the entire cache is dropped because rotated credentials would otherwise leave stale Minio clients in use. Credentials are stored encrypted on `Crypto` docs (`util/encryption.ts`), keyed by `ENCRYPTION_KEY` env var.
+
+There is a separate audio-bucket S3 config (`S3_MEDIA_*` or fallback `S3_*` env vars) for media uploads.
+
+### Test setup (`src/test/testingModule.ts`)
+
+`createTestingModule(testName)` creates a fresh `luminary-test-<testName>` CouchDB DB per test file, seeds it, mocks `AuthIdentityService` to default to anonymous, and provides a real `DbService`, `Socketio`, and `S3Service`. Use this rather than hand-rolling test modules. Tests share the prefix `DB_DATABASE_PREFIX` (default `luminary-test`).
+
+`nest-cli.json` ensures `designDocs/*.json` and `seedingDocs/*.json` are copied into `dist/src/` on build so production startup can find them.
+
+## Conventions
+
+- Strict null/any checks are off in `tsconfig.json` — be deliberate about runtime guards even where the type system doesn't force them.
+- `*.spec.ts` lives next to the unit under test (no separate `__tests__/` folders here).
+- DTOs in `src/dto/` are the API-side mirror of `shared/src/types/dto.ts`. Field changes must land in both; the API is authoritative for fields it sets (e.g., `parent*`, `availableTranslations`, `fts`, `ftsTokenCount`, `statusChangeDeleteCmdId`).
+- `class-validator` decorators on DTOs are enforced by the global `ValidationPipe` and by `validateChangeRequest`. Use `@Expose()` from `class-transformer` on every persisted field — `instanceToPlain` drops un-exposed fields when writing.
+- New Mango sync queries require a matching `sync-*-index.json` design doc **and** must pass the `sync.ts` validator.
+- Encrypted fields (S3 credentials, etc.) use `util/encryption.ts`; the encryption key lives in `ENCRYPTION_KEY` and rotation is not yet automated — don't store anything irrecoverable.
+- Backwards compatibility: see ADR 0005 (`docs/adr/0005-backwards-compatibility.md`).

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository context
+
+This is the `app/` package of the Luminary monorepo (sibling packages: `api/`, `cms/`, `shared/`, `playwright-tests/`, `docs/`). It is an offline-first Vue 3 + TypeScript PWA built with Vite. It depends on the local `luminary-shared` package via `file:../shared` — changes to that package require it to be rebuilt before they are picked up here.
+
+Cross-package E2E tests live in `../playwright-tests/` (separate `playwright.config.ts`), not in `app/`. There is no in-package Playwright config.
+
+## Commands
+
+Run everything from `app/`:
+
+- `npm run dev` — Vite dev server on http://localhost:4174 (strict port)
+- `npm run build` — runs `type-check` and `build-only` in parallel
+- `npm run type-check` — `vue-tsc --build --force`
+- `npm run test` / `npm run test:unit` — Vitest (jsdom). Pass a path or `-t "name"` to run a subset, e.g. `npm run test -- src/pages/HomePage.spec.ts -t "renders"`.
+- `npm run lint` / `npm run lint:fix`
+- `npm run format` — Prettier on `src/`
+
+Install with `npm install --install-links` (the shared lib is linked via `file:`). E2E/Playwright runs are owned by the user — do not invoke them.
+
+## Architecture
+
+### Startup flow (`src/main.ts`)
+
+The boot sequence is order-sensitive — read `main.ts` before reordering anything:
+
+1. Pinia is installed early so watchers registered during startup can resolve stores.
+2. `warmMangoCaches()` hydrates Mango query caches from localStorage before any IDB query.
+3. `init()` from `luminary-shared` sets up IndexedDB, the socket, and the doc sync list (`AuthProvider`, `Tag`, `Post`, `Language`, `Redirect`, `Storage` — each with a `syncPriority`; `contentOnly` docs are scoped by language).
+4. A `connect_error` listener for `auth_failed` is registered **before** `setupAuth()` — otherwise the first failure event is lost and the client loops. Handles `provider_not_found` (forces provider re-pick) and silent refresh via `refreshTokenSilently({ ignoreCache: true })`.
+5. i18n is initialised before mount because splash-screen components call `useI18n()` at setup time.
+6. After mount: `initAuthLangSync`, `initLanguage`, `initSync`, plugin loading, then `markAppReady()`.
+
+### Data layer
+
+There is no Vuex/Pinia-managed document cache. Documents come from `luminary-shared`'s IndexedDB via Mango queries (`db/`, `fts/`). UI code subscribes to live refs returned by those queries. The shared lib also owns the socket and REST clients. Server 5xx errors arrive via the shared `serverError` ref; `main.ts` translates them into a debounced toast (translation is the app's responsibility, not shared's).
+
+### Auth (`src/auth.ts`)
+
+Uses `@auth0/auth0-vue` with multiple providers selected at runtime from `AuthProvider` docs. The provider modal, silent refresh, and Auth0 cache clearing are all entry points used from `main.ts`'s error handler — keep them exported.
+
+### Routing & pages
+
+`src/router/` defines routes; page-level components are in `src/pages/` and feature components in `src/components/`. The repo is mid-migration to colocate `__tests__/` next to feature folders (see `pages/SingleContent/`, `components/HomePage/`, etc.). New tests should follow that pattern.
+
+### Render state (for prerender/SSG tooling)
+
+`src/util/renderState.ts` sets `data-render-state` on `<html>` and dispatches a `render-state-change` `CustomEvent`. States: `loading`, `ready`, `error`. External prerenderers consume this; do not change the contract without updating `README.md`.
+
+### i18n
+
+UI strings live in CouchDB Language documents, loaded at runtime (`src/i18n.ts`). English seed is `../api/src/db/seedingDocs/lang-eng.json`. See `../docs/translations.md` for the workflow.
+
+### Plugins
+
+`VITE_PLUGIN_PATH` env var points to an out-of-tree plugins folder. The Vite + Vitest configs copy `$VITE_PLUGIN_PATH/*` into `src/plugins/` at the start of every `dev`, `build`, and `test` run. `VITE_PLUGINS` is a JSON array of plugin names to load. Plugin filename must equal the exported class name.
+
+### Query string parameters
+
+Supported flags (see `README.md` for full list): `autoplay=true`, `autofullscreen=true`, `nonotifications` (suppresses all in-app notifications — current branch work).
+
+## Conventions
+
+- Path alias `@` → `src/` (configured in `vite.config.ts` and tsconfig).
+- Tailwind for styling; `prettier-plugin-tailwindcss` reorders classes on format.
+- Sentry is initialised via `src/util/initSentry.ts`; use the exported `Sentry` (may be undefined when DSN is unset) — always null-check.
+- `src/main.ts`, `src/analytics.ts`, `src/auth.ts`, and `src/guards/**` are excluded from coverage; don't chase coverage there.
+- Vitest globals are enabled (`describe`/`it`/`expect` are ambient).

--- a/cms/CLAUDE.md
+++ b/cms/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository context
+
+This is the `cms/` package of the Luminary monorepo (sibling packages: `api/`, `app/`, `shared/`, `playwright-tests/`, `docs/`). Vue 3 + TypeScript + Vite SPA used by editors to manage content that the `app/` PWA consumes. Depends on the local `luminary-shared` package via `file:../shared` — rebuild shared before changes are picked up here. Install with `npm install --install-links`.
+
+Cross-package E2E tests also exist in `../playwright-tests/`. The `cms/` package itself uses Playwright for its own e2e tests (auth-bypass mode, see README). E2E runs are owned by the user — do not invoke them.
+
+## Commands
+
+Run from `cms/`:
+
+- `npm run dev` — Vite dev server on http://localhost:4175 (strict port)
+- `npm run build` — runs `type-check` and `build-only` in parallel
+- `npm run type-check` — `vue-tsc --build --force`
+- `npm run test` / `npm run test:unit` — Vitest (jsdom). Subset: `npm run test -- src/pages/Foo.spec.ts -t "name"`.
+- `npm run lint` / `npm run lint:fix`
+- `npm run format` — Prettier on `src/`
+
+Auth bypass for local dev / e2e: set `VITE_AUTH_BYPASS=true` (mocks an `E2E Test User`, skips Auth0). Never enable in production.
+
+## Architecture
+
+### Startup flow (`src/main.ts`)
+
+Order-sensitive — read `main.ts` before reordering:
+
+1. Pinia installed early so startup watchers (e.g. `useNotificationStore`) can resolve stores.
+2. `init()` from `luminary-shared` sets up IndexedDB, the socket, and the doc index. The CMS sync list registers all editable doc types (`AuthProvider`, `AutoGroupMappings`, `Tag`, `Post`, `Redirect`, `Language`, `Group`, `Storage`); `User` is registered with `sync: false`. `AutoGroupMappings` are listed but are edited directly via `ApiLiveQuery` and intentionally not mirrored into Dexie (see comment in `sync.ts`).
+3. The socket `connect_error` listener for `auth_failed` is registered **before** `setupAuth()` — otherwise the first failure event is lost and the client loops. Handles `provider_not_found` (force provider re-pick) and silent refresh via `refreshTokenSilently({ ignoreCache: true })`.
+4. After auth: a `serverError` watcher pushes debounced toast notifications (5s debounce). The CMS has no i18n layer — toast copy is hard-coded English here, not in shared.
+5. `changeReqWarnings` / `changeReqErrors` watchers surface change-request feedback as warning/error notifications.
+6. `initAuthLangSync()`, `initLanguage()`, `initSync()`, then mount.
+
+### Sync architecture (`src/sync.ts`)
+
+Two-tier sync driven by two iterators on `syncIterators`:
+
+- **`language` iterator** ticks on `accessMap` or `isConnected` change. Drives sync of `AuthProvider` + `Language` docs (the bootstrap layer).
+- **`content` iterator** ticks on the same triggers plus `cmsLanguageIdsAsRef` change, but only when at least one CMS language is selected. Drives sync of `Post`/`Tag`/`Redirect`/`Group`/`Storage` plus their `Content` children (scoped to the selected languages).
+
+When `isConnected` flips false, `setCancelSync(true)` aborts in-flight syncs. `triggerSync()` bumps both iterators for manual re-sync. `Content` syncs pass `includeDeleteCmds: false` because parent-type syncs already handle delete commands (permissions are calculated on the parent type).
+
+### Data layer
+
+No Pinia-managed document cache. Documents come from `luminary-shared`'s IndexedDB via Mango queries; UI subscribes to live refs. Pinia is used for UI state only (notifications, etc. — see `src/stores/`).
+
+### Auth (`src/auth.ts`)
+
+`@auth0/auth0-vue` with multiple providers selected at runtime from `AuthProvider` docs. `setupAuth`, `refreshTokenSilently`, `loginWithProvider`, `openProviderModal`, `clearAuth0Cache`, `resolveActiveProvider` are all entry points used by `main.ts`'s error handler — keep them exported. Auth-bypass mode short-circuits all of this.
+
+### i18n
+
+The CMS UI is English-only — there is no i18n layer. Translation infrastructure (Language docs, `initLanguage`) is loaded only because shared content/Language metadata is multilingual.
+
+## Conventions
+
+- Path alias `@` → `src/` (in `vite.config.ts` + tsconfig).
+- Tailwind for styling; `prettier-plugin-tailwindcss` reorders classes on format.
+- Sentry is initialised in `main.ts` only when `import.meta.env.PROD`. The `Sentry` re-exported from `globalConfig` may be undefined elsewhere — null-check.
+- Vitest globals enabled (`describe`/`it`/`expect` are ambient); `jsdom` environment; coverage excludes `src/main.ts` and `src/pages/internal/ComponentSandbox.vue`.
+- Migration in progress: feature folders should colocate a `__tests__/` subdirectory (e.g. `pages/ComponentFolder/__tests__/`). New tests follow this pattern.
+- `LImage` is the standard image component, including for small icons like auth provider logos.

--- a/shared/CLAUDE.md
+++ b/shared/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this package is
+
+`luminary-shared` is a Vue 3 frontend library that consumers (the Luminary APP and CMS) install to talk to the Luminary sync API. It owns: IndexedDB (Dexie) storage, REST + Socket.io transport, document syncing, an offline FTS search engine, permissions/ACL evaluation, and a set of Vue composables (`useDexieLiveQuery`, `ApiLiveQuery`, `createEditable`, …) that bridge IndexedDB ↔ Vue reactivity.
+
+This is published to npm as `luminary-shared`. The bundle is the lib output from `src/index.ts`; everything callers can use is re-exported there.
+
+## Common commands
+
+```sh
+npm run build         # vue-tsc + vite build → dist/
+npm run test          # vitest run (one-shot)
+npm run test:watch    # vitest watch mode
+npm run lint          # eslint .vue/.ts/.cjs/.mjs/.tsx
+npm run lint:fix
+npm run format        # prettier --write src/
+npm run type-check    # vue-tsc --noEmit + vite build
+```
+
+Run a single test file: `npx vitest run src/path/to/file.spec.ts`
+Run a single test by name: `npx vitest run -t "test name pattern"`
+
+## Local install in consuming projects
+
+Installing this package via plain `npm install ../shared` breaks IndexedDB reactivity because the symlink hides the real package boundary from Dexie. Always use the `--install-links` flag when installing from a sibling checkout:
+
+```sh
+npm install --install-links ../shared
+```
+
+After making local changes, run `npm run build` here, then re-run the install command in the consuming project.
+
+## Architecture
+
+### Entry point and initialization
+
+`src/luminary.ts` exposes a single `init(config)` that, in order, sets the shared config, opens Dexie (`initDatabase`), creates the Socket.io connection (`getSocket`), and starts the REST sync (`getRest` + `initSync`). Calling code does this once at app startup. The exported surface area for consumers is everything in `src/index.ts`.
+
+`SharedConfig` (`src/config.ts`) is the single configuration object: `cms` flag, app-specific `docsIndex` string appended to the shared Dexie index, `apiUrl`, the `syncList` of doc-type sync queries, and a `Ref<Uuid[]>` of active language IDs (used by Socket.io and FTS filtering).
+
+### Data layer — `src/db/database.ts`
+
+One Dexie `Database` class wraps four tables:
+
+- `docs` — all documents (Posts, Tags, Content, Languages, Groups, etc.) keyed by `_id`. The index string is built by concatenating a fixed shared index (`_id,type,parentType,language,expiryDate,parentId,publishDate,[type+tagType],*fts`) with the consumer's `docsIndex`. The `*fts` MultiEntry index powers offline trigram search.
+- `localChanges` — outgoing change queue; written to by `db.upsert()` and drained by `syncLocalChanges`.
+- `queryCache` — generic query result cache (`MangoQuery/queryCache.ts`).
+- `luminaryInternals` — key/value store for `syncMap`, `syncList`, FTS `corpusStats`, etc.
+
+Schema versioning is **automatic**: `bumpDBVersion` compares the JSON-serialized index against the previous one in `localStorage["dexie.dbIndex"]` and bumps the Dexie version when it changes. You usually don't need to manage versions manually — just add fields to the index string and the next load will migrate.
+
+The exported singleton is `db`, available after `initDatabase()` resolves. `db.upsert(...)` is the standard write path: it writes to `docs` and queues a `localChange` for upload (or, for deletes with `deleteReq`, removes from `docs` and queues the delete). `db.bulkPut(docs)` handles incoming docs from the API including `DeleteCmd` resolution (with a stale-delete guard — skips deletes whose target is already newer).
+
+`db.deleteRevoked()` watches `accessMap` and removes any docs the user no longer has access to. `db.deleteExpired()` purges past-expiry docs on non-CMS clients on startup.
+
+### Sync — `src/rest/sync2/`
+
+The sync system is documented in detail in `src/rest/sync2/README.md`. Read it before changing sync code. Quick model:
+
+- Walks backwards in time per `(type, memberOf-set, languages-set)` "column," storing block ranges in `syncList`.
+- Splits into multiple autonomous runners when new groups/languages are added; recombines via **vertical merge** (adjacent time ranges, same key) and **horizontal merge** (overlapping ranges, different groups/languages, both EOF).
+- `setCancelSync(true/false)` is a kill switch the consumer must drive based on connectivity — it does not auto-reset.
+- `DeleteCmd` documents are synced as a sibling column to each content/post/tag column so deletions propagate even past the initial sync window.
+
+`src/rest/syncLocalChanges.ts` drains the `localChanges` table to the API and applies ack/reject responses via `db.applyLocalChangeAck`.
+
+### Socket.io live updates — `src/socket/socketio.ts`
+
+The socket emits `joinSocketGroups` on connect with the configured `syncList`, then pushes `data` events. Incoming docs are filtered against `syncList` and `appLanguageIdsAsRef` before being bulk-put into Dexie. `accessMap` and `maxUploadFileSize` are received via a `clientConfig` event. Auth failures (`err.message === "auth_failed"`) disable reconnection so a stale token doesn't loop.
+
+`isConnected` is a Vue ref that drives `ApiLiveQuery`'s online/offline behavior.
+
+### Permissions — `src/permissions/permissions.ts`
+
+`accessMap` is a `useLocalStorage` ref of `{ groupId: { docType: { permission: boolean } } }`. `verifyAccess(groups, docType, permission, "any"|"all")` is the lookup; `getAccessibleGroups(permission)` inverts it to per-docType group lists (used by `deleteRevoked`). The map is replaced wholesale by the server's `clientConfig` socket event.
+
+### Vue reactivity utilities — `src/util/`
+
+The library's "public composable" surface:
+
+- **`useDexieLiveQuery` / `useDexieLiveQueryWithDeps`** (`util/useDexieLiveQuery/`) — Vue 3 wrapper around Dexie's `liveQuery`. This is the **preferred** way to read from IndexedDB; the older `db.toRef`, `db.getAsRef`, `db.whereTypeAsRef`, etc. on the `Database` class are deprecated and log a warning when called.
+- **`useDexieLiveQueryAsEditable`** — same but wraps the result with `createEditable` so the UI can edit a copy and diff against the source.
+- **`createEditable`** — produces a clone of a source ref that the UI can mutate. Tracks user vs. source modifications so external updates don't clobber in-progress edits.
+- **`ApiLiveQuery` / `ApiLiveQueryAsEditable`** (`util/ApiLiveQuery/`) — same idea but talks to the REST API + Socket.io directly instead of IndexedDB. Used for queries that can't or shouldn't be cached locally (e.g. CMS searches).
+- **`MangoQuery/`** — Mango-syntax query helpers. `mangoCompile(selector)` returns an in-memory predicate; `mangoToDexie(table, query)` translates a Mango query into a Dexie `Collection` with index pushdown where possible and an in-memory filter for the rest. Both use template-based caching (structure normalized, values extracted) with `localStorage` persistence via `warmMangoCaches()`. See `mangoCompile.md` and `mangoToDexie.md`.
+- **`LFormData`** — `FormData` subclass that serializes nested objects + binary attachments into the multipart format the API expects.
+- **`asyncArray`** (`filterAsync`, `someAsync`), **`watchValue`** — small async/reactivity utilities used across the lib.
+
+### Full-text search — `src/fts/`
+
+Offline fuzzy search using **trigram indexing + BM25**. Read `src/fts/README.md` before changing FTS code. Key points:
+
+- FTS data is computed server-side and shipped on `ContentDto.fts` as `string[]` of `"trigram:tf"` entries; Dexie indexes the array via the `*fts` MultiEntry index.
+- Searches use `db.docs.where("fts").between(trigram + ":", trigram + ";")` per trigram, parse TF, compute BM25 against `corpusStats` (stored under `luminaryInternals["corpusStats"]`).
+- `scheduleCorpusStatsRecompute()` is debounced (10s) and called from every doc-mutation path (`bulkPut` with content, `deleteRevoked`, `deleteExpired`, `purge`) plus on startup.
+- The field config (title=3.0, summary=1.5, text=1.0, author=1.0) is **hard-coded identically** in `api/src/util/ftsIndexing.ts` and `shared/src/fts/ftsSearch.ts` — if you change one, change both.
+- Consumer surface is `useFtsSearch(query, options)` (Vue composable, debounced, paginated) or `ftsSearch(opts)` (direct call).
+
+### Types — `src/types/`
+
+`dto.ts` defines all document DTOs (`BaseDocumentDto`, `ContentDto`, `PostDto`, `TagDto`, `LanguageDto`, `UserDto`, `DeleteCmdDto`, etc.). `enum.ts` defines `DocType`, `PublishStatus`, `TagType`, `PostType`, `AclPermission`, `MediaType`, etc. These are the single source of truth — the API mirrors them, but this package owns the client-side shape.
+
+## Test setup
+
+Tests run under Vitest + jsdom + `fake-indexeddb/auto`. Mock data lives in `src/tests/mockdata.ts` (mock languages, content, tags, posts).
+
+`vitest.setup.ts` intercepts `console.warn` and **fails the test** if it sees a Dexie or `mangoToDexie` "missing index" / "full table scan" warning. If you legitimately need to test warning behavior, spy on `console.warn` with `mockImplementation` — that replaces the original so the setup hook never sees it. If you hit this failure in normal work, the right answer is almost always to add the missing index, not to silence the warning.
+
+## Build output
+
+The lib is built by Vite (`vite.config.ts`) using `rollup-plugin-auto-external` to keep all dependencies external (consumers' `node_modules` resolve them) and `vite-plugin-dts` to emit `dist/index.d.ts`. `minify: false` is intentional — consuming apps minify the combined bundle. `stats.html` is the rollup-visualizer output; open it when reviewing bundle size.


### PR DESCRIPTION
  ## Summary
  - Check in repo-aware CLAUDE.md guides and a set of project-specific skills so Claude Code sessions start with shared context instead of re-discovering it each time.
  - Removes the prior `.gitignore` entries that excluded `CLAUDE.md`, `.claude/settings.json`, and `.agent` so this context travels with the repo.

  ## Changes
  - `CLAUDE.md` + `api|app|cms|shared/CLAUDE.md` — per-package guides covering layout, local setup/ports, cross-package contracts (DTO mirror, FTS config, sync-query validation, auth failure codes), and workflow conventions.
  - `.claude/skills/` — drafting/investigation skills: `add-sync-query`, `add-schema-upgrade`, `sync-dtos`, `rebuild-shared`, `explain-permission`, `trace-sync`, `prep-task`, `diff-vs-main`, `pr-body`.
  - `.claude/settings.json` — shared Claude Code settings checked in for the project.
  - `.gitignore` — drop `CLAUDE.md`, `.claude/settings.json`, and `.agent` ignores so the new files are tracked.

  - Tooling/docs only — no runtime code changed, so no CI or contract impact.