### PR TITLE
CMS: Add preventClose prop to LModal to lock the sign-in modal

### DIFF
--- a/cms/src/components/authProvider/SelectionModal.vue
+++ b/cms/src/components/authProvider/SelectionModal.vue
@@ -45,7 +45,12 @@ const handleProviderSelect = (provider: AuthProviderDto) => {
 </script>
 
 <template>
-    <LModal heading="Sign in" v-model:isVisible="isVisible" :showClosingButton="false">
+    <LModal
+        heading="Sign in"
+        v-model:isVisible="isVisible"
+        :showClosingButton="false"
+        :preventClose="true"
+    >
         <div class="flex flex-col gap-3 py-2">
             <button
                 v-for="provider in providers"

--- a/cms/src/components/modals/LModal.vue
+++ b/cms/src/components/modals/LModal.vue
@@ -11,12 +11,15 @@ type Props = {
     largeModal?: boolean;
     stickToEdges?: boolean;
     showClosingButton?: boolean;
+    // When true, the modal cannot be dismissed by clicking outside of it or pressing Escape.
+    preventClose?: boolean;
     beforeClose?: () => boolean;
 };
 const props = withDefaults(defineProps<Props>(), {
     largeModal: false,
     noDivider: false,
     showClosingButton: true,
+    preventClose: false,
 });
 
 const isVisible = defineModel<boolean>("isVisible");
@@ -24,6 +27,12 @@ const isVisible = defineModel<boolean>("isVisible");
 const tryClose = () => {
     if (props.beforeClose && props.beforeClose() === false) return;
     isVisible.value = false;
+};
+
+// Dismiss attempts via the backdrop or the Escape key; blocked when preventClose is set.
+const tryDismiss = () => {
+    if (props.preventClose) return;
+    tryClose();
 };
 
 const modalRef = ref<HTMLElement>();
@@ -45,13 +54,13 @@ const isMobileScreen = breakpoints.smaller("sm");
                 'fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-center justify-center bg-zinc-800 bg-opacity-50 backdrop-blur-sm',
                 stickToEdges && isMobileScreen ? '' : 'p-2',
             ]"
-            @mousedown.self="tryClose()"
+            @mousedown.self="tryDismiss()"
             data-test="modal-backdrop"
         >
             <!-- Modal content at higher z-index -->
             <div
                 tabindex="0"
-                @keydown.esc="tryClose()"
+                @keydown.esc="tryDismiss()"
                 @click.stop
                 ref="modalRef"
                 data-test="modal-content"


### PR DESCRIPTION
Add a `preventClose` prop to LModal that, when true, blocks dismissal via backdrop click and the Escape key. Set it on the auth provider SelectionModal so users cannot dismiss the sign-in prompt without picking a provider.