### PR TITLE
fix(auth): keep users logged in after IndexedDB eviction (#1671)

### DIFF
--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -25,9 +25,12 @@ vi.mock("@sentry/vue", () => ({
 }));
 
 import {
+    ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuth0Cache,
     openProviderModal,
+    persistActiveProvider,
+    readPersistedProvider,
     refreshTokenSilently,
     resolveActiveProvider,
     setupAuth,
@@ -154,6 +157,131 @@ describe("auth", () => {
             const resolved = await resolveActiveProvider();
             expect(resolved?._id).toBe(providerA._id);
         });
+
+        it("resolves from the persisted provider when Dexie has been evicted (issue #1671)", async () => {
+            // The Auth0 refresh-token cache survives in localStorage but the
+            // AuthProvider doc has been evicted from IndexedDB. _id + domain come
+            // from the persisted blob; clientId + audience from the cache key —
+            // no Dexie dependency.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: { access_token: "fake" } }),
+            );
+            persistActiveProvider(providerA);
+            // Dexie intentionally left empty.
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("write-through: caches the resolved Dexie doc so it survives later eviction", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).toBeNull();
+
+            const first = await resolveActiveProvider();
+            expect(first?._id).toBe(providerA._id);
+            // The Dexie resolve wrote the config through to localStorage.
+            expect(readPersistedProvider()?._id).toBe(providerA._id);
+
+            // Now evict Dexie; resolution still works from the persisted copy.
+            await db.docs.clear();
+            const second = await resolveActiveProvider();
+            expect(second?._id).toBe(providerA._id);
+        });
+
+        it("prefers the live Dexie doc over a stale persisted domain (Dexie-first)", async () => {
+            // Persisted copy has a stale domain (e.g. the provider was migrated
+            // to an Auth0 custom domain). The live Dexie doc is authoritative and
+            // refreshes the persisted copy.
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider({ _id: providerA._id, domain: "stale.auth0.com" });
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?.domain).toBe(providerA.domain);
+            expect(resolved?.audience).toBe(providerA.audience);
+            expect(readPersistedProvider()?.domain).toBe(providerA.domain);
+        });
+
+        // Regression — the #1671 recovery must be purely additive: the
+        // pre-existing Dexie path is unchanged, the realistic two-key Auth0
+        // cache parses correctly, and the eviction fallback only fires with a
+        // genuine persisted blob (no accidental recovery).
+        it("Dexie-backed resolve is unchanged with the realistic two-key cache", async () => {
+            // The real Auth0 SDK writes BOTH a standard token key and a sibling
+            // id-token (::@@user@@) key. With the provider doc in Dexie this must
+            // resolve the full config from Dexie, exactly as before.
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("on eviction, reads audience from the standard key and skips the id-token (::@@user@@) key", async () => {
+            // Both keys present, Dexie evicted → clientId + audience come off the
+            // standard key (never "@@user@@"), _id + domain from the blob.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider(providerA);
+
+            expect(await resolveActiveProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("does not recover when only the id-token (::@@user@@) key is present (no audience)", async () => {
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            persistActiveProvider(providerA);
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("does not recover from the cache key alone without a persisted blob (opt-in)", async () => {
+            // Pre-feature behaviour: a session cache with no Dexie doc and no
+            // persisted blob still resolves to null — no accidental recovery.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
     });
 
     describe("clearAuth0Cache", () => {
@@ -187,6 +315,45 @@ describe("auth", () => {
             activeProviderId.value = "provider-a";
             clearAuth0Cache();
             expect(activeProviderId.value).toBeNull();
+        });
+
+        it("removes the persisted active provider (issue #1671)", () => {
+            persistActiveProvider(providerA);
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).not.toBeNull();
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).toBeNull();
+        });
+    });
+
+    describe("persistActiveProvider / readPersistedProvider (issue #1671)", () => {
+        it("round-trips _id and domain (and stores nothing else)", () => {
+            persistActiveProvider(providerA);
+            expect(readPersistedProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+            });
+            // clientId / audience are read from the cache key, never persisted.
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).not.toContain(providerA.clientId);
+        });
+
+        it("returns null when nothing is persisted", () => {
+            expect(readPersistedProvider()).toBeNull();
+        });
+
+        it("returns null for corrupt JSON", () => {
+            localStorage.setItem(ACTIVE_PROVIDER_KEY, "{not valid json");
+            expect(readPersistedProvider()).toBeNull();
+        });
+
+        it("returns null when a required field is missing", () => {
+            // Missing `domain` — buildAuth0Options would break without it.
+            localStorage.setItem(
+                ACTIVE_PROVIDER_KEY,
+                JSON.stringify({ _id: "x", clientId: "c", audience: "a" }),
+            );
+            expect(readPersistedProvider()).toBeNull();
         });
     });
 

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -11,6 +11,15 @@ const AUTH0_CACHE_PREFIX = "@@auth0spajs@@::";
 const AUTH0_TX_PREFIX = "a0.spajs.";
 const AUTH0_TX_KEY_PREFIX = "a0.spajs.txs.";
 
+/**
+ * localStorage key holding the active provider's identity. Persisting it next
+ * to Auth0's own localStorage refresh-token cache lets resolveActiveProvider
+ * recover `domain` + `_id` (which otherwise live only in the Dexie
+ * AuthProvider doc) after IndexedDB is evicted but localStorage survives —
+ * the iOS-Safari-ITP logout (issue #1671).
+ */
+export const ACTIVE_PROVIDER_KEY = "activeAuthProvider";
+
 /** Currently active OAuth provider document id (or null when unauthenticated). */
 export const activeProviderId = ref<string | null>(null);
 
@@ -24,12 +33,52 @@ export const showProviderSelectionModal = ref(false);
 export const isAuthPluginInstalled = ref(false);
 
 type Auth0Prompt = "none" | "login" | "consent" | "select_account";
-type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
+export type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
+
+/**
+ * The only provider fields not recoverable from Auth0's own storage after a
+ * Dexie eviction. `clientId` and `audience` live in the Auth0 cache key, so we
+ * never persist them — see {@link resolveActiveProvider}.
+ */
+type PersistedProvider = Pick<AuthProviderDto, "_id" | "domain">;
 
 function clearStoragePrefix(storage: Storage, prefix: string): void {
     for (let i = storage.length - 1; i >= 0; i--) {
         const key = storage.key(i);
         if (key?.startsWith(prefix)) storage.removeItem(key);
+    }
+}
+
+/**
+ * Persist the active provider's `_id` + `domain` to localStorage — the only two
+ * fields that aren't recoverable from Auth0's own storage after a Dexie
+ * eviction. Best-effort: storage failures (quota, Safari private mode) must
+ * never abort a login redirect, so they are swallowed — resolution just falls
+ * back to the Dexie lookup.
+ */
+export function persistActiveProvider(p: PersistedProvider): void {
+    if (typeof localStorage === "undefined") return;
+    try {
+        localStorage.setItem(ACTIVE_PROVIDER_KEY, JSON.stringify({ _id: p._id, domain: p.domain }));
+    } catch {
+        // ignore — persistence is an optimization, not a requirement
+    }
+}
+
+/**
+ * Read the persisted `{ _id, domain }`. Returns null when absent, corrupt, or
+ * missing either field.
+ */
+export function readPersistedProvider(): PersistedProvider | null {
+    if (typeof localStorage === "undefined") return null;
+    try {
+        const raw = localStorage.getItem(ACTIVE_PROVIDER_KEY);
+        if (!raw) return null;
+        const p = JSON.parse(raw);
+        if (p && p._id && p.domain) return { _id: p._id, domain: p.domain };
+        return null;
+    } catch {
+        return null;
     }
 }
 
@@ -40,21 +89,35 @@ function setProviderIdHeader(id: string | null): void {
 }
 
 /**
- * Identify the current provider by reading Auth0's own storage footprint and
- * looking it up in Dexie. Prefers the localStorage session cache; falls back
- * to the PKCE transaction key in sessionStorage, but only while we're on the
- * OAuth callback URL — without that gate, a stale txs key from an aborted
- * login would impersonate a real session and lock the user out of re-picking.
+ * Identify the current provider by reading Auth0's own storage footprint, then
+ * recovering its config. Prefers the localStorage session cache; falls back to
+ * the PKCE transaction key in sessionStorage, but only while we're on the OAuth
+ * callback URL — without that gate, a stale txs key from an aborted login would
+ * impersonate a real session and lock the user out of re-picking.
+ *
+ * Once a clientId is known, the config (`domain`, `_id`, …) comes Dexie-first:
+ * the AuthProvider doc is authoritative (so provider edits propagate) and we
+ * write it through to localStorage. Only when Dexie has no match — typically
+ * after IndexedDB eviction while the Auth0 refresh token survives in
+ * localStorage (issue #1671) — do we fall back to the persisted copy, so the
+ * session can still silently refresh instead of logging the user out.
  */
-export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
+export async function resolveActiveProvider(): Promise<ProviderConfig | null> {
     if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
 
+    // The standard Auth0 token cache key is `<prefix><clientId>::<audience>::<scope>`,
+    // so clientId + audience are both recoverable from it. (The sibling id-token
+    // key `<prefix><clientId>::@@user@@` has no audience segment — skip it.)
     let clientId: string | null = null;
+    let audience: string | null = null;
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         if (!key?.startsWith(AUTH0_CACHE_PREFIX)) continue;
-        clientId = key.slice(AUTH0_CACHE_PREFIX.length).split("::")[0] || null;
-        if (clientId) break;
+        const segments = key.slice(AUTH0_CACHE_PREFIX.length).split("::");
+        if (!segments[0]) continue;
+        clientId = segments[0];
+        if (segments.length >= 3 && segments[1]) audience = segments[1];
+        if (audience) break;
     }
 
     if (!clientId) {
@@ -74,7 +137,19 @@ export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
         .equals(DocType.AuthProvider)
         .filter((d) => (d as AuthProviderDto).clientId === clientId)
         .first();
-    return (doc as AuthProviderDto) ?? null;
+    if (doc) {
+        const d = doc as AuthProviderDto;
+        persistActiveProvider(d);
+        return { _id: d._id, domain: d.domain, clientId: d.clientId, audience: d.audience };
+    }
+
+    // Dexie evicted: rebuild from the persisted `{ _id, domain }` plus the
+    // clientId + audience still carried by the Auth0 cache key.
+    const persisted = readPersistedProvider();
+    if (persisted && audience) {
+        return { _id: persisted._id, domain: persisted.domain, clientId, audience };
+    }
+    return null;
 }
 
 /**
@@ -207,6 +282,9 @@ export async function loginWithProvider(
     provider: ProviderConfig,
     opts?: { prompt?: Auth0Prompt },
 ): Promise<void> {
+    // Remember the chosen provider so a returning session can be resolved
+    // without the Dexie AuthProvider doc (issue #1671).
+    persistActiveProvider(provider);
     // Evict stale PKCE transactions from aborted attempts so the next
     // callback matches the fresh code_verifier.
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
@@ -225,6 +303,11 @@ export function clearAuth0Cache(): void {
     removeCustomHeader("Authorization");
     clearStoragePrefix(localStorage, AUTH0_CACHE_PREFIX);
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
+    try {
+        localStorage.removeItem(ACTIVE_PROVIDER_KEY);
+    } catch {
+        // ignore — storage may be unavailable
+    }
 }
 
 export function openProviderModal(): void {

--- a/cms/src/auth.spec.ts
+++ b/cms/src/auth.spec.ts
@@ -16,9 +16,12 @@ vi.mock("@auth0/auth0-vue", () => ({
 }));
 
 import {
+    ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuth0Cache,
     openProviderModal,
+    persistActiveProvider,
+    readPersistedProvider,
     refreshTokenSilently,
     resolveActiveProvider,
     setupAuth,
@@ -136,6 +139,131 @@ describe("auth", () => {
             const resolved = await resolveActiveProvider();
             expect(resolved?._id).toBe(providerA._id);
         });
+
+        it("resolves from the persisted provider when Dexie has been evicted (issue #1671)", async () => {
+            // The Auth0 refresh-token cache survives in localStorage but the
+            // AuthProvider doc has been evicted from IndexedDB. _id + domain come
+            // from the persisted blob; clientId + audience from the cache key —
+            // no Dexie dependency.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: { access_token: "fake" } }),
+            );
+            persistActiveProvider(providerA);
+            // Dexie intentionally left empty.
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("write-through: caches the resolved Dexie doc so it survives later eviction", async () => {
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).toBeNull();
+
+            const first = await resolveActiveProvider();
+            expect(first?._id).toBe(providerA._id);
+            // The Dexie resolve wrote the config through to localStorage.
+            expect(readPersistedProvider()?._id).toBe(providerA._id);
+
+            // Now evict Dexie; resolution still works from the persisted copy.
+            await db.docs.clear();
+            const second = await resolveActiveProvider();
+            expect(second?._id).toBe(providerA._id);
+        });
+
+        it("prefers the live Dexie doc over a stale persisted domain (Dexie-first)", async () => {
+            // Persisted copy has a stale domain (e.g. the provider was migrated
+            // to an Auth0 custom domain). The live Dexie doc is authoritative and
+            // refreshes the persisted copy.
+            await db.docs.bulkPut([providerA]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider({ _id: providerA._id, domain: "stale.auth0.com" });
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?.domain).toBe(providerA.domain);
+            expect(resolved?.audience).toBe(providerA.audience);
+            expect(readPersistedProvider()?.domain).toBe(providerA.domain);
+        });
+
+        // Regression — the #1671 recovery must be purely additive: the
+        // pre-existing Dexie path is unchanged, the realistic two-key Auth0
+        // cache parses correctly, and the eviction fallback only fires with a
+        // genuine persisted blob (no accidental recovery).
+        it("Dexie-backed resolve is unchanged with the realistic two-key cache", async () => {
+            // The real Auth0 SDK writes BOTH a standard token key and a sibling
+            // id-token (::@@user@@) key. With the provider doc in Dexie this must
+            // resolve the full config from Dexie, exactly as before.
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("on eviction, reads audience from the standard key and skips the id-token (::@@user@@) key", async () => {
+            // Both keys present, Dexie evicted → clientId + audience come off the
+            // standard key (never "@@user@@"), _id + domain from the blob.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider(providerA);
+
+            expect(await resolveActiveProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+                clientId: providerA.clientId,
+                audience: providerA.audience,
+            });
+        });
+
+        it("does not recover when only the id-token (::@@user@@) key is present (no audience)", async () => {
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::@@user@@`,
+                JSON.stringify({ id_token: "fake", decodedToken: { claims: {} } }),
+            );
+            persistActiveProvider(providerA);
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
+
+        it("does not recover from the cache key alone without a persisted blob (opt-in)", async () => {
+            // Pre-feature behaviour: a session cache with no Dexie doc and no
+            // persisted blob still resolves to null — no accidental recovery.
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+
+            expect(await resolveActiveProvider()).toBeNull();
+        });
     });
 
     describe("clearAuth0Cache", () => {
@@ -169,6 +297,45 @@ describe("auth", () => {
             activeProviderId.value = "provider-a";
             clearAuth0Cache();
             expect(activeProviderId.value).toBeNull();
+        });
+
+        it("removes the persisted active provider (issue #1671)", () => {
+            persistActiveProvider(providerA);
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).not.toBeNull();
+
+            clearAuth0Cache();
+
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).toBeNull();
+        });
+    });
+
+    describe("persistActiveProvider / readPersistedProvider (issue #1671)", () => {
+        it("round-trips _id and domain (and stores nothing else)", () => {
+            persistActiveProvider(providerA);
+            expect(readPersistedProvider()).toEqual({
+                _id: providerA._id,
+                domain: providerA.domain,
+            });
+            // clientId / audience are read from the cache key, never persisted.
+            expect(localStorage.getItem(ACTIVE_PROVIDER_KEY)).not.toContain(providerA.clientId);
+        });
+
+        it("returns null when nothing is persisted", () => {
+            expect(readPersistedProvider()).toBeNull();
+        });
+
+        it("returns null for corrupt JSON", () => {
+            localStorage.setItem(ACTIVE_PROVIDER_KEY, "{not valid json");
+            expect(readPersistedProvider()).toBeNull();
+        });
+
+        it("returns null when a required field is missing", () => {
+            // Missing `domain` — buildAuth0Options would break without it.
+            localStorage.setItem(
+                ACTIVE_PROVIDER_KEY,
+                JSON.stringify({ _id: "x", clientId: "c", audience: "a" }),
+            );
+            expect(readPersistedProvider()).toBeNull();
         });
     });
 
@@ -308,6 +475,43 @@ describe("auth", () => {
             expect(mockGetAccessTokenSilently).toHaveBeenCalledTimes(2);
             expect(mockGetAccessTokenSilently.mock.calls[0]).toEqual([{ cacheMode: "off" }]);
             expect(mockGetAccessTokenSilently.mock.calls[1]).toEqual([{ cacheMode: "off" }]);
+        });
+    });
+
+    // Issue #1671 — the CMS no-provider branch used to clearAuth0Cache(),
+    // destroying a still-valid refresh token whenever Dexie had no matching
+    // AuthProvider doc (e.g. IndexedDB evicted while localStorage survived).
+    // It must now leave the cache intact; the router guard surfaces the
+    // provider modal, and the server's provider_not_found path cleans up a
+    // truly-deleted provider.
+    describe("setupAuth — no-provider branch is non-destructive (issue #1671)", () => {
+        const appStub = { use: () => {} } as unknown as App<Element>;
+
+        beforeEach(() => {
+            mockCreateAuth0.mockReset();
+            mockCreateAuth0.mockImplementation(() => ({
+                getAccessTokenSilently: mockGetAccessTokenSilently,
+                handleRedirectCallback: mockHandleRedirectCallback,
+                install: () => {},
+            }));
+        });
+
+        it("leaves the Auth0 cache key in place and does not open the modal when no provider resolves", async () => {
+            // Auth0 session cached in localStorage, but no AuthProvider doc in
+            // Dexie and nothing persisted — the eviction shape.
+            const cacheKey = `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`;
+            const cacheValue = JSON.stringify({ body: { access_token: "fake" } });
+            localStorage.setItem(cacheKey, cacheValue);
+
+            await setupAuth(appStub);
+
+            // Cache untouched — the whole point of the change.
+            expect(localStorage.getItem(cacheKey)).toBe(cacheValue);
+            // No Auth0 plugin installed (we don't know domain/_id), no header.
+            expect(mockCreateAuth0).not.toHaveBeenCalled();
+            expect(activeProviderId.value).toBeNull();
+            // The modal is the router guard's job, not setupAuth's.
+            expect(showProviderSelectionModal.value).toBe(false);
         });
     });
 });

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -10,6 +10,15 @@ const AUTH0_CACHE_PREFIX = "@@auth0spajs@@::";
 const AUTH0_TX_PREFIX = "a0.spajs.";
 const AUTH0_TX_KEY_PREFIX = "a0.spajs.txs.";
 
+/**
+ * localStorage key holding the active provider's identity. Persisting it next
+ * to Auth0's own localStorage refresh-token cache lets resolveActiveProvider
+ * recover `domain` + `_id` (which otherwise live only in the Dexie
+ * AuthProvider doc) after IndexedDB is evicted but localStorage survives —
+ * the iOS-Safari-ITP logout (issue #1671).
+ */
+export const ACTIVE_PROVIDER_KEY = "cms_activeAuthProvider";
+
 /** Development / E2E testing bypass. */
 export const isAuthBypassed = import.meta.env.VITE_AUTH_BYPASS === "true";
 
@@ -27,12 +36,52 @@ export const showProviderSelectionModal = ref(false);
 export const isAuthPluginInstalled = ref(false);
 
 type Auth0Prompt = "none" | "login" | "consent" | "select_account";
-type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
+export type ProviderConfig = Pick<AuthProviderDto, "_id" | "domain" | "clientId" | "audience">;
+
+/**
+ * The only provider fields not recoverable from Auth0's own storage after a
+ * Dexie eviction. `clientId` and `audience` live in the Auth0 cache key, so we
+ * never persist them — see {@link resolveActiveProvider}.
+ */
+type PersistedProvider = Pick<AuthProviderDto, "_id" | "domain">;
 
 function clearStoragePrefix(storage: Storage, prefix: string): void {
     for (let i = storage.length - 1; i >= 0; i--) {
         const key = storage.key(i);
         if (key?.startsWith(prefix)) storage.removeItem(key);
+    }
+}
+
+/**
+ * Persist the active provider's `_id` + `domain` to localStorage — the only two
+ * fields that aren't recoverable from Auth0's own storage after a Dexie
+ * eviction. Best-effort: storage failures (quota, Safari private mode) must
+ * never abort a login redirect, so they are swallowed — resolution just falls
+ * back to the Dexie lookup.
+ */
+export function persistActiveProvider(p: PersistedProvider): void {
+    if (typeof localStorage === "undefined") return;
+    try {
+        localStorage.setItem(ACTIVE_PROVIDER_KEY, JSON.stringify({ _id: p._id, domain: p.domain }));
+    } catch {
+        // ignore — persistence is an optimization, not a requirement
+    }
+}
+
+/**
+ * Read the persisted `{ _id, domain }`. Returns null when absent, corrupt, or
+ * missing either field.
+ */
+export function readPersistedProvider(): PersistedProvider | null {
+    if (typeof localStorage === "undefined") return null;
+    try {
+        const raw = localStorage.getItem(ACTIVE_PROVIDER_KEY);
+        if (!raw) return null;
+        const p = JSON.parse(raw);
+        if (p && p._id && p.domain) return { _id: p._id, domain: p.domain };
+        return null;
+    } catch {
+        return null;
     }
 }
 
@@ -43,21 +92,35 @@ function setProviderIdHeader(id: string | null): void {
 }
 
 /**
- * Identify the current provider by reading Auth0's own storage footprint and
- * looking it up in Dexie. Prefers the localStorage session cache; falls back
- * to the PKCE transaction key in sessionStorage, but only while we're on the
- * OAuth callback URL — without that gate, a stale txs key from an aborted
- * login would impersonate a real session and lock the user out of re-picking.
+ * Identify the current provider by reading Auth0's own storage footprint, then
+ * recovering its config. Prefers the localStorage session cache; falls back to
+ * the PKCE transaction key in sessionStorage, but only while we're on the OAuth
+ * callback URL — without that gate, a stale txs key from an aborted login would
+ * impersonate a real session and lock the user out of re-picking.
+ *
+ * Once a clientId is known, the config (`domain`, `_id`, …) comes Dexie-first:
+ * the AuthProvider doc is authoritative (so provider edits propagate) and we
+ * write it through to localStorage. Only when Dexie has no match — typically
+ * after IndexedDB eviction while the Auth0 refresh token survives in
+ * localStorage (issue #1671) — do we fall back to the persisted copy, so the
+ * session can still silently refresh instead of logging the user out.
  */
-export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
+export async function resolveActiveProvider(): Promise<ProviderConfig | null> {
     if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
 
+    // The standard Auth0 token cache key is `<prefix><clientId>::<audience>::<scope>`,
+    // so clientId + audience are both recoverable from it. (The sibling id-token
+    // key `<prefix><clientId>::@@user@@` has no audience segment — skip it.)
     let clientId: string | null = null;
+    let audience: string | null = null;
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         if (!key?.startsWith(AUTH0_CACHE_PREFIX)) continue;
-        clientId = key.slice(AUTH0_CACHE_PREFIX.length).split("::")[0] || null;
-        if (clientId) break;
+        const segments = key.slice(AUTH0_CACHE_PREFIX.length).split("::");
+        if (!segments[0]) continue;
+        clientId = segments[0];
+        if (segments.length >= 3 && segments[1]) audience = segments[1];
+        if (audience) break;
     }
 
     if (!clientId) {
@@ -77,7 +140,19 @@ export async function resolveActiveProvider(): Promise<AuthProviderDto | null> {
         .equals(DocType.AuthProvider)
         .filter((d) => (d as AuthProviderDto).clientId === clientId)
         .first();
-    return (doc as AuthProviderDto) ?? null;
+    if (doc) {
+        const d = doc as AuthProviderDto;
+        persistActiveProvider(d);
+        return { _id: d._id, domain: d.domain, clientId: d.clientId, audience: d.audience };
+    }
+
+    // Dexie evicted: rebuild from the persisted `{ _id, domain }` plus the
+    // clientId + audience still carried by the Auth0 cache key.
+    const persisted = readPersistedProvider();
+    if (persisted && audience) {
+        return { _id: persisted._id, domain: persisted.domain, clientId, audience };
+    }
+    return null;
 }
 
 function buildAuth0Options(p: ProviderConfig) {
@@ -117,10 +192,14 @@ export async function setupAuth(app: App<Element>): Promise<void> {
 
     const provider = await resolveActiveProvider();
     if (!provider) {
-        // Auth0 cache keys from a deleted provider (or a session that predates
-        // the provider doc landing in Dexie) will linger in localStorage
-        // forever without this — no other path cleans them up for a cold start.
-        clearAuth0Cache();
+        // Don't destroy a possibly-valid Auth0 session just because Dexie has
+        // no matching AuthProvider doc — IndexedDB can be evicted while the
+        // localStorage refresh token survives (issue #1671), and wiping the
+        // cache here would conflate "no provider doc right now" with "no
+        // session." The router guard (conditionalAuthGuard) opens the provider
+        // modal because no Auth0 plugin was installed, and the server's
+        // `provider_not_found` connect_error path still wipes the cache if the
+        // provider really is gone.
         return;
     }
 
@@ -167,9 +246,7 @@ export async function setupAuth(app: App<Element>): Promise<void> {
  *   we'd loop forever on any clock skew or server-side revocation.
  * @returns `true` on success, `false` otherwise.
  */
-export async function refreshTokenSilently(opts?: {
-    ignoreCache?: boolean;
-}): Promise<boolean> {
+export async function refreshTokenSilently(opts?: { ignoreCache?: boolean }): Promise<boolean> {
     if (!installedOauth) return false;
     try {
         const token = await installedOauth.getAccessTokenSilently(
@@ -193,6 +270,9 @@ export async function loginWithProvider(
     provider: ProviderConfig,
     opts?: { prompt?: Auth0Prompt },
 ): Promise<void> {
+    // Remember the chosen provider so a returning session can be resolved
+    // without the Dexie AuthProvider doc (issue #1671).
+    persistActiveProvider(provider);
     // Evict stale PKCE transactions from aborted attempts so the next
     // callback matches the fresh code_verifier.
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
@@ -211,6 +291,11 @@ export function clearAuth0Cache(): void {
     removeCustomHeader("Authorization");
     clearStoragePrefix(localStorage, AUTH0_CACHE_PREFIX);
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
+    try {
+        localStorage.removeItem(ACTIVE_PROVIDER_KEY);
+    } catch {
+        // ignore — storage may be unavailable
+    }
 }
 
 export function openProviderModal(): void {


### PR DESCRIPTION
The Auth0 refresh token survives in localStorage, but `domain` and `_id` — needed to rebuild the Auth0 client and silently refresh — live only in the AuthProvider doc in IndexedDB, which browsers evict (~7 days; iOS Safari ITP). With IDB gone, resolveActiveProvider returned null and the user was logged out despite holding a valid refresh token.

Persist the minimal `{ _id, domain }` to localStorage at login and on a successful Dexie resolve. On a Dexie miss, resolveActiveProvider rebuilds the full provider config from that blob plus the `clientId` and `audience` already carried in the Auth0 cache key — recovering the session without IndexedDB. clientId/audience are never persisted (read off the documented cache key, not the SDK-internal cache value); only non-secret ids are stored, beside the refresh token the SDK already keeps there.

CMS: stop wiping the Auth0 cache in the no-provider branch, which was destroying still-valid refresh tokens on cold start; the router guard already surfaces the provider modal.

- app/src/auth.ts, cms/src/auth.ts: ACTIVE_PROVIDER_KEY + persist/readPersistedProvider helpers; Dexie-first resolve with localStorage eviction fallback; clear the key on logout/provider switch
- app/src/auth.spec.ts, cms/src/auth.spec.ts: eviction-recovery, write-through migration, and additive-regression coverage (incl. the realistic two-key Auth0 cache)