### PR TITLE
chore: gitignore local graphify knowledge-graph output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 *.bkp
 
 stats.html
+
+# graphify knowledge-graph output (generated locally via `graphify`; not committed for now)
+graphify-out/


### PR DESCRIPTION
## What

Adds `graphify-out/` to the root `.gitignore`.

## Why

The [`graphify`](https://github.com/) tool generates a `graphify-out/` directory at the repo root containing the knowledge-graph artifacts (`graph.json`, `GRAPH_REPORT.md`, `graph.html`, `manifest.json`) plus machine-specific dotfiles (`.graphify_root`, `.graphify_python`) and a regenerable `cache/`.

For now we want this generated output to live locally without polluting `git status` or being committed — keeping it ignored until there's a clearer decision on whether the graph artifacts themselves belong in version control.

## Scope

- One line: `graphify-out/` added to `.gitignore`.
- No graph data is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)