### PR TITLE
feat(app): restyle content tile collections to match new design

### DIFF
--- a/app/src/components/BasePage.vue
+++ b/app/src/components/BasePage.vue
@@ -67,10 +67,11 @@ onUnmounted(() => {
             >
                 <!-- Desktop pinned chrome: back (left) + quick controls (right) stay fixed while scrolling.
                      Direct child of the scrolling <main> so `sticky` keeps it pinned the whole way.
-                     pointer-events-none lets clicks fall through the empty centre to the notification. -->
+                     -mb-9 collapses its flow height so page content originates at the top of the page,
+                     sharing this row; pointer-events-none lets clicks fall through the empty centre. -->
                 <div
                     v-if="desktopTopBar"
-                    class="pointer-events-none sticky top-0 z-20 hidden h-9 items-center lg:flex"
+                    class="pointer-events-none sticky top-0 z-20 -mb-9 hidden h-9 items-center lg:flex"
                 >
                     <button
                         v-if="showBackButton"
@@ -85,17 +86,16 @@ onUnmounted(() => {
                     </div>
                 </div>
 
-                <!-- Desktop notification: scrolls with the content. Pulled up to sit on the same row
-                     as the pinned chrome at scroll-top; min-height reserves the row when empty so the
-                     article never slides under the pinned controls. Width matches the article column. -->
+                <!-- Desktop notification: normal flow below the pinned chrome; pushes article down when present.
+                     [&>div]:mb-2 trims the banner's default mb-4 so the gap above the title matches the page-top gap. -->
                 <div
                     v-if="desktopTopBar"
-                    class="-mt-9 mb-6 hidden min-h-[2.25rem] justify-center lg:flex"
+                    class="hidden justify-center lg:flex"
                 >
                     <div class="w-full lg:w-3/4 lg:max-w-3xl">
                         <NotificationBannerManager
                             v-if="showNotifications"
-                            class="[&>div]:mb-0"
+                            class="[&>div]:mb-2"
                         />
                     </div>
                 </div>

--- a/app/src/components/content/ContentTile.vue
+++ b/app/src/components/content/ContentTile.vue
@@ -134,7 +134,7 @@ if (allMedia) {
                             class="w-full"
                             v-if="titlePosition === 'bottom'"
                         >
-                            <h3 class="mt-1 truncate text-sm text-zinc-800 dark:text-slate-50">
+                            <h3 class="mt-2 truncate text-sm text-zinc-800 dark:text-slate-50">
                                 {{ content.title }}
                             </h3>
                             <div

--- a/app/src/components/content/HorizontalContentTileCollection.vue
+++ b/app/src/components/content/HorizontalContentTileCollection.vue
@@ -96,10 +96,10 @@ useInfiniteScroll(
     <div class="select-none">
         <h2
             v-if="title"
-            class="flex min-w-0 items-baseline gap-2 px-4 text-lg font-bold text-zinc-800 dark:text-slate-50"
+            class="flex min-w-0 items-baseline gap-2 px-4 text-lg font-medium text-zinc-800 dark:text-slate-50"
         >
             <span
-                class="h-4 w-1 shrink-0 self-center rounded-full bg-yellow-500"
+                class="h-4 w-1 shrink-0 self-center rounded-l-full bg-yellow-400/50"
                 aria-hidden="true"
             ></span>
             <span class="truncate">{{ title }}</span>

--- a/app/src/components/content/HorizontalContentTileCollection.vue
+++ b/app/src/components/content/HorizontalContentTileCollection.vue
@@ -96,12 +96,16 @@ useInfiniteScroll(
     <div class="select-none">
         <h2
             v-if="title"
-            class="truncate px-4"
+            class="flex min-w-0 items-baseline gap-2 px-4 text-lg font-bold text-zinc-800 dark:text-slate-50"
         >
-            {{ title }}
+            <span
+                class="h-4 w-1 shrink-0 self-center rounded-full bg-yellow-500"
+                aria-hidden="true"
+            ></span>
+            <span class="truncate">{{ title }}</span>
             <span
                 v-if="summary"
-                class="ml-1 text-xs font-normal text-zinc-500 dark:text-slate-200"
+                class="truncate text-xs font-normal text-zinc-500 dark:text-slate-200"
             >
                 {{ summary }}
             </span>

--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -43,7 +43,6 @@ import {
     cmsUrl,
 } from "@/globalConfig";
 import { useNotificationStore } from "@/stores/notification";
-import { storeToRefs } from "pinia";
 import NotFoundPage from "@/pages/NotFoundPage.vue";
 import RelatedContent from "@/components/content/RelatedContent.vue";
 import VerticalTagViewer from "@/components/tags/VerticalTagViewer.vue";
@@ -77,7 +76,6 @@ type Props = {
 const props = defineProps<Props>();
 
 const { t } = useI18n();
-const { banners } = storeToRefs(useNotificationStore());
 const showCategoryModal = ref(false);
 const enableZoom = ref(false);
 const selectedLanguageId = ref(appLanguagePreferredIdAsRef.value);

--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -43,6 +43,7 @@ import {
     cmsUrl,
 } from "@/globalConfig";
 import { useNotificationStore } from "@/stores/notification";
+import { storeToRefs } from "pinia";
 import NotFoundPage from "@/pages/NotFoundPage.vue";
 import RelatedContent from "@/components/content/RelatedContent.vue";
 import VerticalTagViewer from "@/components/tags/VerticalTagViewer.vue";
@@ -76,6 +77,7 @@ type Props = {
 const props = defineProps<Props>();
 
 const { t } = useI18n();
+const { banners } = storeToRefs(useNotificationStore());
 const showCategoryModal = ref(false);
 const enableZoom = ref(false);
 const selectedLanguageId = ref(appLanguagePreferredIdAsRef.value);
@@ -716,7 +718,25 @@ watch([isLoading, content, is404], async () => {
                     class="w-full lg:w-3/4 lg:max-w-3xl"
                     v-else-if="!isLoading && content"
                 >
-                    <div class="flex w-full flex-col items-center">
+                    <!-- Desktop: title row originates at the top of the page, level with the pinned
+                         topbar chrome, and scrolls away with the content like normal. -->
+                    <div class="hidden h-9 items-center justify-center gap-2 lg:flex">
+                        <h1
+                            class="truncate text-xl tracking-tight text-zinc-900 dark:text-slate-50 lg:text-2xl"
+                        >
+                            {{ content.title }}
+                        </h1>
+                        <button
+                            v-if="canEdit() && cmsUrl"
+                            @click="openCmsEditor"
+                            class="flex flex-shrink-0 cursor-pointer items-center text-zinc-400 hover:text-yellow-500 dark:hover:text-yellow-400"
+                            data-test="editButton"
+                        >
+                            <PencilIcon class="h-5 w-5" />
+                        </button>
+                    </div>
+
+                    <div class="flex w-full flex-col items-center lg:hidden">
                         <div class="mt-1 flex flex-col gap-4 text-center md:mt-4">
                             <div class="flex flex-row items-start justify-center gap-2">
                                 <h1
@@ -736,7 +756,7 @@ watch([isLoading, content, is404], async () => {
                         </div>
                     </div>
 
-                    <div class="mt-5">
+                    <div class="mt-5 lg:mt-2">
                         <IgnorePagePadding
                             :mobileOnly="true"
                             :ignoreTop="true"


### PR DESCRIPTION
- Section header: bold title with yellow accent bar, inline summary
- ContentTile: play/audio icons in a dark circular badge instead of the blur-glow effect; slightly more spacing under the image title