### PR TITLE
fix: mobile topbar excess right padding & SearchModal double FTS call

### DIFF
--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -405,7 +405,10 @@ watch(isSearchOpen, (open) => {
         const q = searchQuery.value.trim();
         // Only fetch when the current query has not already been searched (covers live + manual,
         // including "no results" where ftsResults is empty but lastSearchedQuery matches).
-        if (q.length >= 3 && lastSearchedQuery.value !== q) runSearch();
+        // In live mode useFtsSearch's query watcher (immediate: true) already triggered
+        // doSearch; only call runSearch explicitly in manual mode where the watcher is inactive.
+        if (isManualSearchMode.value && q.length >= 3 && lastSearchedQuery.value !== q)
+            runSearch();
     });
 }, { immediate: true });
 

--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -130,7 +130,7 @@ const handleLogin = () => {
                     </div>
                 </div>
 
-                <div class="ml-2 mr-5 flex cursor-pointer items-center gap-4">
+                <div class="ml-2 mr-0 flex cursor-pointer items-center gap-4 lg:mr-5">
                     <slot name="quickControls" />
                 </div>
                 <div class="hidden lg:block"><ProfileMenu /></div>


### PR DESCRIPTION
## Summary

Two small bug fixes in the navigation components:

### 1. APP: Right padding too much on Mobile Topbar — closes #1701

The `quickControls` wrapper had `mr-5` (20 px) applied on **all** screen sizes. On mobile, `ProfileMenu` is hidden (`lg:block`), so that margin stacked on top of the outer container's `pr-5` (20 px), producing ~40 px of compound right padding — visibly excessive.

**Fix:** `mr-5` → `mr-0 lg:mr-5` — removes the inner margin on mobile while keeping the intentional gap between `quickControls` and `ProfileMenu` on desktop.

### 2. APP: Search modal calls FTS API query twice — closes #1712

In **live mode** (desktop, `debounceMs = 250`), `useFtsSearch` registers its internal query watcher with `{ immediate: true }`, which fires `doSearch` synchronously when the watcher is first set up (or when `debounceMs` switches mode). Separately, `watch(isSearchOpen)` in `SearchModal.vue` also called `runSearch()` for the same query — producing two concurrent FTS calls.

**Fix:** Guard the explicit `runSearch()` call with `isManualSearchMode.value`. In live mode the composable's own watcher handles all searches; in manual mode (mobile) the explicit trigger is still needed when reopening the modal with an unexecuted query.

## Test plan

- [ ] Mobile: open the app on a narrow viewport, verify the topbar right edge has normal padding (matches left side roughly)
- [ ] Desktop: open the app, verify the topbar layout (logo / controls / profile) is unchanged
- [ ] Desktop: open the search modal with an existing query, open browser DevTools Network tab, confirm only **one** FTS request fires (not two)
- [ ] Mobile: open the search modal, type 3+ chars, press Go — confirm search still runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qD1R5qGPDX4e2FM3ko1DN

---
_Generated by [Claude Code](https://claude.ai/code/session_011qD1R5qGPDX4e2FM3ko1DN)_