### PR TITLE
APP: Fix hybrid query crash on single content when copyright/privacy IDs unset

### DIFF
--- a/app/src/components/content/CopyrightBanner.vue
+++ b/app/src/components/content/CopyrightBanner.vue
@@ -2,15 +2,24 @@
 import { computed } from "vue";
 import { useContentQuery } from "@/composables/useContentQuery";
 
-const copyright = useContentQuery(() => [{ parentId: import.meta.env.VITE_COPYRIGHT_ID }], {
-    includeScheduled: false,
-    limit: 1,
-    // Seek by parentId; the publishDate sort is required to engage the index.
-    useIndex: "content-parentId-publishDate-index",
-    sort: [{ publishDate: "desc" }],
-    // Keep `text` — the copyright body is rendered below; the default strips it.
-    stripFields: ["fts", "ftsTokenCount", "memberOf", "_rev"],
-});
+// When VITE_COPYRIGHT_ID is unset there is no copyright page to seek. A
+// `{ parentId: undefined }` clause serializes to `{}` over the wire, leaving the
+// parentId index pinned with a publishDate sort but no parentId equality — which
+// CouchDB rejects ("No index exists for this sort"). Match nothing via a
+// provably-empty `$in` so HybridQuery short-circuits before any Dexie read or POST.
+const copyrightId = import.meta.env.VITE_COPYRIGHT_ID;
+const copyright = useContentQuery(
+    () => (copyrightId ? [{ parentId: copyrightId }] : [{ parentId: { $in: [] } }]),
+    {
+        includeScheduled: false,
+        limit: 1,
+        // Seek by parentId; the publishDate sort is required to engage the index.
+        useIndex: "content-parentId-publishDate-index",
+        sort: [{ publishDate: "desc" }],
+        // Keep `text` — the copyright body is rendered below; the default strips it.
+        stripFields: ["fts", "ftsTokenCount", "memberOf", "_rev"],
+    },
+);
 
 const copyrightContent = computed(() => copyright.value[0]?.text ?? "");
 </script>

--- a/app/src/components/navigation/PrivacyPolicyModal.spec.ts
+++ b/app/src/components/navigation/PrivacyPolicyModal.spec.ts
@@ -45,6 +45,7 @@ describe("PrivacyPolicyModal.vue", () => {
     });
     afterEach(() => {
         vi.clearAllMocks();
+        vi.unstubAllEnvs();
         db.docs.clear();
         isAuthPluginInstalled.value = false;
     });
@@ -153,6 +154,13 @@ describe("PrivacyPolicyModal.vue", () => {
             isAuthenticated: ref(true),
             logout: vi.fn(),
         });
+
+        // The component reads VITE_PRIVACY_POLICY_ID at setup time to build its
+        // query. Locally this comes from .env, but CI has no .env, leaving it
+        // undefined — which makes the query short-circuit to match nothing and
+        // the policy never reads as "outdated". Stub it so the test is
+        // self-sufficient regardless of environment.
+        vi.stubEnv("VITE_PRIVACY_POLICY_ID", "page-privacy-policy");
 
         await db.docs.clear();
         await db.docs.bulkPut([

--- a/app/src/components/navigation/PrivacyPolicyModal.vue
+++ b/app/src/components/navigation/PrivacyPolicyModal.vue
@@ -28,8 +28,14 @@ const show = defineModel<boolean>("show");
 // Set the privacy policy status to "updated" if the policy has changed and the user previously accepted it
 // Content is partially synced, so this routes through HybridQuery (IndexedDB +
 // API supplement). The injected { type: Content } is required for that routing.
+// When VITE_PRIVACY_POLICY_ID is unset there is no policy page to seek. A
+// `{ parentId: undefined }` clause serializes to `{}` over the wire, leaving the
+// parentId index pinned with a publishDate sort but no parentId equality — which
+// CouchDB rejects ("No index exists for this sort"). Match nothing via a
+// provably-empty `$in` so HybridQuery short-circuits before any Dexie read or POST.
+const privacyPolicyId = import.meta.env.VITE_PRIVACY_POLICY_ID;
 const privacyPolicyArr = useContentQuery(
-    () => [{ parentId: import.meta.env.VITE_PRIVACY_POLICY_ID }],
+    () => (privacyPolicyId ? [{ parentId: privacyPolicyId }] : [{ parentId: { $in: [] } }]),
     {
         includeScheduled: false,
         limit: 1,


### PR DESCRIPTION
CopyrightBanner and PrivacyPolicyModal seek their content by `parentId: import.meta.env.VITE_COPYRIGHT_ID` / `VITE_PRIVACY_POLICY_ID` without guarding for an unset env var. When the id is undefined the clause serializes to `{}` over the wire, leaving the query pinned to content-parentId-publishDate-index with a publishDate desc sort but no parentId equality. CouchDB can't serve a standalone publishDate sort from that [parentId, publishDate] index, so the hybridQuery POST fails every time on single content pages ("No index exists for this sort") and the limit-1 shortfall round-trip freezes the UI for ~1s.

Guard both call sites with the provably-empty `{ parentId: { $in: [] } }` pattern the SingleContent queries already use, so an unset id short-circuits in HybridQuery before any Dexie read or API POST instead of firing a crashing query. Configured ids are unchanged (parentId equality + publishDate sort is exactly what the index serves).