### PR TITLE
fix(search): prevent duplicate FTS API calls and stale results on reset

### DIFF
--- a/app/src/components/navigation/SearchModal.vue
+++ b/app/src/components/navigation/SearchModal.vue
@@ -513,6 +513,11 @@ const handleInputKeydown = (event: KeyboardEvent) => {
 };
 
 const clearSearch = () => {
+    // Cancel any in-flight search and debounce timer synchronously before clearing state,
+    // so a slow previous run can't repopulate results after the clear.
+    cancel();
+    ftsResults.value = [];
+    lastSearchedQuery.value = "";
     searchQuery.value = "";
     inputRef.value?.focus();
 };

--- a/shared/src/fts/useFtsSearch.ts
+++ b/shared/src/fts/useFtsSearch.ts
@@ -164,6 +164,12 @@ export function useFtsSearch(
     function runSearch() {
         const q = queryRef.value.trim();
         currentQuery = q;
+        // Cancel any pending debounce timer so the explicit run doesn't race with
+        // the timer-driven doSearch and cause a duplicate API call.
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = undefined;
+        }
         doSearch(q, 0, false);
     }
 


### PR DESCRIPTION
## Summary

Fixes two S-sized search bugs found during a project board scan:

- **#1712 — Search modal calls FTS API query twice**: `runSearch()` in `useFtsSearch` now cancels any pending debounce timer before calling `doSearch()`. Previously, when `SearchModal` explicitly called `runSearch()` (e.g. on modal open via `watch(isSearchOpen)`), the still-pending 250 ms debounce timer would also fire `doSearch` for the same query — sending two identical HTTP requests to the FTS endpoint.

- **#1707 — Search not clearing when pressing reset button**: `clearSearch()` in `SearchModal.vue` now synchronously calls `cancel()`, clears `ftsResults`, and resets `lastSearchedQuery` _before_ setting `searchQuery` to `""`. Previously, an in-flight API response completing during Vue's async watcher flush could repopulate the result list after the user pressed reset, because the `searchGeneration` counter hadn't been bumped yet at that point.

## Files changed

| File | Change |
|---|---|
| `shared/src/fts/useFtsSearch.ts` | `runSearch()` clears debounce timer before `doSearch()` |
| `app/src/components/navigation/SearchModal.vue` | `clearSearch()` cancels + clears state synchronously upfront |

## Test plan

- [ ] Open search modal on desktop, type a 3+ char query — confirm only one network request to `/fts` fires (check DevTools Network tab)
- [ ] Type a query, press the reset (↩) button — confirm results disappear immediately and do not reappear
- [ ] On slow network: start a search, immediately press reset — confirm old results do not flash back in
- [ ] Pick a recent search term — confirm results load (single API call)
- [ ] All 87 FTS unit tests pass: `cd shared && npm run test -- src/fts/`

Closes #1712
Closes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tkin8K6TtYEiKFdrUkqYzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkin8K6TtYEiKFdrUkqYzC)_