### PR TITLE
APP: Re-translate persistent notification banners on language change (#1725)

### DIFF
--- a/app/src/App.spec.ts
+++ b/app/src/App.spec.ts
@@ -8,7 +8,7 @@ import waitForExpect from "wait-for-expect";
 import { setActivePinia } from "pinia";
 import { createTestingPinia } from "@pinia/testing";
 import { isConnected } from "luminary-shared";
-import { useNotificationStore } from "./stores/notification";
+import { resolveNotificationText, useNotificationStore } from "./stores/notification";
 import { mockEnglishContentDto } from "./tests/mockdata";
 import { isAppLoading, theme } from "./globalConfig";
 import LoadingBar from "@/components/LoadingBar.vue";
@@ -89,14 +89,19 @@ describe("App", () => {
 
             await waitForExpect(() => {
                 expect(notificationStore.addNotification).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        id: "offlineBanner",
-                        title: "You are offline",
-                        description:
-                            "You can still use the app and browse through offline content, but some content (like videos) might not be available.",
-                    }),
+                    expect.objectContaining({ id: "offlineBanner" }),
                 );
             });
+
+            // Title/description are getters so they re-translate on language change — resolve them to assert text.
+            const offlineBanner = vi
+                .mocked(notificationStore.addNotification)
+                .mock.calls.map((call) => call[0])
+                .find((n) => n.id === "offlineBanner");
+            expect(resolveNotificationText(offlineBanner!.title)).toBe("You are offline.");
+            expect(resolveNotificationText(offlineBanner!.description)).toBe(
+                "You can still use the app and browse through offline content, but some content (like videos) might not be available.",
+            );
 
             isConnected.value = true;
 
@@ -121,13 +126,18 @@ describe("App", () => {
 
             await waitForExpect(() => {
                 expect(notificationStore.addNotification).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        id: "accountBanner",
-                        title: "You are missing out!",
-                        description: "Click here to create an account or log in",
-                    }),
+                    expect.objectContaining({ id: "accountBanner" }),
                 );
             }, 8000);
+
+            const accountBanner = vi
+                .mocked(notificationStore.addNotification)
+                .mock.calls.map((call) => call[0])
+                .find((n) => n.id === "accountBanner");
+            expect(resolveNotificationText(accountBanner!.title)).toBe("You are missing out!");
+            expect(resolveNotificationText(accountBanner!.description)).toBe(
+                "Click here to create an account or log in",
+            );
         }, 9000);
     });
 

--- a/app/src/App.spec.ts
+++ b/app/src/App.spec.ts
@@ -165,10 +165,9 @@ describe("App", () => {
 
     describe("Router", () => {
         it("redirects to home when accessed externally", async () => {
-
             const routes = [
-            { path: "/", name: "home", component: HomePage },
-            { path: "/explore", name: "explore", component: ExplorePage },
+                { path: "/", name: "home", component: HomePage },
+                { path: "/explore", name: "explore", component: ExplorePage },
             ];
 
             const testRouter = createRouter({
@@ -194,10 +193,10 @@ describe("App", () => {
             await testRouter.push("/explore");
             await testRouter.isReady();
 
-           await waitForExpect(() => {
-            expect(replaceSpy).toHaveBeenCalledWith({ name: "home" });
-            expect(pushSpy).toHaveBeenCalledWith("/explore");
-           });
+            await waitForExpect(() => {
+                expect(replaceSpy).toHaveBeenCalledWith({ name: "home" });
+                expect(pushSpy).toHaveBeenCalledWith("/explore");
+            });
         });
     });
 });

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -53,9 +53,8 @@ setTimeout(() => {
             if (!isConnected.value) {
                 useNotificationStore().addNotification({
                     id: "offlineBanner",
-                    title: "You are offline",
-                    description:
-                        "You can still use the app and browse through offline content, but some content (like videos) might not be available.",
+                    title: () => t("notification.offline.title"),
+                    description: () => t("notification.offline.message"),
                     state: "warning",
                     type: "banner",
                     icon: SignalSlashIcon,
@@ -76,8 +75,8 @@ watch(
         if (isConnected.value && !isAuthenticated.value) {
             useNotificationStore().addNotification({
                 id: "accountBanner",
-                title: t("notification.login.title"),
-                description: t("notification.login.message"),
+                title: () => t("notification.login.title"),
+                description: () => t("notification.login.message"),
                 state: "warning",
                 type: "banner",
                 icon: ArrowLeftEndOnRectangleIcon,

--- a/app/src/components/navigation/PrivacyPolicyModal.vue
+++ b/app/src/components/navigation/PrivacyPolicyModal.vue
@@ -69,13 +69,6 @@ const modalMessageMap = {
     necessaryOnly: t("privacy_policy.banner.message_map.necessaryOnly"),
 };
 
-const bannerMessageMap = {
-    ...modalMessageMap,
-    outdated: t("privacy_policy.banner.message_map.outdated"),
-    unaccepted: t("privacy_policy.banner.message_map.unaccepted"),
-    necessaryOnly: t("privacy_policy.banner.message_map.necessaryOnly"),
-};
-
 const status: ComputedRef<"accepted" | "outdated" | "unaccepted" | "necessaryOnly"> = computed(
     () => {
         if (!userPreferencesAsRef.value.privacyPolicy) return "unaccepted";
@@ -121,11 +114,14 @@ setTimeout(() => {
                     id: "privacy-policy-banner",
                     type: "bottom",
                     state: "info",
-                    title:
+                    title: () =>
                         status == "outdated"
                             ? t("privacy_policy.banner.title_map.outdated")
                             : t("privacy_policy.banner.title"),
-                    description: bannerMessageMap[status],
+                    description: () =>
+                        status == "outdated"
+                            ? t("privacy_policy.banner.message_map.outdated")
+                            : t("privacy_policy.banner.message_map.unaccepted"),
                     icon: ShieldCheckIcon,
                     link: () => (show.value = true),
                     closable: false,

--- a/app/src/components/notifications/NotificationBanner.vue
+++ b/app/src/components/notifications/NotificationBanner.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, type FunctionalComponent } from "vue";
+import { computed, ref, type FunctionalComponent } from "vue";
 import {
     CheckCircleIcon,
     ExclamationTriangleIcon,
     InformationCircleIcon,
 } from "@heroicons/vue/24/outline";
 import { XMarkIcon } from "@heroicons/vue/20/solid";
-import { type Notification, useNotificationStore } from "@/stores/notification";
+import { type Notification, resolveNotificationText, useNotificationStore } from "@/stores/notification";
 import { RouterLink, useRouter } from "vue-router";
 
 type Props = {
@@ -14,6 +14,10 @@ type Props = {
 };
 
 const props = defineProps<Props>();
+
+// Resolve text inside a computed so getter-based titles re-translate on language change.
+const title = computed(() => resolveNotificationText(props.notification.title));
+const description = computed(() => resolveNotificationText(props.notification.description));
 
 const router = useRouter();
 
@@ -97,15 +101,15 @@ const handleNotificationClick = (notification: Notification) => {
                 />
                 <div class="flex flex-col md:inline-block md:align-middle">
                     <span
-                        v-if="notification.title"
+                        v-if="title"
                         class="text-md font-medium md:text-sm"
-                        >{{ notification.title }}</span
+                        >{{ title }}</span
                     >
                     <span
-                        v-if="notification.description"
+                        v-if="description"
                         class="text-xs md:ml-3"
                     >
-                        {{ notification.description }}
+                        {{ description }}
                     </span>
                 </div>
             </component>

--- a/app/src/components/notifications/NotificationBanner.vue
+++ b/app/src/components/notifications/NotificationBanner.vue
@@ -6,7 +6,11 @@ import {
     InformationCircleIcon,
 } from "@heroicons/vue/24/outline";
 import { XMarkIcon } from "@heroicons/vue/20/solid";
-import { type Notification, resolveNotificationText, useNotificationStore } from "@/stores/notification";
+import {
+    type Notification,
+    resolveNotificationText,
+    useNotificationStore,
+} from "@/stores/notification";
 import { RouterLink, useRouter } from "vue-router";
 
 type Props = {

--- a/app/src/components/notifications/NotificationBottom.vue
+++ b/app/src/components/notifications/NotificationBottom.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
-import { ref, type FunctionalComponent } from "vue";
+import { computed, ref, type FunctionalComponent } from "vue";
 import {
     CheckCircleIcon,
     ExclamationTriangleIcon,
     InformationCircleIcon,
 } from "@heroicons/vue/24/outline";
-import { type Notification } from "@/stores/notification";
+import { type Notification, resolveNotificationText } from "@/stores/notification";
 
 type Props = {
     notification: Notification;
 };
 
 const props = defineProps<Props>();
+
+// Resolve text inside a computed so getter-based titles re-translate on language change.
+const title = computed(() => resolveNotificationText(props.notification.title));
+const description = computed(() => resolveNotificationText(props.notification.description));
 
 const icon = ref<FunctionalComponent>();
 
@@ -55,9 +59,9 @@ switch (props.notification.state) {
         class="flex flex-col items-start justify-between border-t-2 border-t-zinc-100/25 bg-yellow-500/10 px-4 py-4 dark:border-t-slate-700/50 dark:bg-yellow-500/5 md:flex-row md:items-center"
     >
         <div class="flex-col md:mb-0">
-            <p class="mb-2 font-bold">{{ props.notification.title }}</p>
+            <p class="mb-2 font-bold">{{ title }}</p>
 
-            <p class="text-sm">{{ props.notification.description }}</p>
+            <p class="text-sm">{{ description }}</p>
         </div>
         <div class="w-full text-nowrap md:w-auto">
             <!-- Render actions slot or dynamic actions from props -->

--- a/app/src/components/notifications/NotificationBottom.vue
+++ b/app/src/components/notifications/NotificationBottom.vue
@@ -65,8 +65,14 @@ switch (props.notification.state) {
         </div>
         <div class="w-full text-nowrap md:w-auto">
             <!-- Render actions slot or dynamic actions from props -->
-            <slot v-if="$slots.actions" name="actions" />
-            <component :is="props.notification.actions" v-else-if="props.notification.actions" />
+            <slot
+                v-if="$slots.actions"
+                name="actions"
+            />
+            <component
+                :is="props.notification.actions"
+                v-else-if="props.notification.actions"
+            />
         </div>
     </div>
 </template>

--- a/app/src/components/notifications/NotificationToast.vue
+++ b/app/src/components/notifications/NotificationToast.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref, type FunctionalComponent } from "vue";
+import { computed, ref, type FunctionalComponent } from "vue";
 import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/vue/24/outline";
 import { XMarkIcon } from "@heroicons/vue/20/solid";
-import { type Notification, useNotificationStore } from "@/stores/notification";
+import { type Notification, resolveNotificationText, useNotificationStore } from "@/stores/notification";
 import { RouterLink } from "vue-router";
 
 type Props = {
@@ -10,6 +10,10 @@ type Props = {
 };
 
 const props = defineProps<Props>();
+
+// Resolve text inside a computed so getter-based titles re-translate on language change.
+const title = computed(() => resolveNotificationText(props.notification.title));
+const description = computed(() => resolveNotificationText(props.notification.description));
 
 const show = ref(true);
 
@@ -73,10 +77,10 @@ switch (props.notification.state) {
                     </div>
                     <div class="ml-3 w-0 flex-1 pt-0.5">
                         <p class="text-sm font-medium text-zinc-900 dark:text-white">
-                            {{ notification.title }}
+                            {{ title }}
                         </p>
                         <p class="mt-1 text-sm text-zinc-500 dark:text-white">
-                            {{ notification.description }}
+                            {{ description }}
                         </p>
                     </div>
                     <div class="ml-4 flex flex-shrink-0">

--- a/app/src/components/notifications/NotificationToast.vue
+++ b/app/src/components/notifications/NotificationToast.vue
@@ -2,7 +2,11 @@
 import { computed, ref, type FunctionalComponent } from "vue";
 import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/vue/24/outline";
 import { XMarkIcon } from "@heroicons/vue/20/solid";
-import { type Notification, resolveNotificationText, useNotificationStore } from "@/stores/notification";
+import {
+    type Notification,
+    resolveNotificationText,
+    useNotificationStore,
+} from "@/stores/notification";
 import { RouterLink } from "vue-router";
 
 type Props = {
@@ -96,7 +100,10 @@ switch (props.notification.state) {
                             v-if="notification.closable"
                         >
                             <span class="sr-only">Close</span>
-                            <XMarkIcon class="h-5 w-5" aria-hidden="true" />
+                            <XMarkIcon
+                                class="h-5 w-5"
+                                aria-hidden="true"
+                            />
                         </button>
                     </div>
                 </div>

--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -512,10 +512,11 @@ watch(
         setTimeout(() => {
             useNotificationStore().addNotification({
                 id: "content-available",
-                title: t("notification.translation_available.title"),
-                description: t("notification.translation_available.description", {
-                    language: appLanguageAsRef.value?.name,
-                }),
+                title: () => t("notification.translation_available.title"),
+                description: () =>
+                    t("notification.translation_available.description", {
+                        language: appLanguageAsRef.value?.name,
+                    }),
                 state: "info",
                 type: "banner",
                 closable: true,

--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -33,7 +33,7 @@ import VideoPlayer from "@/components/content/VideoPlayer.vue";
 import * as auth0 from "@auth0/auth0-vue";
 import LImage from "@/components/images/LImage.vue";
 import ImageModal from "@/components/images/ImageModal.vue";
-import { useNotificationStore } from "@/stores/notification";
+import { resolveNotificationText, useNotificationStore } from "@/stores/notification";
 
 const routeReplaceMock = vi.hoisted(() => vi.fn());
 const mockIsExternalNavigation = vi.hoisted(() => vi.fn());
@@ -495,13 +495,21 @@ describe("SingleContent", () => {
             expect(useNotificationStore().addNotification).toHaveBeenCalledWith(
                 expect.objectContaining({
                     id: "content-available",
-                    title: "Translation available",
-                    description: `The content is also available in English. Click here to view it.`,
                     state: "info",
                     type: "banner",
                 }),
             );
         }, 3000);
+
+        // Title/description are getters so they re-translate on language change — resolve them to assert text.
+        const contentAvailable = vi
+            .mocked(useNotificationStore().addNotification)
+            .mock.calls.map((call) => call[0])
+            .find((n) => n.id === "content-available");
+        expect(resolveNotificationText(contentAvailable!.title)).toBe("Translation available");
+        expect(resolveNotificationText(contentAvailable!.description)).toBe(
+            "The content is also available in English. Click here to view it.",
+        );
     });
 
     it("shows the notification when opening from external link", async () => {
@@ -532,13 +540,21 @@ describe("SingleContent", () => {
             expect(useNotificationStore().addNotification).toHaveBeenCalledWith(
                 expect.objectContaining({
                     id: "content-available",
-                    title: "Translation available",
-                    description: `The content is also available in English. Click here to view it.`,
                     state: "info",
                     type: "banner",
                 }),
             );
         }, 3000);
+
+        // Title/description are getters so they re-translate on language change — resolve them to assert text.
+        const contentAvailable = vi
+            .mocked(useNotificationStore().addNotification)
+            .mock.calls.map((call) => call[0])
+            .find((n) => n.id === "content-available");
+        expect(resolveNotificationText(contentAvailable!.title)).toBe("Translation available");
+        expect(resolveNotificationText(contentAvailable!.description)).toBe(
+            "The content is also available in English. Click here to view it.",
+        );
     });
 
     it("shows the notification when opening from direct link (URL paste/bookmark)", async () => {

--- a/app/src/stores/notification.ts
+++ b/app/src/stores/notification.ts
@@ -2,13 +2,25 @@ import { defineStore } from "pinia";
 import { computed, ref, type FunctionalComponent, type VNode } from "vue";
 import type { RouteLocationNamedRaw } from "vue-router";
 
+/**
+ * Notification text is either a plain string or a getter. Persistent notifications
+ * (banners/bottom) should pass a getter `() => t("key")` so the text re-resolves
+ * when the app language changes — a stored string stays frozen in the language it
+ * was created in. The notification components resolve this via `resolveNotificationText`
+ * inside a computed, which keeps it reactive to the i18n locale.
+ */
+export type NotificationText = string | (() => string);
+
+export const resolveNotificationText = (text?: NotificationText): string | undefined =>
+    typeof text === "function" ? text() : text;
+
 export type Notification = {
     /**
      * Optional notification ID. If not provided, it will be generated. The ID is needed to remove the notification.
      */
     id?: number | string;
-    title?: string;
-    description?: string;
+    title?: NotificationText;
+    description?: NotificationText;
     state: "success" | "error" | "info" | "warning";
     type: "toast" | "banner" | "bottom";
     icon?: FunctionalComponent;


### PR DESCRIPTION
Resolve notification title/description through a getter in a computed so banners re-run t() reactively instead of holding a string frozen at creation time; also translate the previously-hardcoded offline banner.