### PR TITLE
fix(app,cms): reconnect socket when a backgrounded tab becomes visible again

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -85,8 +85,8 @@ async function Startup() {
     socket.on(
         "connect_error",
         async (err: Error & { data?: { type?: string; reason?: string } }) => {
-            reconnecting = false;
             if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
+            reconnecting = false;
 
             const reason = err.data?.reason;
 
@@ -133,6 +133,9 @@ async function Startup() {
     // restarting an attempt that's already in flight.
     watch(isConnected, (connected) => {
         if (connected) reconnecting = false;
+    });
+    socket.on("disconnect", () => {
+        reconnecting = false;
     });
     document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -73,12 +73,19 @@ async function Startup() {
 
     const socket = getSocket();
 
+    // Guards the visibilitychange-triggered reconnect below against firing again
+    // while a previous attempt is still in flight (e.g. rapid tab switching, or a
+    // slow Auth0 round-trip during startup) — otherwise each flip restarts the
+    // handshake and the connection state visibly flaps.
+    let reconnecting = false;
+
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
     // by then, the event is lost and the client loops forever.
     socket.on(
         "connect_error",
         async (err: Error & { data?: { type?: string; reason?: string } }) => {
+            reconnecting = false;
             if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
 
             const reason = err.data?.reason;
@@ -113,19 +120,26 @@ async function Startup() {
         },
     );
 
+    await setupAuth(app, router);
+    socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
+
     // A tab backgrounded during sleep/long idle can end up with the socket
     // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
     // handling) with no future retry scheduled. Foregrounding the tab is the
     // natural moment to try again — any resulting auth failure is handled by
-    // the connect_error listener above, same as any other reconnect.
+    // the connect_error listener above, same as any other reconnect. Registered
+    // after setupAuth() so it can't race the initial (possibly slow, Auth0-backed)
+    // connection attempt; `reconnecting` stops repeat visibility flips from
+    // restarting an attempt that's already in flight.
+    watch(isConnected, (connected) => {
+        if (connected) reconnecting = false;
+    });
     document.addEventListener("visibilitychange", () => {
-        if (document.visibilityState === "visible" && !isConnected.value) {
+        if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
+            reconnecting = true;
             socket.reconnect();
         }
     });
-
-    await setupAuth(app, router);
-    socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
 
     // Install all plugins before mounting — components rendered during the
     // splash screen (e.g. SearchModal) call useI18n() at setup time.

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -78,6 +78,16 @@ async function Startup() {
     // slow Auth0 round-trip during startup) — otherwise each flip restarts the
     // handshake and the connection state visibly flaps.
     let reconnecting = false;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    // Transport can connect while the server never sends clientConfig (see
+    // socketio.ts), in which case isConnected never flips true and no `disconnect`
+    // fires either — nothing would ever clear `reconnecting`. This timeout is the
+    // backstop so a stuck handshake doesn't permanently block future reconnects.
+    function stopReconnecting() {
+        reconnecting = false;
+        clearTimeout(reconnectTimeout);
+    }
 
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
@@ -86,7 +96,7 @@ async function Startup() {
         "connect_error",
         async (err: Error & { data?: { type?: string; reason?: string } }) => {
             if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-            reconnecting = false;
+            stopReconnecting();
 
             const reason = err.data?.reason;
 
@@ -132,14 +142,15 @@ async function Startup() {
     // connection attempt; `reconnecting` stops repeat visibility flips from
     // restarting an attempt that's already in flight.
     watch(isConnected, (connected) => {
-        if (connected) reconnecting = false;
+        if (connected) stopReconnecting();
     });
     socket.on("disconnect", () => {
-        reconnecting = false;
+        stopReconnecting();
     });
     document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
             reconnecting = true;
+            reconnectTimeout = setTimeout(() => (reconnecting = false), 20_000);
             socket.reconnect();
         }
     });

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -13,7 +13,7 @@ import {
 } from "@/auth";
 import { useNotificationStore } from "./stores/notification";
 import { appPluginsManager } from "@/build-time/contracts/plugin-registry";
-import { getSocket, init, warmMangoCaches, serverError } from "luminary-shared";
+import { getSocket, init, warmMangoCaches, serverError, isConnected } from "luminary-shared";
 import {
     appSyncedLanguageIdsAsRef,
     initLanguage,
@@ -112,6 +112,17 @@ async function Startup() {
             }
         },
     );
+
+    // A tab backgrounded during sleep/long idle can end up with the socket
+    // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
+    // handling) with no future retry scheduled. Foregrounding the tab is the
+    // natural moment to try again — any resulting auth failure is handled by
+    // the connect_error listener above, same as any other reconnect.
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible" && !isConnected.value) {
+            socket.reconnect();
+        }
+    });
 
     await setupAuth(app, router);
     socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -13,7 +13,7 @@ import {
 } from "@/auth";
 import { useNotificationStore } from "./stores/notification";
 import { appPluginsManager } from "@/build-time/contracts/plugin-registry";
-import { getSocket, init, warmMangoCaches, serverError, isConnected } from "luminary-shared";
+import { getSocket, init, warmMangoCaches, serverError } from "luminary-shared";
 import {
     appSyncedLanguageIdsAsRef,
     initLanguage,
@@ -73,22 +73,6 @@ async function Startup() {
 
     const socket = getSocket();
 
-    // Guards the visibilitychange-triggered reconnect below against firing again
-    // while a previous attempt is still in flight (e.g. rapid tab switching, or a
-    // slow Auth0 round-trip during startup) — otherwise each flip restarts the
-    // handshake and the connection state visibly flaps.
-    let reconnecting = false;
-    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
-
-    // Transport can connect while the server never sends clientConfig (see
-    // socketio.ts), in which case isConnected never flips true and no `disconnect`
-    // fires either — nothing would ever clear `reconnecting`. This timeout is the
-    // backstop so a stuck handshake doesn't permanently block future reconnects.
-    function stopReconnecting() {
-        reconnecting = false;
-        clearTimeout(reconnectTimeout);
-    }
-
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
     // by then, the event is lost and the client loops forever.
@@ -96,8 +80,6 @@ async function Startup() {
         "connect_error",
         async (err: Error & { data?: { type?: string; reason?: string } }) => {
             if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-            stopReconnecting();
-
             const reason = err.data?.reason;
 
             // Provider was deleted / never existed: don't re-attempt login with
@@ -132,28 +114,6 @@ async function Startup() {
 
     await setupAuth(app, router);
     socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
-
-    // A tab backgrounded during sleep/long idle can end up with the socket
-    // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
-    // handling) with no future retry scheduled. Foregrounding the tab is the
-    // natural moment to try again — any resulting auth failure is handled by
-    // the connect_error listener above, same as any other reconnect. Registered
-    // after setupAuth() so it can't race the initial (possibly slow, Auth0-backed)
-    // connection attempt; `reconnecting` stops repeat visibility flips from
-    // restarting an attempt that's already in flight.
-    watch(isConnected, (connected) => {
-        if (connected) stopReconnecting();
-    });
-    socket.on("disconnect", () => {
-        stopReconnecting();
-    });
-    document.addEventListener("visibilitychange", () => {
-        if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
-            reconnecting = true;
-            reconnectTimeout = setTimeout(() => (reconnecting = false), 20_000);
-            socket.reconnect();
-        }
-    });
 
     // Install all plugins before mounting — components rendered during the
     // splash screen (e.g. SearchModal) call useI18n() at setup time.

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -9,7 +9,6 @@ import {
     changeReqWarnings,
     getSocket,
     init,
-    isConnected,
     serverError,
 } from "luminary-shared";
 import { apiUrl, initLanguage } from "@/globalConfig";
@@ -48,22 +47,6 @@ async function Startup() {
 
     const socket = getSocket();
 
-    // Guards the visibilitychange-triggered reconnect below against firing again
-    // while a previous attempt is still in flight (e.g. rapid tab switching, or a
-    // slow Auth0 round-trip during startup) — otherwise each flip restarts the
-    // handshake and the connection state visibly flaps.
-    let reconnecting = false;
-    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
-
-    // Transport can connect while the server never sends clientConfig (see
-    // socketio.ts), in which case isConnected never flips true and no `disconnect`
-    // fires either — nothing would ever clear `reconnecting`. This timeout is the
-    // backstop so a stuck handshake doesn't permanently block future reconnects.
-    function stopReconnecting() {
-        reconnecting = false;
-        clearTimeout(reconnectTimeout);
-    }
-
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
     // by then, the event is lost and the client loops forever.
@@ -72,8 +55,6 @@ async function Startup() {
             "connect_error",
             async (err: Error & { data?: { type?: string; reason?: string } }) => {
                 if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-                stopReconnecting();
-
                 const reason = err.data?.reason;
 
                 // Provider was deleted / never existed: don't re-attempt login
@@ -116,30 +97,6 @@ async function Startup() {
     // default-groups map and deleteRevoked would purge local data. The pending
     // re-login/refresh connects the socket instead.
     if (!(readPersistedProvider() && !auth.activeProviderId.value)) socket.connect();
-
-    if (!isAuthBypassed) {
-        // A tab backgrounded during sleep/long idle can end up with the socket
-        // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
-        // handling) with no future retry scheduled. Foregrounding the tab is the
-        // natural moment to try again — any resulting auth failure is handled by
-        // the connect_error listener above, same as any other reconnect. Registered
-        // after setupAuth() so it can't race the initial (possibly slow, Auth0-backed)
-        // connection attempt; `reconnecting` stops repeat visibility flips from
-        // restarting an attempt that's already in flight.
-        watch(isConnected, (connected) => {
-            if (connected) stopReconnecting();
-        });
-        socket.on("disconnect", () => {
-            stopReconnecting();
-        });
-        document.addEventListener("visibilitychange", () => {
-            if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
-                reconnecting = true;
-                reconnectTimeout = setTimeout(() => (reconnecting = false), 20_000);
-                socket.reconnect();
-            }
-        });
-    }
 
     // Show notification on server error (5xx), debounced to avoid flooding.
     // CMS has no i18n layer; copy is owned here rather than in the shared lib.

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -53,6 +53,16 @@ async function Startup() {
     // slow Auth0 round-trip during startup) — otherwise each flip restarts the
     // handshake and the connection state visibly flaps.
     let reconnecting = false;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    // Transport can connect while the server never sends clientConfig (see
+    // socketio.ts), in which case isConnected never flips true and no `disconnect`
+    // fires either — nothing would ever clear `reconnecting`. This timeout is the
+    // backstop so a stuck handshake doesn't permanently block future reconnects.
+    function stopReconnecting() {
+        reconnecting = false;
+        clearTimeout(reconnectTimeout);
+    }
 
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
@@ -62,7 +72,7 @@ async function Startup() {
             "connect_error",
             async (err: Error & { data?: { type?: string; reason?: string } }) => {
                 if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
-                reconnecting = false;
+                stopReconnecting();
 
                 const reason = err.data?.reason;
 
@@ -117,14 +127,15 @@ async function Startup() {
         // connection attempt; `reconnecting` stops repeat visibility flips from
         // restarting an attempt that's already in flight.
         watch(isConnected, (connected) => {
-            if (connected) reconnecting = false;
+            if (connected) stopReconnecting();
         });
         socket.on("disconnect", () => {
-            reconnecting = false;
+            stopReconnecting();
         });
         document.addEventListener("visibilitychange", () => {
             if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
                 reconnecting = true;
+                reconnectTimeout = setTimeout(() => (reconnecting = false), 20_000);
                 socket.reconnect();
             }
         });

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -61,8 +61,8 @@ async function Startup() {
         socket.on(
             "connect_error",
             async (err: Error & { data?: { type?: string; reason?: string } }) => {
-                reconnecting = false;
                 if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
+                reconnecting = false;
 
                 const reason = err.data?.reason;
 
@@ -118,6 +118,9 @@ async function Startup() {
         // restarting an attempt that's already in flight.
         watch(isConnected, (connected) => {
             if (connected) reconnecting = false;
+        });
+        socket.on("disconnect", () => {
+            reconnecting = false;
         });
         document.addEventListener("visibilitychange", () => {
             if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -48,6 +48,12 @@ async function Startup() {
 
     const socket = getSocket();
 
+    // Guards the visibilitychange-triggered reconnect below against firing again
+    // while a previous attempt is still in flight (e.g. rapid tab switching, or a
+    // slow Auth0 round-trip during startup) — otherwise each flip restarts the
+    // handshake and the connection state visibly flaps.
+    let reconnecting = false;
+
     // Register the apiAuthFailed listener BEFORE setupAuth(), because setupAuth()
     // may connect the socket with an expired token — if the listener isn't ready
     // by then, the event is lost and the client loops forever.
@@ -55,6 +61,7 @@ async function Startup() {
         socket.on(
             "connect_error",
             async (err: Error & { data?: { type?: string; reason?: string } }) => {
+                reconnecting = false;
                 if (err.data?.type !== "auth_failed" && err.message !== "auth_failed") return;
 
                 const reason = err.data?.reason;
@@ -89,17 +96,6 @@ async function Startup() {
                 }
             },
         );
-
-        // A tab backgrounded during sleep/long idle can end up with the socket
-        // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
-        // handling) with no future retry scheduled. Foregrounding the tab is the
-        // natural moment to try again — any resulting auth failure is handled by
-        // the connect_error listener above, same as any other reconnect.
-        document.addEventListener("visibilitychange", () => {
-            if (document.visibilityState === "visible" && !isConnected.value) {
-                socket.reconnect();
-            }
-        });
     }
 
     await auth.setupAuth(app);
@@ -110,6 +106,26 @@ async function Startup() {
     // default-groups map and deleteRevoked would purge local data. The pending
     // re-login/refresh connects the socket instead.
     if (!(readPersistedProvider() && !auth.activeProviderId.value)) socket.connect();
+
+    if (!isAuthBypassed) {
+        // A tab backgrounded during sleep/long idle can end up with the socket
+        // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
+        // handling) with no future retry scheduled. Foregrounding the tab is the
+        // natural moment to try again — any resulting auth failure is handled by
+        // the connect_error listener above, same as any other reconnect. Registered
+        // after setupAuth() so it can't race the initial (possibly slow, Auth0-backed)
+        // connection attempt; `reconnecting` stops repeat visibility flips from
+        // restarting an attempt that's already in flight.
+        watch(isConnected, (connected) => {
+            if (connected) reconnecting = false;
+        });
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "visible" && !isConnected.value && !reconnecting) {
+                reconnecting = true;
+                socket.reconnect();
+            }
+        });
+    }
 
     // Show notification on server error (5xx), debounced to avoid flooding.
     // CMS has no i18n layer; copy is owned here rather than in the shared lib.

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -9,6 +9,7 @@ import {
     changeReqWarnings,
     getSocket,
     init,
+    isConnected,
     serverError,
 } from "luminary-shared";
 import { apiUrl, initLanguage } from "@/globalConfig";
@@ -88,6 +89,17 @@ async function Startup() {
                 }
             },
         );
+
+        // A tab backgrounded during sleep/long idle can end up with the socket
+        // disconnected and auto-reconnect turned off (see socketio.ts's auth_failed
+        // handling) with no future retry scheduled. Foregrounding the tab is the
+        // natural moment to try again — any resulting auth failure is handled by
+        // the connect_error listener above, same as any other reconnect.
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "visible" && !isConnected.value) {
+                socket.reconnect();
+            }
+        });
     }
 
     await auth.setupAuth(app);

--- a/shared/src/socket/socketio.spec.ts
+++ b/shared/src/socket/socketio.spec.ts
@@ -18,6 +18,14 @@ vi.spyOn(RestApi, "getRest").mockReturnValue({
 describe("socketio", () => {
     const socketServer = new Server(12345);
 
+    function foregroundDocument() {
+        Object.defineProperty(document, "visibilityState", {
+            configurable: true,
+            value: "visible",
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+    }
+
     beforeAll(async () => {
         initConfig({
             cms: true,
@@ -87,6 +95,62 @@ describe("socketio", () => {
 
         await waitForExpect(() => {
             expect(serverConnectCalled).toEqual(true);
+            expect(isConnected.value).toEqual(true);
+        });
+    });
+
+    it("reconnects when a disconnected tab becomes visible", async () => {
+        let serverConnectCalled = false;
+        socketServer.on("connection", (socket) => {
+            serverConnectCalled = true;
+            socket.emit("clientConfig", {});
+        });
+
+        getSocket().disconnect();
+        foregroundDocument();
+
+        await waitForExpect(() => {
+            expect(serverConnectCalled).toEqual(true);
+            expect(isConnected.value).toEqual(true);
+        });
+    });
+
+    it("does not start duplicate foreground reconnects while a handshake is pending", async () => {
+        let connectionCount = 0;
+        socketServer.on("connection", () => {
+            connectionCount += 1;
+        });
+
+        getSocket().disconnect();
+        foregroundDocument();
+        foregroundDocument();
+
+        await waitForExpect(() => {
+            expect(connectionCount).toEqual(1);
+        });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(connectionCount).toEqual(1);
+    });
+
+    it("allows a later foreground retry after the pending connection disconnects", async () => {
+        let connectionCount = 0;
+        socketServer.on("connection", (socket) => {
+            connectionCount += 1;
+            if (connectionCount === 1) socket.disconnect(true);
+            else socket.emit("clientConfig", {});
+        });
+
+        getSocket().disconnect();
+        foregroundDocument();
+
+        await waitForExpect(() => {
+            expect(connectionCount).toEqual(1);
+            expect(isConnected.value).toEqual(false);
+        });
+
+        foregroundDocument();
+        await waitForExpect(() => {
+            expect(connectionCount).toEqual(2);
             expect(isConnected.value).toEqual(true);
         });
     });

--- a/shared/src/socket/socketio.ts
+++ b/shared/src/socket/socketio.ts
@@ -30,6 +30,8 @@ export const maxMediaUploadFileSize = useLocalStorage("maxMediaUploadFileSize", 
 
 class SocketIO {
     private socket: Socket;
+    private foregroundReconnectInFlight = false;
+    private foregroundReconnectTimeout: ReturnType<typeof setTimeout> | undefined;
 
     /**
      * Create a new SocketIO instance
@@ -60,10 +62,12 @@ class SocketIO {
 
         this.socket.on("disconnect", () => {
             isConnected.value = false;
+            this.stopForegroundReconnect();
         });
 
         this.socket.on("connect_error", (err: Error & { data?: { type?: string } }) => {
             isConnected.value = false;
+            this.stopForegroundReconnect();
             // When the server rejects credentials in its middleware, it passes
             // next(new Error("auth_failed")). Stop auto-reconnection so the
             // client doesn't loop with the same stale token.
@@ -81,8 +85,42 @@ class SocketIO {
             if (c.maxMediaUploadFileSize) maxMediaUploadFileSize.value = c.maxMediaUploadFileSize;
             if (c.accessMap) accessMap.value = c.accessMap;
             isConnected.value = true; // Only set isConnected after configuration has been received from the API
+            this.stopForegroundReconnect();
         });
+
+        // A tab foregrounded after sleep or a long idle can have a disconnected
+        // socket with auto-reconnection disabled following an auth failure. Retry
+        // once when it becomes visible; consumer auth-error handlers remain
+        // responsible for refreshing credentials if the retry is rejected.
+        if (typeof document !== "undefined") {
+            document.addEventListener("visibilitychange", this.reconnectOnVisibilityChange);
+        }
     }
+
+    private stopForegroundReconnect() {
+        this.foregroundReconnectInFlight = false;
+        clearTimeout(this.foregroundReconnectTimeout);
+        this.foregroundReconnectTimeout = undefined;
+    }
+
+    private reconnectOnVisibilityChange = () => {
+        if (
+            document.visibilityState !== "visible" ||
+            isConnected.value ||
+            this.foregroundReconnectInFlight
+        ) {
+            return;
+        }
+
+        // Set this after reconnect(): its intentional disconnect synchronously
+        // emits `disconnect`, which clears a prior attempt's guard.
+        this.reconnect();
+        this.foregroundReconnectInFlight = true;
+        this.foregroundReconnectTimeout = setTimeout(() => {
+            this.foregroundReconnectInFlight = false;
+            this.foregroundReconnectTimeout = undefined;
+        }, 20_000);
+    };
 
     /**
      * Adds the listener function as an event listener for ev.

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(
             environment: "jsdom",
             exclude: [...configDefaults.exclude, "e2e/*"],
             root: fileURLToPath(new URL("./", import.meta.url)),
-            setupFiles: ["vitest.setup.ts"],
+            setupFiles: ["vitest.localstorage.ts", "vitest.setup.ts"],
             coverage: {
                 provider: "v8",
                 exclude: [

--- a/shared/vitest.localstorage.ts
+++ b/shared/vitest.localstorage.ts
@@ -1,0 +1,17 @@
+// Node 26's jsdom doesn't expose localStorage, while the database reads it
+// during module initialization. Provide the minimal Storage implementation
+// needed by shared unit tests before their setup runs.
+if (typeof globalThis.localStorage === "undefined") {
+    const store = new Map<string, string>();
+    const storage: Storage = {
+        get length() {
+            return store.size;
+        },
+        clear: () => store.clear(),
+        getItem: (key) => (store.has(key) ? store.get(key)! : null),
+        key: (index) => [...store.keys()][index] ?? null,
+        removeItem: (key) => void store.delete(key),
+        setItem: (key, value) => void store.set(key, String(value)),
+    };
+    globalThis.localStorage = storage;
+}


### PR DESCRIPTION
A tab idle/backgrounded long enough (laptop sleep, OS-throttled timers) can leave the socket disconnected with auto-reconnect turned off (socketio.ts disables it after an auth_failed) and no future retry scheduled, since socket.io's own reconnection backoff is JS-timer-driven and gets throttled while hidden. Foregrounding the tab now triggers an immediate reconnect attempt instead of waiting on a possibly-stalled timer, reusing the existing connect_error -> refresh -> re-login recovery path unchanged.