### PR TITLE
fix: surface real server error details to client console

### DIFF
--- a/api/src/exceptions/allExceptions.filter.spec.ts
+++ b/api/src/exceptions/allExceptions.filter.spec.ts
@@ -38,17 +38,17 @@ describe("AllExceptionsFilter", () => {
         jest.restoreAllMocks();
     });
 
-    it("returns a user-friendly message for unknown exceptions", () => {
+    it("returns the real message for unknown exceptions", () => {
         filter.catch(new Error("db connection failed"), mockHost);
 
         expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
         expect(mockResponse.send).toHaveBeenCalledWith({
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: "Something went wrong on the server. Please try again in a minute.",
+            message: "db connection failed",
         });
     });
 
-    it("returns a user-friendly message for 5xx HttpExceptions", () => {
+    it("returns the real message for 5xx HttpExceptions", () => {
         const exception = new HttpException("Service Unavailable", HttpStatus.SERVICE_UNAVAILABLE);
 
         filter.catch(exception, mockHost);
@@ -56,7 +56,7 @@ describe("AllExceptionsFilter", () => {
         expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.SERVICE_UNAVAILABLE);
         expect(mockResponse.send).toHaveBeenCalledWith({
             statusCode: HttpStatus.SERVICE_UNAVAILABLE,
-            message: "Something went wrong on the server. Please try again in a minute.",
+            message: "Service Unavailable",
         });
     });
 
@@ -112,7 +112,7 @@ describe("AllExceptionsFilter", () => {
         expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
         expect(mockResponse.send).toHaveBeenCalledWith({
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: "Something went wrong on the server. Please try again in a minute.",
+            message: "some string error",
         });
     });
 

--- a/api/src/exceptions/allExceptions.filter.spec.ts
+++ b/api/src/exceptions/allExceptions.filter.spec.ts
@@ -38,13 +38,13 @@ describe("AllExceptionsFilter", () => {
         jest.restoreAllMocks();
     });
 
-    it("returns the real message for unknown exceptions", () => {
+    it("returns a generic message for unknown exceptions, never the raw error", () => {
         filter.catch(new Error("db connection failed"), mockHost);
 
         expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
         expect(mockResponse.send).toHaveBeenCalledWith({
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: "db connection failed",
+            message: "Internal server error",
         });
     });
 
@@ -106,13 +106,13 @@ describe("AllExceptionsFilter", () => {
         expect(loggerErrorSpy).not.toHaveBeenCalled();
     });
 
-    it("handles non-Error, non-HttpException values as 500", () => {
+    it("handles non-Error, non-HttpException values as 500 with a generic message", () => {
         filter.catch("some string error", mockHost);
 
         expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
         expect(mockResponse.send).toHaveBeenCalledWith({
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: "some string error",
+            message: "Internal server error",
         });
     });
 

--- a/api/src/exceptions/allExceptions.filter.ts
+++ b/api/src/exceptions/allExceptions.filter.ts
@@ -12,11 +12,14 @@ import { FastifyReply, FastifyRequest } from "fastify";
  * Global exception filter that:
  *  1. Silently swallows `ERR_STREAM_PREMATURE_CLOSE` — fires when the client
  *     aborts mid-response and is noise, not a real failure.
- *  2. Passes 4xx `HttpException`s through with their original message.
- *  3. For 5xx / unknown errors, logs the real cause server-side and also
- *     returns it as `message` — clients log/report the real error, and
- *     display their own friendly copy. Never sends `.stack` (paths/queries
- *     may appear there); `.message` is assumed safe to expose.
+ *  2. Passes `HttpException`s through with their original message, regardless
+ *     of status — these are deliberately authored by our own code, so the
+ *     text is safe to expose.
+ *  3. For anything else (unexpected errors, ours or a dependency's), logs the
+ *     real cause server-side (never `.stack` to the client — paths/queries
+ *     may appear there) but returns a generic message. An arbitrary Error's
+ *     `.message` was never vetted for client exposure and may contain
+ *     internals (e.g. a DB connection string).
  */
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -32,13 +35,17 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
         if (response.sent || response.raw?.writableEnded) return;
 
-        if (exception instanceof HttpException && exception.getStatus() < 500) {
+        if (exception instanceof HttpException) {
             const status = exception.getStatus();
             const exceptionResponse = exception.getResponse();
             const message =
                 typeof exceptionResponse === "string"
                     ? exceptionResponse
                     : (exceptionResponse as { message?: string }).message ?? exception.message;
+
+            if (status >= 500) {
+                this.logger.error(`[${request.method} ${request.url}]`, exception.stack ?? message);
+            }
 
             response
                 .status(status)
@@ -47,21 +54,14 @@ export class AllExceptionsFilter implements ExceptionFilter {
             return;
         }
 
-        const status =
-            exception instanceof HttpException
-                ? exception.getStatus()
-                : HttpStatus.INTERNAL_SERVER_ERROR;
-
-        const actualMessage = exception instanceof Error ? exception.message : String(exception);
-
         this.logger.error(
             `[${request.method} ${request.url}]`,
-            exception instanceof Error ? exception.stack ?? actualMessage : exception,
+            exception instanceof Error ? exception.stack ?? exception.message : exception,
         );
 
         response
-            .status(status)
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .header("Content-Type", "application/json")
-            .send({ statusCode: status, message: actualMessage });
+            .send({ statusCode: HttpStatus.INTERNAL_SERVER_ERROR, message: "Internal server error" });
     }
 }

--- a/api/src/exceptions/allExceptions.filter.ts
+++ b/api/src/exceptions/allExceptions.filter.ts
@@ -13,8 +13,10 @@ import { FastifyReply, FastifyRequest } from "fastify";
  *  1. Silently swallows `ERR_STREAM_PREMATURE_CLOSE` — fires when the client
  *     aborts mid-response and is noise, not a real failure.
  *  2. Passes 4xx `HttpException`s through with their original message.
- *  3. For 5xx / unknown errors, logs the real cause server-side and returns a
- *     generic user-friendly message so internals don't leak to clients.
+ *  3. For 5xx / unknown errors, logs the real cause server-side and also
+ *     returns it as `message` — clients log/report the real error, and
+ *     display their own friendly copy. Never sends `.stack` (paths/queries
+ *     may appear there); `.message` is assumed safe to expose.
  */
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -50,17 +52,16 @@ export class AllExceptionsFilter implements ExceptionFilter {
                 ? exception.getStatus()
                 : HttpStatus.INTERNAL_SERVER_ERROR;
 
+        const actualMessage = exception instanceof Error ? exception.message : String(exception);
+
         this.logger.error(
             `[${request.method} ${request.url}]`,
-            exception instanceof Error ? exception.stack ?? exception.message : exception,
+            exception instanceof Error ? exception.stack ?? actualMessage : exception,
         );
 
         response
             .status(status)
             .header("Content-Type", "application/json")
-            .send({
-                statusCode: status,
-                message: "Something went wrong on the server. Please try again in a minute.",
-            });
+            .send({ statusCode: status, message: actualMessage });
     }
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -131,6 +131,7 @@ async function Startup() {
     watch(serverError, (error) => {
         if (error) {
             serverError.value = null;
+            console.error(`Server error: ${error.status}${error.message ? ` ${error.message}` : ""}`);
             if (serverErrorTimeout) return;
             Sentry?.captureMessage(
                 `Server error: ${error.status}${error.message ? ` ${error.message}` : ""}`,

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -103,6 +103,7 @@ async function Startup() {
     watch(serverError, (error) => {
         if (error) {
             serverError.value = null;
+            console.error(`Server error: ${error.status}${error.message ? ` ${error.message}` : ""}`);
             if (serverErrorTimeout) return;
             Sentry.captureMessage(
                 `Server error: ${error.status}${error.message ? ` ${error.message}` : ""}`,


### PR DESCRIPTION
The API's exception filter stripped 5xx errors down to a generic message before the client ever saw them, so the app/cms console.error calls had nothing useful to log. Send the real exception.message (never .stack) to clients in all environments; the friendly toast copy is now purely a client-side display choice, unrelated to what the server sends.