### PR TITLE
test(shared): assert DeleteCmd migration strips languages in initSync (#1763)

### DIFF
--- a/shared/src/api/sync/sync.spec.ts
+++ b/shared/src/api/sync/sync.spec.ts
@@ -236,6 +236,11 @@ describe("sync module", () => {
             expect(byChunkType["content:post"].publishDateMax).toBe(OPEN_MAX);
             expect(byChunkType["deleteCmd:post"].publishDateMin).toBe(OPEN_MIN);
             expect(byChunkType["deleteCmd:post"].publishDateMax).toBe(OPEN_MAX);
+            // The DeleteCmd migration also strips `languages` off legacy scoped entries so they
+            // converge onto the language-UNSCOPED identity (deletes of any downloaded doc must
+            // propagate regardless of synced languages). Content entries keep their `languages`.
+            expect(byChunkType["deleteCmd:post"].languages).toBeUndefined();
+            expect(byChunkType["content:post"].languages).toEqual(["en"]);
             // Non-Content non-DeleteCmd entry stays undefined — publishDate is dead weight there.
             expect(byChunkType["language"].publishDateMin).toBeUndefined();
             expect(byChunkType["language"].publishDateMax).toBeUndefined();


### PR DESCRIPTION
## What & why

The `initSync` legacy-migration test in `shared/src/api/sync/sync.spec.ts` — _"resolves legacy publishDate fields only on Content and DeleteCmd entries"_ — set up a legacy `deleteCmd:post` entry **with** `languages: ["en"]` and exercised the DeleteCmd migration path, but only asserted on `publishDateMin/Max`. It never verified the DeleteCmd-specific behavior in [`sync.ts:136`](https://github.com/bccsa/luminary/blob/main/shared/src/api/sync/sync.ts#L136):

```ts
if (type === DocType.DeleteCmd && entry.languages !== undefined) entry.languages = undefined;
```

Migration strips `languages` off legacy scoped DeleteCmd entries so they converge onto the language-**unscoped** identity (deletes of any downloaded doc must propagate regardless of synced languages). That was a silent test gap.

## Change

Test-only. Adds two assertions to the existing test:
- `deleteCmd:post.languages` is `undefined` after migration (the missing assertion).
- `content:post.languages` is still `["en"]` — a companion check confirming the strip is DeleteCmd-specific and doesn't touch Content columns.

No production code changed.

## Verification

`npx vitest run src/api/sync/sync.spec.ts` → **60 passed**.

Closes #1763
