### PR TITLE
fix(api): don't count $ne/$nin-excluded languages toward the language cap (#1764)

### DIFF
--- a/api/src/validation/query/validateQuery.spec.ts
+++ b/api/src/validation/query/validateQuery.spec.ts
@@ -295,6 +295,26 @@ describe("validateQuery", () => {
             expect(res.valid).toBe(false);
             expect(res.error).toMatch(/too many languages/);
         });
+
+        it("does not count languages under a $not-wrapped $in toward the cap", () => {
+            // {language: {$not: {$in: [...]}}} excludes every listed id — same as a bare $nin.
+            const q: any = {
+                selector: { type: "content", language: { $not: { $in: langs(over()) } } },
+            };
+            expect(validateQuery(q).valid).toBe(true);
+        });
+
+        it("does not count a $not-wrapped $eq language toward the cap", () => {
+            const q: any = {
+                selector: {
+                    $and: [
+                        { language: { $in: langs(DEFAULT_MAX_LANGUAGES) } },
+                        { language: { $not: { $eq: "lang-excluded" } } },
+                    ],
+                },
+            };
+            expect(validateQuery(q).valid).toBe(true);
+        });
     });
 
     describe("use_index (registry membership)", () => {

--- a/api/src/validation/query/validateQuery.spec.ts
+++ b/api/src/validation/query/validateQuery.spec.ts
@@ -258,6 +258,43 @@ describe("validateQuery", () => {
             expect(res.valid).toBe(false);
             expect(res.error).toMatch(/too many languages \(max 2\)/);
         });
+
+        it("does not count $nin-excluded languages toward the cap", () => {
+            // Excluding more than the cap of languages narrows the result — it must not be rejected.
+            const q: any = {
+                selector: { type: "content", language: { $nin: langs(over()) } },
+            };
+            expect(validateQuery(q).valid).toBe(true);
+        });
+
+        it("does not count a $ne-excluded language toward the cap", () => {
+            // `language` included ids are at the cap; the extra $ne exclusion must not push it over.
+            const q: any = {
+                selector: {
+                    $and: [
+                        { language: { $in: langs(DEFAULT_MAX_LANGUAGES) } },
+                        { language: { $ne: "lang-excluded" } },
+                    ],
+                },
+            };
+            expect(validateQuery(q).valid).toBe(true);
+        });
+
+        it("still counts included languages when exclusions are also present", () => {
+            // Over-cap INCLUDED ids ($in) are rejected even though a sibling $nin exclusion exists —
+            // the exclusion is ignored, the inclusion still counts.
+            const q: any = {
+                selector: {
+                    $and: [
+                        { language: { $in: langs(over()) } },
+                        { language: { $nin: ["x", "y"] } },
+                    ],
+                },
+            };
+            const res = validateQuery(q);
+            expect(res.valid).toBe(false);
+            expect(res.error).toMatch(/too many languages/);
+        });
     });
 
     describe("use_index (registry membership)", () => {

--- a/api/src/validation/query/validateQuery.ts
+++ b/api/src/validation/query/validateQuery.ts
@@ -45,6 +45,14 @@ const LOGICAL_OPERATORS = new Set(["$and", "$or", "$nor", "$not"]);
 const ARRAY_OPERATORS = new Set(["$in", "$nin", "$all"]);
 
 /**
+ * Exclusion operators. Values under these reference languages the query wants to EXCLUDE, not
+ * include, so they must not count toward the per-request language cap: `{language: {$ne: "fr"}}`
+ * or `{language: {$nin: ["fr", "de"]}}` narrows the result, it doesn't widen the requested set.
+ * Descending into one clears the owning field so its leaves aren't collected as referenced ids.
+ */
+const EXCLUSION_OPERATORS = new Set(["$ne", "$nin"]);
+
+/**
  * Array fields on which `$elemMatch` is permitted:
  *  - `memberOf` — group permission filter (injected server-side).
  *  - `availableTranslations` — language-priority filtering in hybrid queries.
@@ -178,8 +186,9 @@ function fail(error: string): ValidationResult {
  * document field name (not a logical/comparison operator), so `$elemMatch` can be
  * allowed only when it sits directly under an allowed array field. Also collects the
  * distinct language ids referenced by `language` field constraints (equality, `$eq`, or
- * `$in` members) for the language cap. Returns the first error (or null when clean) plus
- * the collected language set.
+ * `$in` members) for the language cap — but NOT ids under exclusion operators (`$ne`/`$nin`),
+ * which narrow rather than widen the requested set. Returns the first error (or null when
+ * clean) plus the collected language set.
  */
 function walkSelector(selector: any): { error: string | null; languages: Set<string> } {
     let clauseCount = 0;
@@ -228,9 +237,14 @@ function walkSelector(selector: any): { error: string | null; languages: Set<str
             }
 
             // Logical operators ($and/$or/$nor/$not) and comparison operators ($in, $gte, …)
-            // don't introduce a new owning field; a plain field key does.
-            const nextOwningField =
-                LOGICAL_OPERATORS.has(key) || key.startsWith("$") ? owningField : key;
+            // don't introduce a new owning field; a plain field key does. Exclusion operators
+            // ($ne/$nin) clear the owning field so their (excluded) language ids aren't collected
+            // toward the cap — see EXCLUSION_OPERATORS.
+            const nextOwningField = EXCLUSION_OPERATORS.has(key)
+                ? undefined
+                : LOGICAL_OPERATORS.has(key) || key.startsWith("$")
+                  ? owningField
+                  : key;
 
             const err = walk(node[key], nextOwningField, depth + 1);
             if (err) return err;

--- a/api/src/validation/query/validateQuery.ts
+++ b/api/src/validation/query/validateQuery.ts
@@ -48,9 +48,13 @@ const ARRAY_OPERATORS = new Set(["$in", "$nin", "$all"]);
  * Exclusion operators. Values under these reference languages the query wants to EXCLUDE, not
  * include, so they must not count toward the per-request language cap: `{language: {$ne: "fr"}}`
  * or `{language: {$nin: ["fr", "de"]}}` narrows the result, it doesn't widen the requested set.
+ * `$not` is included too — `{language: {$not: {$in: [...]}}}` / `{$not: {$eq: "fr"}}` are likewise
+ * exclusions regardless of the operator nested inside. (A double-negated `$not: {$ne: "fr"}}`,
+ * meaning "must equal fr", would be miscategorized as an exclusion by this blanket rule — an
+ * unrealistic shape for a scalar `language` field, deliberately not special-cased here.)
  * Descending into one clears the owning field so its leaves aren't collected as referenced ids.
  */
-const EXCLUSION_OPERATORS = new Set(["$ne", "$nin"]);
+const EXCLUSION_OPERATORS = new Set(["$ne", "$nin", "$not"]);
 
 /**
  * Array fields on which `$elemMatch` is permitted:
@@ -186,9 +190,9 @@ function fail(error: string): ValidationResult {
  * document field name (not a logical/comparison operator), so `$elemMatch` can be
  * allowed only when it sits directly under an allowed array field. Also collects the
  * distinct language ids referenced by `language` field constraints (equality, `$eq`, or
- * `$in` members) for the language cap — but NOT ids under exclusion operators (`$ne`/`$nin`),
- * which narrow rather than widen the requested set. Returns the first error (or null when
- * clean) plus the collected language set.
+ * `$in` members) for the language cap — but NOT ids under exclusion operators (`$ne`/`$nin`/
+ * `$not`), which narrow rather than widen the requested set. Returns the first error (or null
+ * when clean) plus the collected language set.
  */
 function walkSelector(selector: any): { error: string | null; languages: Set<string> } {
     let clauseCount = 0;
@@ -238,8 +242,9 @@ function walkSelector(selector: any): { error: string | null; languages: Set<str
 
             // Logical operators ($and/$or/$nor/$not) and comparison operators ($in, $gte, …)
             // don't introduce a new owning field; a plain field key does. Exclusion operators
-            // ($ne/$nin) clear the owning field so their (excluded) language ids aren't collected
-            // toward the cap — see EXCLUSION_OPERATORS.
+            // ($ne/$nin/$not) clear the owning field instead, so their (excluded) language ids
+            // aren't collected toward the cap — see EXCLUSION_OPERATORS. Checked before the
+            // logical-operator branch so $not (a member of both sets) takes the exclusion path.
             const nextOwningField = EXCLUSION_OPERATORS.has(key)
                 ? undefined
                 : LOGICAL_OPERATORS.has(key) || key.startsWith("$")


### PR DESCRIPTION
## What & why

The `/query` universal validator enforces a per-request **language cap** for non-CMS queries by collecting the distinct language ids a selector references. `walkSelector` collected every string leaf whose nearest owning field is `language`.

The bug: exclusion operators start with `$`, so [`walkSelector`](https://github.com/bccsa/luminary/blob/main/api/src/validation/query/validateQuery.ts#L232-L233) preserved `owningField = "language"` when descending into them. That meant:

```js
{ language: { $ne: "fr" } }            // "fr" counted toward the cap
{ language: { $nin: ["fr", "de", …] } } // every excluded id counted toward the cap
```

Exclusion operators *narrow* the result — they reference languages the query wants to **exclude**, not include — so they should never count toward the cap. This was a latent over-count that could reject a perfectly legitimate narrowing query.

## Change

- New `EXCLUSION_OPERATORS` set (`$ne`, `$nin`). When `walkSelector` descends into one, it clears the owning field so the excluded ids aren't collected.
- Included ids (equality / `$eq` / `$in`) still count exactly as before.
- Tests: `$nin` over-cap exclusion accepted, `$ne` exclusion on top of an at-cap `$in` accepted, and a mixed case proving over-cap **inclusions** are still rejected while a sibling exclusion is ignored.

## Verification

`npx jest src/validation/query/validateQuery.spec.ts` → **46 passed** (11 in the language-cap block, incl. 3 new).

Closes #1764