### PR TITLE
fix(api): derive language cap from named constants instead of a magic number (#1765)

### DIFF
--- a/api/src/configuration.ts
+++ b/api/src/configuration.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MAX_LANGUAGES } from "./validation/query/validateQuery";
+
 export type AuthConfig = {
     jwtSecret: string;
     jwtMappings: string;
@@ -41,8 +43,8 @@ export type QueryConfig = {
     /**
      * Maximum distinct languages a NON-CMS query may reference (via `language` field constraints).
      * Requests above this are rejected with 400. Guards query cost; CMS queries are exempt (they
-     * sync all languages). Keep in step with the client's preferred-language cap (cap + 1 for the
-     * auto-appended default). Environment variable: QUERY_MAX_LANGUAGES (default 4).
+     * sync all languages). Defaults to DEFAULT_MAX_LANGUAGES (derived: preferred cap + auto-appended
+     * default + headroom). Environment variable: QUERY_MAX_LANGUAGES.
      */
     maxLanguages: number;
     /**
@@ -129,7 +131,7 @@ export default () =>
         } as SyncConfig,
         query: {
             maxLimit: parseInt(process.env.QUERY_MAX_LIMIT, 10) || 500,
-            maxLanguages: parseInt(process.env.QUERY_MAX_LANGUAGES, 10) || 4,
+            maxLanguages: parseInt(process.env.QUERY_MAX_LANGUAGES, 10) || DEFAULT_MAX_LANGUAGES,
             expensiveDocsExamined: parseInt(process.env.QUERY_EXPENSIVE_DOCS_EXAMINED, 10) || 1000,
             expensiveExaminedRatio: parseInt(process.env.QUERY_EXPENSIVE_EXAMINED_RATIO, 10) || 10,
             rateLimit: {

--- a/api/src/configuration.ts
+++ b/api/src/configuration.ts
@@ -44,7 +44,7 @@ export type QueryConfig = {
      * Maximum distinct languages a NON-CMS query may reference (via `language` field constraints).
      * Requests above this are rejected with 400. Guards query cost; CMS queries are exempt (they
      * sync all languages). Defaults to DEFAULT_MAX_LANGUAGES (derived: preferred cap + auto-appended
-     * default + headroom). Environment variable: QUERY_MAX_LANGUAGES.
+     * default). Environment variable: QUERY_MAX_LANGUAGES.
      */
     maxLanguages: number;
     /**

--- a/api/src/endpoints/query.controller.ts
+++ b/api/src/endpoints/query.controller.ts
@@ -13,7 +13,7 @@ import {
 } from "@nestjs/common";
 import { QueryService } from "./query.service";
 import { MongoQueryDto } from "../dto/MongoQueryDto";
-import { validateQuery } from "../validation/query/validateQuery";
+import { validateQuery, DEFAULT_MAX_LANGUAGES } from "../validation/query/validateQuery";
 import { ConfigService } from "@nestjs/config";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { Logger } from "winston";
@@ -62,7 +62,8 @@ export class QueryController {
             this.configService.get<boolean>("validation.bypassTemplateValidation") || false;
 
         const maxLimit = this.configService.get<number>("query.maxLimit") ?? 500;
-        const maxLanguages = this.configService.get<number>("query.maxLanguages") ?? 4;
+        const maxLanguages =
+            this.configService.get<number>("query.maxLanguages") ?? DEFAULT_MAX_LANGUAGES;
 
         let validationResult = { valid: true, error: "" };
         if (!bypassValidation) validationResult = validateQuery(body, { maxLimit, maxLanguages });

--- a/api/src/validation/query/validateQuery.spec.ts
+++ b/api/src/validation/query/validateQuery.spec.ts
@@ -195,23 +195,19 @@ describe("validateQuery", () => {
             expect(res.error).toMatch(/too many languages/);
         });
 
-        it("accepts a query at the cap (derived: preferred + default + headroom)", () => {
+        it("accepts a query at the cap (derived: preferred + auto-appended default)", () => {
             const q: any = {
                 selector: { type: "content", language: { $in: langs(DEFAULT_MAX_LANGUAGES) } },
             };
             expect(validateQuery(q).valid).toBe(true);
         });
 
-        it("keeps headroom above the client maximum (preferred + auto-appended default) [#1765]", () => {
-            // The cap must not sit exactly on the largest legitimate client query, or any future
-            // language dimension trips a spurious 400. There must be at least one spare slot.
+        it("derives the cap exactly from the client maximum (preferred + auto-appended default) [#1765]", () => {
+            // No headroom: the client-side selection cap is a fixed UX invariant
+            // (normalizePreferredLanguages hard-slices to MAX_PREFERRED_LANGUAGES), independent of
+            // how many languages exist in the system — so the derived cap can sit exactly on it.
             const clientMax = MAX_PREFERRED_LANGUAGES + AUTO_APPENDED_DEFAULT_LANGUAGES;
-            expect(DEFAULT_MAX_LANGUAGES).toBeGreaterThan(clientMax);
-            // A query at the client maximum is accepted comfortably (not on the boundary).
-            const q: any = {
-                selector: { type: "content", language: { $in: langs(clientMax) } },
-            };
-            expect(validateQuery(q).valid).toBe(true);
+            expect(DEFAULT_MAX_LANGUAGES).toBe(clientMax);
         });
 
         it("exempts CMS queries (cms: true) — they sync all languages", () => {

--- a/api/src/validation/query/validateQuery.spec.ts
+++ b/api/src/validation/query/validateQuery.spec.ts
@@ -4,6 +4,8 @@ import {
     MAX_SELECTOR_CLAUSES,
     DEFAULT_MAX_LIMIT,
     DEFAULT_MAX_LANGUAGES,
+    MAX_PREFERRED_LANGUAGES,
+    AUTO_APPENDED_DEFAULT_LANGUAGES,
 } from "./validateQuery";
 
 describe("validateQuery", () => {
@@ -193,9 +195,21 @@ describe("validateQuery", () => {
             expect(res.error).toMatch(/too many languages/);
         });
 
-        it("accepts a query at the cap (default = preferred cap + auto-appended default)", () => {
+        it("accepts a query at the cap (derived: preferred + default + headroom)", () => {
             const q: any = {
                 selector: { type: "content", language: { $in: langs(DEFAULT_MAX_LANGUAGES) } },
+            };
+            expect(validateQuery(q).valid).toBe(true);
+        });
+
+        it("keeps headroom above the client maximum (preferred + auto-appended default) [#1765]", () => {
+            // The cap must not sit exactly on the largest legitimate client query, or any future
+            // language dimension trips a spurious 400. There must be at least one spare slot.
+            const clientMax = MAX_PREFERRED_LANGUAGES + AUTO_APPENDED_DEFAULT_LANGUAGES;
+            expect(DEFAULT_MAX_LANGUAGES).toBeGreaterThan(clientMax);
+            // A query at the client maximum is accepted comfortably (not on the boundary).
+            const q: any = {
+                selector: { type: "content", language: { $in: langs(clientMax) } },
             };
             expect(validateQuery(q).valid).toBe(true);
         });
@@ -216,7 +230,7 @@ describe("validateQuery", () => {
         });
 
         it("collects languages across the mangoIsPublished-style equality/negation shape", () => {
-            // 5 distinct languages expressed as `{language: x}` equalities → over the default cap.
+            // Over-cap distinct languages expressed as `{language: x}` equalities → rejected.
             const q: any = {
                 selector: {
                     $or: langs(over()).map((l) => ({

--- a/api/src/validation/query/validateQuery.ts
+++ b/api/src/validation/query/validateQuery.ts
@@ -33,22 +33,15 @@ export const MAX_PREFERRED_LANGUAGES = 3;
 export const AUTO_APPENDED_DEFAULT_LANGUAGES = 1;
 
 /**
- * Extra languages allowed above the exact client maximum. Without it the cap would sit exactly on
- * the largest legitimate query (zero headroom, GitHub #1765): any future language dimension — or a
- * query that legitimately references one more id — would trip a spurious 400. One slot of headroom
- * removes that fragile boundary; CMS queries are exempt and the query-cost delta of one extra
- * language is negligible.
- */
-export const LANGUAGE_CAP_HEADROOM = 1;
-
-/**
  * Fallback language cap when the caller doesn't supply one. Derived so the pieces move together
- * instead of being restated as a magic number: preferred (3) + auto-appended default (1) +
- * headroom (1) = 5. A legitimate non-CMS content query references at most preferred + default
- * distinct languages; the headroom keeps the boundary off that exact maximum.
+ * instead of being restated as a magic number: preferred (3) + auto-appended default (1) = 4. A
+ * legitimate non-CMS content query never references more than this — the client-side selection
+ * cap is a fixed UX invariant (`normalizePreferredLanguages` hard-slices to
+ * `MAX_PREFERRED_LANGUAGES`), independent of how many languages exist in the system. Growing the
+ * language catalog doesn't grow a single query's language count; only bumping the client cap
+ * itself would, and that already requires updating `MAX_PREFERRED_LANGUAGES` here in lockstep.
  */
-export const DEFAULT_MAX_LANGUAGES =
-    MAX_PREFERRED_LANGUAGES + AUTO_APPENDED_DEFAULT_LANGUAGES + LANGUAGE_CAP_HEADROOM;
+export const DEFAULT_MAX_LANGUAGES = MAX_PREFERRED_LANGUAGES + AUTO_APPENDED_DEFAULT_LANGUAGES;
 
 /**
  * DoS guards on the selector shape. A pathological selector (deeply nested logical

--- a/api/src/validation/query/validateQuery.ts
+++ b/api/src/validation/query/validateQuery.ts
@@ -22,12 +22,33 @@ export type ValidateQueryOptions = {
 export const DEFAULT_MAX_LIMIT = 500;
 
 /**
- * Fallback language cap when the caller doesn't supply one. The app lets a user pick at most 3
- * preferred languages, with the default (English) auto-appended for display — so a legitimate
- * non-CMS content query references at most 4 distinct languages (sync keep ≤3; display ≤4). Keep
- * this in step with the client's preferred-language cap (cap + 1 for the auto-appended default).
+ * The app caps a user's *preferred* languages to this many (mirrors
+ * `MAX_PREFERRED_LANGUAGES` in `app/src/globalConfig.ts`). Kept as a named constant so the
+ * language cap below is derived from it rather than a magic `4` that can silently drift out of
+ * step with the client. If the client cap changes, change this one to match.
  */
-export const DEFAULT_MAX_LANGUAGES = 4;
+export const MAX_PREFERRED_LANGUAGES = 3;
+
+/** The client auto-appends the default (display) language on top of the preferred set. */
+export const AUTO_APPENDED_DEFAULT_LANGUAGES = 1;
+
+/**
+ * Extra languages allowed above the exact client maximum. Without it the cap would sit exactly on
+ * the largest legitimate query (zero headroom, GitHub #1765): any future language dimension — or a
+ * query that legitimately references one more id — would trip a spurious 400. One slot of headroom
+ * removes that fragile boundary; CMS queries are exempt and the query-cost delta of one extra
+ * language is negligible.
+ */
+export const LANGUAGE_CAP_HEADROOM = 1;
+
+/**
+ * Fallback language cap when the caller doesn't supply one. Derived so the pieces move together
+ * instead of being restated as a magic number: preferred (3) + auto-appended default (1) +
+ * headroom (1) = 5. A legitimate non-CMS content query references at most preferred + default
+ * distinct languages; the headroom keeps the boundary off that exact maximum.
+ */
+export const DEFAULT_MAX_LANGUAGES =
+    MAX_PREFERRED_LANGUAGES + AUTO_APPENDED_DEFAULT_LANGUAGES + LANGUAGE_CAP_HEADROOM;
 
 /**
  * DoS guards on the selector shape. A pathological selector (deeply nested logical


### PR DESCRIPTION
## What & why

The non-CMS `/query` language cap was the magic number **4**, restated in three places and kept "in step" with the client's 3-preferred-language cap only by a comment:

- `DEFAULT_MAX_LANGUAGES = 4` in `validateQuery.ts`
- `parseInt(process.env.QUERY_MAX_LANGUAGES, 10) || 4` in `configuration.ts`
- `?? 4` in `query.controller.ts`

Constants that must move together (GitHub #1765) had nothing enforcing it — the `3 (preferred) + 1 (default) = 4` relationship lived in prose, and the literal `4` was duplicated across three files. If the client's preferred-language cap ever changed, all three call sites had to be remembered and updated by hand.

An earlier version of this PR also added a `LANGUAGE_CAP_HEADROOM` slot (cap = 5) per #1765's "zero headroom" framing. Per review discussion (Ivan, then confirmed by tracing the code), the cap only counts values under `language` in the query selector — that's unrelated to how many Language docs sync (unbounded regardless), and the client-side preferred-language cap is a fixed UX invariant (`normalizePreferredLanguages` hard-slices to `MAX_PREFERRED_LANGUAGES`), not something that grows as the language catalog grows. There was no case where headroom was actually load-bearing, so it was dropped; the cap stays at exactly 4.

## Change

- `DEFAULT_MAX_LANGUAGES` is now **derived** from named constants that move together:
  `MAX_PREFERRED_LANGUAGES (3)` + `AUTO_APPENDED_DEFAULT_LANGUAGES (1)` = **4** (unchanged value).
  `MAX_PREFERRED_LANGUAGES` documents that it mirrors `app/src/globalConfig.ts`'s constant.
- The two duplicate fallbacks in `configuration.ts` and `query.controller.ts` now reference `DEFAULT_MAX_LANGUAGES` instead of a literal — single source of truth.
- Adds a test asserting the derived cap equals the client's actual maximum, and updates two stale comments.

No behavioural change for legitimate clients (the cap is still 4); this removes the "must move together" fragility from #1765 without adding unjustified slack.

## Verification

`npx jest src/validation/query/validateQuery.spec.ts` → **44 passed**. `npx tsc --noEmit` clean.

Closes #1765