### PR TITLE
refactor: remove two unreachable code paths (#1767)

### DIFF
--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -11,7 +11,6 @@ import {
     appLanguageIdsAsRef,
     appSyncedLanguageIdsAsRef,
     MAX_PREFERRED_LANGUAGES,
-    MAX_SYNCED_LANGUAGES,
     normalizePreferredLanguages,
     normalizeSyncedLanguages,
 } from "@/globalConfig";
@@ -149,10 +148,8 @@ const toggleSynced = (id: string) => {
     if (id === primaryId.value) return; // primary is always synced
     const i = draftSynced.value.indexOf(id);
     if (i === -1) {
-        // Ticking ON = mark for download → only happens once online. Cap the synced set (the primary
-        // is always counted; naturally ≤ the preferred cap, but guard explicitly for future-proofing).
-        const syncedCount = draftOrder.value.filter((oid) => isOfflineChecked(oid)).length;
-        if (syncedCount >= MAX_SYNCED_LANGUAGES) return;
+        // Ticking ON = mark for download → only happens once online. The synced set can't exceed the
+        // preferred cap: only preferred (draftOrder) languages are toggleable and each is added once.
         draftSynced.value.push(id);
         if (!isConnected.value) notifyAddDeferred();
     } else {

--- a/shared/src/api/sync/keepSelector.spec.ts
+++ b/shared/src/api/sync/keepSelector.spec.ts
@@ -2,10 +2,6 @@ import { describe, it, expect } from "vitest";
 import { contentLanguageKeepSelector } from "./keepSelector";
 
 describe("contentLanguageKeepSelector", () => {
-    it("returns match-all {} for an empty language set", () => {
-        expect(contentLanguageKeepSelector([])).toEqual({});
-    });
-
     it("builds the set-based keep for a single language", () => {
         const sel: any = contentLanguageKeepSelector(["en"]);
         // Branch 1: synced-language membership.

--- a/shared/src/api/sync/keepSelector.ts
+++ b/shared/src/api/sync/keepSelector.ts
@@ -10,12 +10,11 @@ import type { MangoSelector } from "../../util/MangoQuery/MangoTypes";
  * ordered priority pick is a display concern, not a keep concern — order is irrelevant here). Used
  * by both the sync backfill and the live keep gate so the two agree on what a client persists.
  *
- * Returns just the `$or` clause; the caller ANDs it into its own base selector. An empty `langs`
- * returns `{}` (match-all) — callers needing match-nothing semantics for the empty case must guard
- * it before calling.
+ * Returns just the `$or` clause; the caller ANDs it into its own base selector. `langs` must be
+ * non-empty: both callers (isSyncable, syncBatch) handle the empty case themselves (match-nothing)
+ * before calling, so this builds the keep unconditionally.
  */
 export function contentLanguageKeepSelector(langs: readonly Uuid[]): MangoSelector {
-    if (!langs.length) return {};
     return {
         $or: [
             { language: { $in: [...langs] } },


### PR DESCRIPTION
## What & why

Removes two provably-unreachable code paths flagged in #1767.

### 1. `contentLanguageKeepSelector` empty-langs branch
`shared/src/api/sync/keepSelector.ts` had `if (!langs.length) return {};`, but both (and only) callers already handle the empty case *before* calling:
- `isSyncable.ts` — `if (!langs.length) return base` returns early.
- `syncBatch.ts` — only calls inside `else if (langs.length)`; the empty case is the sibling `else` (match-nothing `{ $in: [] }`).

The function is internal (not exported from `shared/src/index.ts`), so tightening the contract is safe. Dropped the guard, documented the non-empty precondition, and removed the unit test that only exercised the dead branch.

### 2. `LanguageModal.toggleSynced` synced-cap guard
`app/src/components/navigation/LanguageModal.vue` guarded `if (syncedCount >= MAX_SYNCED_LANGUAGES) return;`. But `MAX_SYNCED_LANGUAGES === MAX_PREFERRED_LANGUAGES === 3`, only preferred languages (`draftOrder`, capped at 3) are toggleable, the toggled `id` is provably **un-checked** at that point (primary returns earlier; `i === -1` means not in `draftSynced`), so `syncedCount ≤ 2 < 3` always. The guard could never fire. Removed it plus the now-unused `MAX_SYNCED_LANGUAGES` import (the constant is still used by `normalizeSyncedLanguages` in `globalConfig.ts`).

## Verification

- `shared`: `keepSelector.spec.ts` → 4 pass; `vue-tsc --noEmit` clean.
- `app`: `LanguageModal.spec.ts` → 12 pass; `vue-tsc --build` clean.

Closes #1767