### PR TITLE
Redesign LanguageModal rows as segmented bars with a right-side offline toggle

### DIFF
--- a/api/src/db/seedingDocs/lang-eng.json
+++ b/api/src/db/seedingDocs/lang-eng.json
@@ -119,6 +119,8 @@
         "language.modal.save": "Save",
         "language.modal.cancel": "Cancel",
         "language.modal.availableOffline": "Available offline",
+        "language.modal.reorder": "Drag to reorder",
+        "language.modal.remove": "Remove language",
         "language.modal.offlineCaption": "Downloaded languages are available offline. Other languages show when you're online.",
         "language.modal.primaryAlwaysOffline": "Your main language is always available offline",
         "language.modal.offline.add.title": "You're offline",

--- a/api/src/db/seedingDocs/lang-fra.json
+++ b/api/src/db/seedingDocs/lang-fra.json
@@ -119,6 +119,8 @@
         "language.modal.save": "Enregistrer",
         "language.modal.cancel": "Annuler",
         "language.modal.availableOffline": "Disponible hors ligne",
+        "language.modal.reorder": "Glisser pour réorganiser",
+        "language.modal.remove": "Supprimer la langue",
         "language.modal.offlineCaption": "Les langues téléchargées sont disponibles hors ligne. Les autres langues s'affichent lorsque vous êtes en ligne.",
         "language.modal.primaryAlwaysOffline": "Votre langue principale est toujours disponible hors ligne",
         "language.modal.offline.add.title": "Vous êtes hors ligne",

--- a/app/src/components/icons/DragHandleIcon.vue
+++ b/app/src/components/icons/DragHandleIcon.vue
@@ -1,0 +1,42 @@
+<!-- A 2×3 dot grid drag handle ("grip"). Heroicons ships no grip/drag-handle icon, so this is
+     hand-rolled to match the shape used by Material Symbols (`drag_indicator`) and Lucide
+     (`grip-vertical`). Sized by the caller via `class` (e.g. `class="h-4 w-4"`); colour follows
+     `currentColor`. -->
+<template>
+    <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+    >
+        <circle
+            cx="5.5"
+            cy="3.5"
+            r="1.4"
+        />
+        <circle
+            cx="10.5"
+            cy="3.5"
+            r="1.4"
+        />
+        <circle
+            cx="5.5"
+            cy="8"
+            r="1.4"
+        />
+        <circle
+            cx="10.5"
+            cy="8"
+            r="1.4"
+        />
+        <circle
+            cx="5.5"
+            cy="12.5"
+            r="1.4"
+        />
+        <circle
+            cx="10.5"
+            cy="12.5"
+            r="1.4"
+        />
+    </svg>
+</template>

--- a/app/src/components/navigation/LanguageModal.spec.ts
+++ b/app/src/components/navigation/LanguageModal.spec.ts
@@ -25,6 +25,8 @@ const i18n = createI18n({
             "language.modal.save": "Save",
             "language.modal.cancel": "Cancel",
             "language.modal.availableOffline": "Available offline",
+            "language.modal.reorder": "Drag to reorder",
+            "language.modal.remove": "Remove language",
             "language.modal.offlineCaption": "Downloaded languages are available offline.",
             "language.modal.primaryAlwaysOffline": "Your main language is always available offline",
             "language.modal.offline.add.title": "You're offline",
@@ -37,6 +39,23 @@ const i18n = createI18n({
 
 const mountModal = () =>
     mount(LanguageModal, { props: { isVisible: true }, global: { plugins: [i18n] } });
+
+// jsdom reports every rect as 0×0, so the drag maths (which derives the row pitch from the first
+// two rows' tops) would no-op. Give the rows a synthetic 48px pitch based on their sibling index.
+const ROW_HEIGHT = 48;
+const stubRowLayout = () =>
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+        this: HTMLElement,
+    ) {
+        const index = this.parentElement
+            ? Array.prototype.indexOf.call(this.parentElement.children, this)
+            : 0;
+        const top = index * ROW_HEIGHT;
+        return { top, bottom: top + ROW_HEIGHT, height: ROW_HEIGHT } as DOMRect;
+    });
+
+const rowIds = (wrapper: ReturnType<typeof mountModal>) =>
+    wrapper.findAll("[data-lang-row]").map((row) => row.attributes("id"));
 
 const addButtonFor = async (wrapper: ReturnType<typeof mountModal>, name: string) => {
     await waitForExpect(async () => {
@@ -155,16 +174,73 @@ describe("LanguageModal.vue", () => {
         expect((checkboxes[1]!.element as HTMLInputElement).checked).toBe(false);
 
         // Promote French to primary → its now-disabled checkbox shows ticked (always synced).
-        await wrapper.find('[data-test="increase-priority"]').trigger("click");
+        await wrapper.findAll('[data-test="drag-handle"]')[1]!.trigger("keydown", {
+            key: "ArrowUp",
+        });
         checkboxes = await wrapper.findAll('[data-test="offline-checkbox"]');
         const frenchAsPrimary = checkboxes[0]!.element as HTMLInputElement;
         expect(frenchAsPrimary.checked).toBe(true);
         expect(frenchAsPrimary.disabled).toBe(true);
 
         // Demote it back → reverts to un-ticked (it was never actually ticked).
-        await wrapper.find('[data-test="decrease-priority"]').trigger("click");
+        await wrapper.findAll('[data-test="drag-handle"]')[0]!.trigger("keydown", {
+            key: "ArrowDown",
+        });
         checkboxes = await wrapper.findAll('[data-test="offline-checkbox"]');
         expect((checkboxes[1]!.element as HTMLInputElement).checked).toBe(false);
+    });
+
+    describe("drag-to-reorder", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("dragging a row past its neighbour reorders it, and Save commits the new order", async () => {
+            appLanguageIdsAsRef.value = [mockLanguageDtoEng._id, mockLanguageDtoFra._id];
+            appSyncedLanguageIdsAsRef.value = [mockLanguageDtoEng._id];
+
+            const wrapper = mountModal();
+            await waitForExpect(async () => {
+                expect((await wrapper.findAll('[data-test="drag-handle"]')).length).toBe(2);
+            });
+            stubRowLayout();
+
+            // Grab English (row 0) and drag it a full row's height down.
+            await wrapper
+                .findAll('[data-test="drag-handle"]')[0]!
+                .trigger("pointerdown", { clientY: 0 });
+            window.dispatchEvent(new MouseEvent("pointermove", { clientY: ROW_HEIGHT + 5 }));
+            await wrapper.vm.$nextTick();
+
+            expect(rowIds(wrapper)).toEqual([mockLanguageDtoFra._id, mockLanguageDtoEng._id]);
+
+            window.dispatchEvent(new MouseEvent("pointerup"));
+            await wrapper.find('[data-test="save-languages"]').trigger("click");
+
+            expect(appLanguageIdsAsRef.value).toEqual([
+                mockLanguageDtoFra._id,
+                mockLanguageDtoEng._id,
+            ]);
+        });
+
+        it("ignores pointer movement after the drag has ended", async () => {
+            appLanguageIdsAsRef.value = [mockLanguageDtoEng._id, mockLanguageDtoFra._id];
+
+            const wrapper = mountModal();
+            await waitForExpect(async () => {
+                expect((await wrapper.findAll('[data-test="drag-handle"]')).length).toBe(2);
+            });
+            stubRowLayout();
+
+            await wrapper
+                .findAll('[data-test="drag-handle"]')[0]!
+                .trigger("pointerdown", { clientY: 0 });
+            window.dispatchEvent(new MouseEvent("pointerup"));
+            window.dispatchEvent(new MouseEvent("pointermove", { clientY: ROW_HEIGHT + 5 }));
+            await wrapper.vm.$nextTick();
+
+            expect(rowIds(wrapper)).toEqual([mockLanguageDtoEng._id, mockLanguageDtoFra._id]);
+        });
     });
 
     it("ticking a non-primary language commits it to the synced set on Save", async () => {
@@ -220,11 +296,15 @@ describe("LanguageModal.vue", () => {
             appSyncedLanguageIdsAsRef.value = [mockLanguageDtoEng._id, mockLanguageDtoFra._id];
             const wrapper = mountModal();
             await waitForExpect(async () => {
-                expect((await wrapper.findAll('[data-test="remove-language-button"]')).length).toBe(2);
+                expect((await wrapper.findAll('[data-test="remove-language-button"]')).length).toBe(
+                    2,
+                );
             });
 
             // Remove French (the second row → index 1).
-            await (await wrapper.findAll('[data-test="remove-language-button"]'))[1]!.trigger("click");
+            await (
+                await wrapper.findAll('[data-test="remove-language-button"]')
+            )[1]!.trigger("click");
 
             // Still two languages — the removal was blocked — and a toast was raised.
             expect((await wrapper.findAll('[data-test="remove-language-button"]')).length).toBe(2);
@@ -239,10 +319,14 @@ describe("LanguageModal.vue", () => {
             appSyncedLanguageIdsAsRef.value = [mockLanguageDtoEng._id];
             const wrapper = mountModal();
             await waitForExpect(async () => {
-                expect((await wrapper.findAll('[data-test="remove-language-button"]')).length).toBe(2);
+                expect((await wrapper.findAll('[data-test="remove-language-button"]')).length).toBe(
+                    2,
+                );
             });
 
-            await (await wrapper.findAll('[data-test="remove-language-button"]'))[1]!.trigger("click");
+            await (
+                await wrapper.findAll('[data-test="remove-language-button"]')
+            )[1]!.trigger("click");
             await wrapper.find('[data-test="save-languages"]').trigger("click");
 
             // French was removed (no downloaded content to clear) and no "clear" toast fired.

--- a/app/src/components/navigation/LanguageModal.spec.ts
+++ b/app/src/components/navigation/LanguageModal.spec.ts
@@ -205,16 +205,17 @@ describe("LanguageModal.vue", () => {
             });
             stubRowLayout();
 
-            // Grab English (row 0) and drag it a full row's height down.
-            await wrapper
-                .findAll('[data-test="drag-handle"]')[0]!
-                .trigger("pointerdown", { clientY: 0 });
-            window.dispatchEvent(new MouseEvent("pointermove", { clientY: ROW_HEIGHT + 5 }));
-            await wrapper.vm.$nextTick();
+            // Grab English (row 0) and drag it a full row's height down. Events are dispatched on
+            // the handle itself (not `window`): pointer capture retargets them there in real
+            // browsers, and Vue reuses the same DOM node for a keyed row across reorders, so a
+            // held reference stays valid even after the row moves.
+            const handle = wrapper.findAll('[data-test="drag-handle"]')[0]!;
+            await handle.trigger("pointerdown", { clientY: 0 });
+            await handle.trigger("pointermove", { clientY: ROW_HEIGHT + 5 });
 
             expect(rowIds(wrapper)).toEqual([mockLanguageDtoFra._id, mockLanguageDtoEng._id]);
 
-            window.dispatchEvent(new MouseEvent("pointerup"));
+            await handle.trigger("pointerup");
             await wrapper.find('[data-test="save-languages"]').trigger("click");
 
             expect(appLanguageIdsAsRef.value).toEqual([
@@ -232,12 +233,10 @@ describe("LanguageModal.vue", () => {
             });
             stubRowLayout();
 
-            await wrapper
-                .findAll('[data-test="drag-handle"]')[0]!
-                .trigger("pointerdown", { clientY: 0 });
-            window.dispatchEvent(new MouseEvent("pointerup"));
-            window.dispatchEvent(new MouseEvent("pointermove", { clientY: ROW_HEIGHT + 5 }));
-            await wrapper.vm.$nextTick();
+            const handle = wrapper.findAll('[data-test="drag-handle"]')[0]!;
+            await handle.trigger("pointerdown", { clientY: 0 });
+            await handle.trigger("pointerup");
+            await handle.trigger("pointermove", { clientY: ROW_HEIGHT + 5 });
 
             expect(rowIds(wrapper)).toEqual([mockLanguageDtoEng._id, mockLanguageDtoFra._id]);
         });

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -15,18 +15,12 @@ import {
     normalizeSyncedLanguages,
 } from "@/globalConfig";
 import LModal from "../form/LModal.vue";
-import {
-    ArrowDownIcon,
-    ArrowDownTrayIcon,
-    ArrowUpIcon,
-    CheckIcon,
-    XMarkIcon,
-} from "@heroicons/vue/24/solid";
+import { ArrowDownTrayIcon, CheckIcon, XMarkIcon } from "@heroicons/vue/24/solid";
 import { InformationCircleIcon, PlusCircleIcon } from "@heroicons/vue/24/outline";
 import { markLanguageSwitch } from "@/util/isLangSwitch";
 import { useNotificationStore } from "@/stores/notification";
 
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 type Props = {
@@ -128,6 +122,76 @@ const decreasePriority = (id: string) => {
         ];
     }
 };
+
+// ── Drag-to-reorder ──────────────────────────────────────────────────────────
+// Pointer events, not HTML5 drag-and-drop: the modal is touch-first and DnD never fires on touch.
+// The grabbed row tracks the finger with a translate, and every full row of travel splices
+// `draftOrder` so the neighbours shuffle live underneath it.
+const draggingId = ref<string | null>(null);
+const dragTranslate = ref(0);
+let dragStartY = 0;
+let dragStartIndex = 0;
+let rowStep = 0; // px between adjacent row tops (rows are uniform height)
+
+const endDrag = () => {
+    draggingId.value = null;
+    dragTranslate.value = 0;
+    window.removeEventListener("pointermove", onDragMove);
+    window.removeEventListener("pointerup", endDrag);
+    window.removeEventListener("pointercancel", endDrag);
+};
+
+function onDragMove(e: PointerEvent) {
+    const id = draggingId.value;
+    if (!id || rowStep <= 0) return; // rowStep is 0 in jsdom (no layout) — drag is a no-op there
+    e.preventDefault(); // suppress text selection / touch scroll while dragging
+    // Clamp the travel to the list's own bounds, so a row can never be dragged outside it.
+    const last = draftOrder.value.length - 1;
+    const dy = Math.max(
+        -dragStartIndex * rowStep,
+        Math.min((last - dragStartIndex) * rowStep, e.clientY - dragStartY),
+    );
+    const target = dragStartIndex + Math.round(dy / rowStep);
+    const current = draftOrder.value.indexOf(id);
+    if (target !== current) {
+        draftOrder.value.splice(target, 0, draftOrder.value.splice(current, 1)[0]!);
+    }
+    // Subtract the travel the reorder itself already absorbed, so the row stays under the finger.
+    dragTranslate.value = dy - (target - dragStartIndex) * rowStep;
+}
+
+const startDrag = (id: string, e: PointerEvent) => {
+    if (draftOrder.value.length <= 1 || e.button > 0) return;
+    const handle = e.currentTarget as HTMLElement;
+    const row = handle.closest("[data-lang-row]");
+    const rows = (row?.parentElement?.children ?? []) as HTMLCollectionOf<HTMLElement>;
+    rowStep =
+        rows.length > 1
+            ? rows[1]!.getBoundingClientRect().top - rows[0]!.getBoundingClientRect().top
+            : 0;
+    dragStartY = e.clientY;
+    dragStartIndex = draftOrder.value.indexOf(id);
+    draggingId.value = id;
+    dragTranslate.value = 0;
+    handle.setPointerCapture?.(e.pointerId);
+    window.addEventListener("pointermove", onDragMove, { passive: false });
+    window.addEventListener("pointerup", endDrag);
+    window.addEventListener("pointercancel", endDrag);
+};
+
+// Keyboard equivalent of the drag: the handle is focusable and arrow keys nudge the row.
+const onHandleKeydown = (id: string, e: KeyboardEvent) => {
+    if (e.key === "ArrowUp") {
+        e.preventDefault();
+        increasePriority(id);
+    } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        decreasePriority(id);
+    }
+};
+
+onBeforeUnmount(endDrag);
+
 const removeFromSelected = (id: string) => {
     // At least one preferred language must remain — empty order breaks sync + offline content.
     if (draftOrder.value.length <= 1) return;
@@ -209,94 +273,140 @@ const cancel = () => emit("close");
         <transition-group
             name="language"
             tag="div"
-            class="flex flex-col gap-2"
+            :class="['flex flex-col gap-2', draggingId && 'select-none']"
             enter-active-class="transition duration-100 ease-in-out"
             enter-from-class="opacity-0 transform -translate-y-2"
             enter-to-class="opacity-100 transform translate-y-0"
             leave-active-class="transition duration-100 ease-in-out"
             leave-from-class="opacity-100 transform translate-y-0"
             leave-to-class="opacity-0 transform translate-y-2"
-            move-class="transition duration-100 ease-in-out"
+            :move-class="draggingId ? 'transition-none' : 'transition duration-100 ease-in-out'"
         >
-            <!-- One segmented bar: [action buttons | language | offline toggle]; the toggle's own
-                 fill is what separates it, no divider lines needed. -->
+            <!-- Row = [segmented bar] ×. The bar is [grip | language | offline toggle]; the toggle's
+                 own fill is what separates it, no divider lines needed. Remove sits OUTSIDE the bar
+                 at the trailing edge: it is destructive, so it stays as far as possible from the
+                 grip you press-and-hold, and the toggle keeps the bar's rounded right edge.
+                 `move-class` is disabled while dragging: TransitionGroup's FLIP writes to
+                 `transform`, which would fight the grabbed row's own translate. -->
             <div
                 v-for="language in languagesSelected"
                 :id="language._id"
                 :key="language._id"
-                class="flex w-full items-stretch overflow-hidden rounded-xl bg-zinc-50 ring-1 ring-zinc-200 dark:bg-slate-600/30 dark:ring-slate-500/50"
+                data-lang-row
+                :class="[
+                    'flex w-full items-center gap-1',
+                    draggingId === language._id && 'relative z-10',
+                ]"
+                :style="
+                    draggingId === language._id
+                        ? { transform: `translateY(${dragTranslate}px)` }
+                        : undefined
+                "
             >
-                <!-- Reorder arrows are always rendered so every row's columns align; at the ends they
-                     render faded + disabled (no data-test, non-clickable) instead of leaving a gap. -->
                 <div
-                    v-if="draftOrder.length > 1"
-                    class="flex shrink-0 items-center gap-0.5 px-2 py-2"
+                    :class="[
+                        'flex min-w-0 flex-1 items-stretch overflow-hidden rounded-xl bg-zinc-50 ring-1 ring-zinc-200 dark:bg-slate-600/30 dark:ring-slate-500/50',
+                        draggingId === language._id &&
+                            'shadow-lg ring-yellow-500 dark:ring-yellow-500',
+                    ]"
                 >
+                    <!-- Grab handle: `touch-none` stops the browser claiming the gesture as a scroll. -->
                     <button
+                        v-if="draftOrder.length > 1"
                         type="button"
-                        :disabled="language._id === draftOrder[0]"
-                        :data-test="language._id === draftOrder[0] ? undefined : 'increase-priority'"
-                        @click="increasePriority(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-yellow-600 disabled:pointer-events-none disabled:opacity-25 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
+                        data-test="drag-handle"
+                        :aria-label="t('language.modal.reorder')"
+                        :title="t('language.modal.reorder')"
+                        class="flex shrink-0 cursor-grab touch-none items-center py-2 pl-2 pr-1 text-zinc-400 hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-500 active:cursor-grabbing dark:text-slate-400 dark:hover:text-slate-200"
+                        @pointerdown="startDrag(language._id, $event)"
+                        @keydown="onHandleKeydown(language._id, $event)"
                     >
-                        <ArrowUpIcon class="h-4 w-4" />
+                        <svg
+                            class="h-4 w-4"
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            aria-hidden="true"
+                        >
+                            <circle
+                                cx="5.5"
+                                cy="3.5"
+                                r="1.4"
+                            />
+                            <circle
+                                cx="10.5"
+                                cy="3.5"
+                                r="1.4"
+                            />
+                            <circle
+                                cx="5.5"
+                                cy="8"
+                                r="1.4"
+                            />
+                            <circle
+                                cx="10.5"
+                                cy="8"
+                                r="1.4"
+                            />
+                            <circle
+                                cx="5.5"
+                                cy="12.5"
+                                r="1.4"
+                            />
+                            <circle
+                                cx="10.5"
+                                cy="12.5"
+                                r="1.4"
+                            />
+                        </svg>
                     </button>
-                    <button
-                        type="button"
-                        :disabled="language._id === draftOrder[draftOrder.length - 1]"
-                        :data-test="
-                            language._id === draftOrder[draftOrder.length - 1]
-                                ? undefined
-                                : 'decrease-priority'
+
+                    <div class="flex min-w-0 flex-1 items-center px-3 py-2">
+                        <span class="truncate text-sm font-semibold">{{ language.name }}</span>
+                    </div>
+
+                    <!-- Offline toggle: the right segment fills yellow when the language is synced
+                         offline. A real checkbox fills the segment and drives state (a11y + tests
+                         unchanged). -->
+                    <label
+                        class="relative flex shrink-0 cursor-pointer items-center px-3"
+                        :title="
+                            language._id === primaryId
+                                ? t('language.modal.primaryAlwaysOffline')
+                                : t('language.modal.availableOffline')
                         "
-                        @click="decreasePriority(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-yellow-600 disabled:pointer-events-none disabled:opacity-25 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
                     >
-                        <ArrowDownIcon class="h-4 w-4" />
-                    </button>
-                    <button
-                        type="button"
-                        data-test="remove-language-button"
-                        @click="removeFromSelected(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-red-600 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-red-500"
-                    >
-                        <XMarkIcon class="h-4 w-4" />
-                    </button>
+                        <input
+                            type="checkbox"
+                            :checked="isOfflineChecked(language._id)"
+                            :disabled="language._id === primaryId"
+                            :aria-label="t('language.modal.availableOffline')"
+                            data-test="offline-checkbox"
+                            class="peer absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent checked:bg-yellow-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-600 disabled:cursor-auto dark:checked:bg-yellow-500"
+                            @change="toggleSynced(language._id)"
+                        />
+                        <component
+                            :is="isOfflineChecked(language._id) ? CheckIcon : ArrowDownTrayIcon"
+                            class="pointer-events-none relative h-4 w-4 text-zinc-500 peer-checked:text-yellow-950 dark:text-slate-300"
+                        />
+                    </label>
                 </div>
 
-                <div class="flex min-w-0 flex-1 items-center px-3 py-2">
-                    <span class="truncate text-sm font-semibold">{{ language.name }}</span>
-                </div>
-
-                <!-- Offline toggle: the right segment fills yellow when the language is synced offline.
-                     A real checkbox fills the segment and drives state (a11y + tests unchanged). -->
-                <label
-                    class="relative flex shrink-0 cursor-pointer items-center px-3"
-                    :title="
-                        language._id === primaryId
-                            ? t('language.modal.primaryAlwaysOffline')
-                            : t('language.modal.availableOffline')
-                    "
+                <button
+                    v-if="draftOrder.length > 1"
+                    type="button"
+                    data-test="remove-language-button"
+                    :aria-label="t('language.modal.remove')"
+                    :title="t('language.modal.remove')"
+                    @click="removeFromSelected(language._id)"
+                    class="flex shrink-0 cursor-pointer items-center rounded-full p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-red-500"
                 >
-                    <input
-                        type="checkbox"
-                        :checked="isOfflineChecked(language._id)"
-                        :disabled="language._id === primaryId"
-                        :aria-label="t('language.modal.availableOffline')"
-                        data-test="offline-checkbox"
-                        class="peer absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent checked:bg-yellow-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-600 disabled:cursor-auto dark:checked:bg-yellow-500"
-                        @change="toggleSynced(language._id)"
-                    />
-                    <component
-                        :is="isOfflineChecked(language._id) ? CheckIcon : ArrowDownTrayIcon"
-                        class="pointer-events-none relative h-4 w-4 text-zinc-500 peer-checked:text-yellow-950 dark:text-slate-300"
-                    />
-                </label>
+                    <XMarkIcon class="h-4 w-4" />
+                </button>
             </div>
         </transition-group>
 
         <p
-            class="mt-2 flex items-center gap-1.5 border-t border-zinc-200 px-3 pt-3 pb-1 text-xs text-zinc-500 dark:border-slate-600 dark:text-slate-400"
+            class="mt-2 flex items-center gap-1.5 border-t border-zinc-200 px-3 pb-1 pt-3 text-xs text-zinc-500 dark:border-slate-600 dark:text-slate-400"
         >
             <InformationCircleIcon class="h-4 w-4 shrink-0" />
             {{ t("language.modal.offlineCaption") }}

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -20,8 +20,9 @@ import { ArrowDownTrayIcon, CheckIcon, XMarkIcon } from "@heroicons/vue/24/solid
 import { InformationCircleIcon, PlusCircleIcon } from "@heroicons/vue/24/outline";
 import { markLanguageSwitch } from "@/util/isLangSwitch";
 import { useNotificationStore } from "@/stores/notification";
+import { useDragReorder } from "@/composables/useDragReorder";
 
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 type Props = {
@@ -125,60 +126,7 @@ const decreasePriority = (id: string) => {
 };
 
 // ── Drag-to-reorder ──────────────────────────────────────────────────────────
-// Pointer events, not HTML5 drag-and-drop: the modal is touch-first and DnD never fires on touch.
-// The grabbed row tracks the finger with a translate, and every full row of travel splices
-// `draftOrder` so the neighbours shuffle live underneath it.
-const draggingId = ref<string | null>(null);
-const dragTranslate = ref(0);
-let dragStartY = 0;
-let dragStartIndex = 0;
-let rowStep = 0; // px between adjacent row tops (rows are uniform height)
-
-const endDrag = () => {
-    draggingId.value = null;
-    dragTranslate.value = 0;
-    window.removeEventListener("pointermove", onDragMove);
-    window.removeEventListener("pointerup", endDrag);
-    window.removeEventListener("pointercancel", endDrag);
-};
-
-function onDragMove(e: PointerEvent) {
-    const id = draggingId.value;
-    if (!id || rowStep <= 0) return; // rowStep is 0 in jsdom (no layout) — drag is a no-op there
-    e.preventDefault(); // suppress text selection / touch scroll while dragging
-    // Clamp the travel to the list's own bounds, so a row can never be dragged outside it.
-    const last = draftOrder.value.length - 1;
-    const dy = Math.max(
-        -dragStartIndex * rowStep,
-        Math.min((last - dragStartIndex) * rowStep, e.clientY - dragStartY),
-    );
-    const target = dragStartIndex + Math.round(dy / rowStep);
-    const current = draftOrder.value.indexOf(id);
-    if (target !== current) {
-        draftOrder.value.splice(target, 0, draftOrder.value.splice(current, 1)[0]!);
-    }
-    // Subtract the travel the reorder itself already absorbed, so the row stays under the finger.
-    dragTranslate.value = dy - (target - dragStartIndex) * rowStep;
-}
-
-const startDrag = (id: string, e: PointerEvent) => {
-    if (draftOrder.value.length <= 1 || e.button > 0) return;
-    const handle = e.currentTarget as HTMLElement;
-    const row = handle.closest("[data-lang-row]");
-    const rows = (row?.parentElement?.children ?? []) as HTMLCollectionOf<HTMLElement>;
-    rowStep =
-        rows.length > 1
-            ? rows[1]!.getBoundingClientRect().top - rows[0]!.getBoundingClientRect().top
-            : 0;
-    dragStartY = e.clientY;
-    dragStartIndex = draftOrder.value.indexOf(id);
-    draggingId.value = id;
-    dragTranslate.value = 0;
-    handle.setPointerCapture?.(e.pointerId);
-    window.addEventListener("pointermove", onDragMove, { passive: false });
-    window.addEventListener("pointerup", endDrag);
-    window.addEventListener("pointercancel", endDrag);
-};
+const { draggingId, dragTranslate, startDrag, onDragMove, endDrag } = useDragReorder(draftOrder);
 
 // Keyboard equivalent of the drag: the handle is focusable and arrow keys nudge the row.
 const onHandleKeydown = (id: string, e: KeyboardEvent) => {
@@ -190,8 +138,6 @@ const onHandleKeydown = (id: string, e: KeyboardEvent) => {
         decreasePriority(id);
     }
 };
-
-onBeforeUnmount(endDrag);
 
 const removeFromSelected = (id: string) => {
     // At least one preferred language must remain — empty order breaks sync + offline content.
@@ -320,6 +266,10 @@ const cancel = () => emit("close");
                         :title="t('language.modal.reorder')"
                         class="flex shrink-0 cursor-grab touch-none items-center py-2 pl-2 pr-1 text-zinc-400 hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-500 active:cursor-grabbing dark:text-slate-400 dark:hover:text-slate-200"
                         @pointerdown="startDrag(language._id, $event)"
+                        @pointermove="onDragMove"
+                        @pointerup="endDrag"
+                        @pointercancel="endDrag"
+                        @lostpointercapture="endDrag"
                         @keydown="onHandleKeydown(language._id, $event)"
                     >
                         <DragHandleIcon class="h-4 w-4" />

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -15,6 +15,7 @@ import {
     normalizeSyncedLanguages,
 } from "@/globalConfig";
 import LModal from "../form/LModal.vue";
+import DragHandleIcon from "../icons/DragHandleIcon.vue";
 import { ArrowDownTrayIcon, CheckIcon, XMarkIcon } from "@heroicons/vue/24/solid";
 import { InformationCircleIcon, PlusCircleIcon } from "@heroicons/vue/24/outline";
 import { markLanguageSwitch } from "@/util/isLangSwitch";
@@ -321,43 +322,7 @@ const cancel = () => emit("close");
                         @pointerdown="startDrag(language._id, $event)"
                         @keydown="onHandleKeydown(language._id, $event)"
                     >
-                        <svg
-                            class="h-4 w-4"
-                            viewBox="0 0 16 16"
-                            fill="currentColor"
-                            aria-hidden="true"
-                        >
-                            <circle
-                                cx="5.5"
-                                cy="3.5"
-                                r="1.4"
-                            />
-                            <circle
-                                cx="10.5"
-                                cy="3.5"
-                                r="1.4"
-                            />
-                            <circle
-                                cx="5.5"
-                                cy="8"
-                                r="1.4"
-                            />
-                            <circle
-                                cx="10.5"
-                                cy="8"
-                                r="1.4"
-                            />
-                            <circle
-                                cx="5.5"
-                                cy="12.5"
-                                r="1.4"
-                            />
-                            <circle
-                                cx="10.5"
-                                cy="12.5"
-                                r="1.4"
-                            />
-                        </svg>
+                        <DragHandleIcon class="h-4 w-4" />
                     </button>
 
                     <div class="flex min-w-0 flex-1 items-center px-3 py-2">

--- a/app/src/components/navigation/LanguageModal.vue
+++ b/app/src/components/navigation/LanguageModal.vue
@@ -15,8 +15,14 @@ import {
     normalizeSyncedLanguages,
 } from "@/globalConfig";
 import LModal from "../form/LModal.vue";
-import { ArrowDownIcon, ArrowUpIcon, CheckIcon, XMarkIcon } from "@heroicons/vue/24/solid";
-import { PlusCircleIcon } from "@heroicons/vue/24/outline";
+import {
+    ArrowDownIcon,
+    ArrowDownTrayIcon,
+    ArrowUpIcon,
+    CheckIcon,
+    XMarkIcon,
+} from "@heroicons/vue/24/solid";
+import { InformationCircleIcon, PlusCircleIcon } from "@heroicons/vue/24/outline";
 import { markLanguageSwitch } from "@/util/isLangSwitch";
 import { useNotificationStore } from "@/stores/notification";
 
@@ -203,7 +209,7 @@ const cancel = () => emit("close");
         <transition-group
             name="language"
             tag="div"
-            class="divide-y divide-zinc-200 dark:divide-slate-600"
+            class="flex flex-col gap-2"
             enter-active-class="transition duration-100 ease-in-out"
             enter-from-class="opacity-0 transform -translate-y-2"
             enter-to-class="opacity-100 transform translate-y-0"
@@ -212,86 +218,104 @@ const cancel = () => emit("close");
             leave-to-class="opacity-0 transform translate-y-2"
             move-class="transition duration-100 ease-in-out"
         >
+            <!-- One segmented bar: [action buttons | language | offline toggle]; the toggle's own
+                 fill is what separates it, no divider lines needed. -->
             <div
                 v-for="language in languagesSelected"
                 :id="language._id"
                 :key="language._id"
-                class="flex w-full items-center gap-3 p-3"
+                class="flex w-full items-stretch overflow-hidden rounded-xl bg-zinc-50 ring-1 ring-zinc-200 dark:bg-slate-600/30 dark:ring-slate-500/50"
             >
-                <div class="relative flex h-4 w-4 shrink-0 items-center justify-center">
-                    <input
-                        type="checkbox"
-                        :checked="isOfflineChecked(language._id)"
-                        :disabled="language._id === primaryId"
-                        :title="
-                            language._id === primaryId
-                                ? t('language.modal.primaryAlwaysOffline')
-                                : t('language.modal.availableOffline')
-                        "
-                        :aria-label="t('language.modal.availableOffline')"
-                        data-test="offline-checkbox"
-                        class="peer h-4 w-4 cursor-pointer appearance-none rounded-full border border-zinc-300 checked:border-yellow-500 checked:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-1 disabled:cursor-auto disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:checked:border-yellow-500 dark:checked:bg-yellow-500"
-                        @change="toggleSynced(language._id)"
-                    />
-                    <CheckIcon
-                        class="pointer-events-none absolute h-2.5 w-2.5 text-white opacity-0 peer-checked:opacity-100"
-                    />
-                </div>
-
-                <span class="flex-1 text-sm">{{ language.name }}</span>
-
-                <div class="flex items-center gap-1">
+                <!-- Reorder arrows are always rendered so every row's columns align; at the ends they
+                     render faded + disabled (no data-test, non-clickable) instead of leaving a gap. -->
+                <div
+                    v-if="draftOrder.length > 1"
+                    class="flex shrink-0 items-center gap-0.5 px-2 py-2"
+                >
                     <button
-                        v-if="language._id !== draftOrder[0]"
                         type="button"
-                        data-test="increase-priority"
+                        :disabled="language._id === draftOrder[0]"
+                        :data-test="language._id === draftOrder[0] ? undefined : 'increase-priority'"
                         @click="increasePriority(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-100 hover:text-yellow-600 dark:text-slate-500 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
+                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-yellow-600 disabled:pointer-events-none disabled:opacity-25 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
                     >
                         <ArrowUpIcon class="h-4 w-4" />
                     </button>
                     <button
-                        v-if="language._id !== draftOrder[draftOrder.length - 1]"
                         type="button"
-                        data-test="decrease-priority"
+                        :disabled="language._id === draftOrder[draftOrder.length - 1]"
+                        :data-test="
+                            language._id === draftOrder[draftOrder.length - 1]
+                                ? undefined
+                                : 'decrease-priority'
+                        "
                         @click="decreasePriority(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-100 hover:text-yellow-600 dark:text-slate-500 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
+                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-yellow-600 disabled:pointer-events-none disabled:opacity-25 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
                     >
                         <ArrowDownIcon class="h-4 w-4" />
                     </button>
                     <button
-                        v-if="draftOrder.length > 1"
                         type="button"
                         data-test="remove-language-button"
                         @click="removeFromSelected(language._id)"
-                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-100 hover:text-red-600 dark:text-slate-500 dark:hover:bg-slate-600 dark:hover:text-red-500"
+                        class="flex cursor-pointer items-center rounded-full p-1 text-zinc-400 hover:bg-zinc-200 hover:text-red-600 dark:text-slate-400 dark:hover:bg-slate-600 dark:hover:text-red-500"
                     >
                         <XMarkIcon class="h-4 w-4" />
                     </button>
                 </div>
+
+                <div class="flex min-w-0 flex-1 items-center px-3 py-2">
+                    <span class="truncate text-sm font-semibold">{{ language.name }}</span>
+                </div>
+
+                <!-- Offline toggle: the right segment fills yellow when the language is synced offline.
+                     A real checkbox fills the segment and drives state (a11y + tests unchanged). -->
+                <label
+                    class="relative flex shrink-0 cursor-pointer items-center px-3"
+                    :title="
+                        language._id === primaryId
+                            ? t('language.modal.primaryAlwaysOffline')
+                            : t('language.modal.availableOffline')
+                    "
+                >
+                    <input
+                        type="checkbox"
+                        :checked="isOfflineChecked(language._id)"
+                        :disabled="language._id === primaryId"
+                        :aria-label="t('language.modal.availableOffline')"
+                        data-test="offline-checkbox"
+                        class="peer absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent checked:bg-yellow-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-600 disabled:cursor-auto dark:checked:bg-yellow-500"
+                        @change="toggleSynced(language._id)"
+                    />
+                    <component
+                        :is="isOfflineChecked(language._id) ? CheckIcon : ArrowDownTrayIcon"
+                        class="pointer-events-none relative h-4 w-4 text-zinc-500 peer-checked:text-yellow-950 dark:text-slate-300"
+                    />
+                </label>
             </div>
         </transition-group>
 
-        <p class="px-3 py-2 text-xs text-zinc-500 dark:text-slate-400">
+        <p
+            class="mt-2 flex items-center gap-1.5 border-t border-zinc-200 px-3 pt-3 pb-1 text-xs text-zinc-500 dark:border-slate-600 dark:text-slate-400"
+        >
+            <InformationCircleIcon class="h-4 w-4 shrink-0" />
             {{ t("language.modal.offlineCaption") }}
         </p>
 
         <div
             v-if="canAddMore"
-            class="divide-y divide-zinc-200 dark:divide-slate-600"
+            class="mt-1 flex flex-col gap-2 border-t border-zinc-200 pt-3 dark:border-slate-600"
         >
             <div
                 v-for="language in availableLanguages"
                 :id="language._id"
                 :key="language._id"
-                class="flex w-full cursor-pointer items-center gap-2 rounded-lg p-3 hover:bg-zinc-100 dark:hover:bg-slate-600"
+                class="flex w-full cursor-pointer items-center gap-2 rounded-xl border border-dashed border-zinc-300 px-3 py-2.5 text-zinc-500 transition-colors hover:border-yellow-400 hover:bg-yellow-50 hover:text-yellow-700 dark:border-slate-500 dark:text-slate-400 dark:hover:border-yellow-500/60 dark:hover:bg-slate-600 dark:hover:text-yellow-500"
                 data-test="add-language-button"
                 @click="addLanguage(language._id)"
             >
-                <PlusCircleIcon
-                    class="h-5 w-5 cursor-pointer text-zinc-500 hover:text-yellow-600 dark:text-slate-400 dark:hover:text-yellow-500"
-                />
-                <span class="text-sm">{{ language.name }}</span>
+                <PlusCircleIcon class="h-5 w-5 shrink-0" />
+                <span class="text-sm font-medium">{{ language.name }}</span>
             </div>
         </div>
 

--- a/app/src/composables/useDragReorder.ts
+++ b/app/src/composables/useDragReorder.ts
@@ -1,0 +1,66 @@
+import { ref, type Ref } from "vue";
+
+// Pointer events, not HTML5 drag-and-drop: callers are touch-first and DnD never fires on touch.
+// The grabbed row tracks the finger with a translate, and every full row of travel splices
+// `order` so the neighbours shuffle live underneath it.
+//
+// `startDrag` puts the handle into pointer capture, so the browser retargets every later
+// pointermove/pointerup/pointercancel for that pointer back to the handle regardless of where
+// the finger physically ends up — bind `onDragMove`/`endDrag` as plain `v-on` directives on the
+// SAME handle element (incl. `@lostpointercapture="endDrag"` as a fallback if the row is ever
+// removed mid-drag) rather than adding/removing listeners on `window` by hand.
+//
+// Not vue-use's `useDraggable`: that tracks one element's free x/y position, it doesn't know
+// about a list, row height, or index splicing — the reorder semantics here (clamping to list
+// bounds, converting travel into a discrete index swap) would still have to be hand-rolled on
+// top of it. `useSortable` (vue-use/integrations, wraps SortableJS) is the closer fit but pulls
+// in a new dependency for something ~50 lines already does.
+export function useDragReorder(order: Ref<string[]>) {
+    const draggingId = ref<string | null>(null);
+    const dragTranslate = ref(0);
+    let dragStartY = 0;
+    let dragStartIndex = 0;
+    let rowStep = 0; // px between adjacent row tops (rows are uniform height)
+
+    const endDrag = () => {
+        draggingId.value = null;
+        dragTranslate.value = 0;
+    };
+
+    function onDragMove(e: PointerEvent) {
+        const id = draggingId.value;
+        if (!id || rowStep <= 0) return; // rowStep is 0 in jsdom (no layout) — drag is a no-op there
+        e.preventDefault(); // suppress text selection / touch scroll while dragging
+        // Clamp the travel to the list's own bounds, so a row can never be dragged outside it.
+        const last = order.value.length - 1;
+        const dy = Math.max(
+            -dragStartIndex * rowStep,
+            Math.min((last - dragStartIndex) * rowStep, e.clientY - dragStartY),
+        );
+        const target = dragStartIndex + Math.round(dy / rowStep);
+        const current = order.value.indexOf(id);
+        if (target !== current) {
+            order.value.splice(target, 0, order.value.splice(current, 1)[0]!);
+        }
+        // Subtract the travel the reorder itself already absorbed, so the row stays under the finger.
+        dragTranslate.value = dy - (target - dragStartIndex) * rowStep;
+    }
+
+    const startDrag = (id: string, e: PointerEvent) => {
+        if (order.value.length <= 1 || e.button > 0) return;
+        const handle = e.currentTarget as HTMLElement;
+        const row = handle.closest("[data-lang-row]");
+        const rows = (row?.parentElement?.children ?? []) as HTMLCollectionOf<HTMLElement>;
+        rowStep =
+            rows.length > 1
+                ? rows[1]!.getBoundingClientRect().top - rows[0]!.getBoundingClientRect().top
+                : 0;
+        dragStartY = e.clientY;
+        dragStartIndex = order.value.indexOf(id);
+        draggingId.value = id;
+        dragTranslate.value = 0;
+        handle.setPointerCapture?.(e.pointerId);
+    };
+
+    return { draggingId, dragTranslate, startDrag, onDragMove, endDrag };
+}


### PR DESCRIPTION
Moves the offline-sync checkbox to the right side of each language row as a labelled segment (matches ticket 1759), keeps reorder/remove controls left-aligned and always rendered (disabled at the ends) so columns stay aligned, and adds section dividers plus dashed "add language" pills for the not-yet-selected list.


https://github.com/user-attachments/assets/10ecef51-698d-4bcd-96a5-c3a5a294143f

