### PR TITLE
Add expiry-date range filter to /fts and a CMS date-range filter UI (#1704)

### DIFF
--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -1149,7 +1149,7 @@ describe("DbService", () => {
                         update.type === DocType.DeleteCmd &&
                         update.deleteReason === DeleteReason.StatusChange
                     ) {
-                        service.off("update", deleteCmdHandler1);
+                        service.off("update", deleteCmdHandler2);
                         updateEventDoc2 = update;
                     }
                 };

--- a/api/src/dto/FtsSearchReqDto.ts
+++ b/api/src/dto/FtsSearchReqDto.ts
@@ -106,6 +106,18 @@ export class FtsSearchReqDto {
     @Expose()
     publishedBefore?: number;
 
+    /** Restrict to content with `expiryDate` greater than or equal to this value. */
+    @IsOptional()
+    @IsNumber()
+    @Expose()
+    expiresAfter?: number;
+
+    /** Restrict to content with `expiryDate` less than or equal to this value. */
+    @IsOptional()
+    @IsNumber()
+    @Expose()
+    expiresBefore?: number;
+
     /**
      * Strict mode: keep only docs where every query word (≥3 chars) is a substring of
      * `title` or `author` (AND across words). Pairs with {@link sort} for a precise,

--- a/api/src/endpoints/ftsSearch.service.spec.ts
+++ b/api/src/endpoints/ftsSearch.service.spec.ts
@@ -209,6 +209,23 @@ describe("FtsSearchService", () => {
         expect(res.map((r) => r.docId)).toEqual(["inrange"]);
     });
 
+    it("applies the expiryDate range filter", async () => {
+        dbService.ftsTrigramCandidates.mockResolvedValue([
+            row("inrange", "gar", value({ expiryDate: 500 })),
+            row("tooearly", "gar", value({ expiryDate: 100 })),
+            row("toolate", "gar", value({ expiryDate: 900 })),
+        ]);
+        dbService.getDocs.mockResolvedValue({
+            docs: [{ _id: "inrange", title: "garden", ftsTokenCount: 10 }],
+        });
+
+        const res = await service.search(
+            makeReq({ cms: true, expiresAfter: 400, expiresBefore: 600 }),
+            mockUser,
+        );
+        expect(res.map((r) => r.docId)).toEqual(["inrange"]);
+    });
+
     it("ranks by score and returns trimmed docs without fts index fields", async () => {
         dbService.ftsTrigramCandidates.mockResolvedValue([
             row("low", "gar", value({ tf: 1 })),

--- a/api/src/endpoints/ftsSearch.service.ts
+++ b/api/src/endpoints/ftsSearch.service.ts
@@ -347,6 +347,13 @@ export class FtsSearchService {
                 (publishDate == null || publishDate > req.publishedBefore)
             )
                 continue;
+            if (req.expiresAfter != null && (expiryDate == null || expiryDate < req.expiresAfter))
+                continue;
+            if (
+                req.expiresBefore != null &&
+                (expiryDate == null || expiryDate > req.expiresBefore)
+            )
+                continue;
 
             // survivor → record tf and accessible df
             let tfMap = perDocTf.get(row.docId);

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -72,57 +72,6 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
-        "../shared": {
-            "name": "luminary-shared",
-            "version": "0.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/lodash.clonedeep": "^4.5.9",
-                "@types/lodash.isequal": "^4.5.8",
-                "@vueuse/core": "^10.11.0",
-                "lodash-es": "^4.17.21",
-                "luxon": "^3.4.4",
-                "socket.io-client": "^4.7.5",
-                "uuid": "^9.0.1"
-            },
-            "devDependencies": {
-                "@rushstack/eslint-patch": "^1.3.3",
-                "@tsconfig/node18": "^18.2.4",
-                "@types/jsdom": "^21.1.7",
-                "@types/lodash-es": "^4.17.12",
-                "@types/luxon": "^3.4.2",
-                "@types/node": "^18.19.3",
-                "@types/rollup-plugin-auto-external": "^2.0.5",
-                "@types/uuid": "^9.0.8",
-                "@vitejs/plugin-vue": "^5.0.4",
-                "@vitest/coverage-v8": "^1.6.1",
-                "@vue/eslint-config-prettier": "^8.0.0",
-                "@vue/eslint-config-typescript": "^12.0.0",
-                "@vue/test-utils": "^2.4.6",
-                "@vue/tsconfig": "^0.5.0",
-                "dexie": "^4.0.11",
-                "eslint": "^8.49.0",
-                "eslint-plugin-vue": "^9.17.0",
-                "express": "^4.21.2",
-                "fake-indexeddb": "^6.0.0",
-                "jsdom": "^24.1.3",
-                "prettier": "^3.0.3",
-                "rollup-plugin-auto-external": "^2.0.0",
-                "rollup-plugin-visualizer": "^6.0.3",
-                "socket.io": "^4.7.5",
-                "typescript": "~5.3.0",
-                "vite": "^5.4.20",
-                "vite-plugin-dts": "^3.9.1",
-                "vitest": "^1.6.1",
-                "vue": "^3.5.13",
-                "vue-tsc": "^1.8.27",
-                "wait-for-expect": "^3.0.2"
-            },
-            "peerDependencies": {
-                "dexie": "^4.0.11",
-                "vue": "^3.5.13"
-            }
-        },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -5613,8 +5562,22 @@
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/luminary-shared": {
-            "resolved": "../shared",
-            "link": true
+            "version": "0.0.3",
+            "resolved": "file:../shared",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/lodash.clonedeep": "^4.5.9",
+                "@types/lodash.isequal": "^4.5.8",
+                "@vueuse/core": "^10.11.0",
+                "lodash-es": "^4.17.21",
+                "luxon": "^3.4.4",
+                "socket.io-client": "^4.7.5",
+                "uuid": "^9.0.1"
+            },
+            "peerDependencies": {
+                "dexie": "^4.0.11",
+                "vue": "^3.5.13"
+            }
         },
         "node_modules/luxon": {
             "version": "3.5.0",
@@ -8385,6 +8348,20 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/vary": {

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -72,6 +72,57 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
+        "../shared": {
+            "name": "luminary-shared",
+            "version": "0.0.3",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/lodash.clonedeep": "^4.5.9",
+                "@types/lodash.isequal": "^4.5.8",
+                "@vueuse/core": "^10.11.0",
+                "lodash-es": "^4.17.21",
+                "luxon": "^3.4.4",
+                "socket.io-client": "^4.7.5",
+                "uuid": "^9.0.1"
+            },
+            "devDependencies": {
+                "@rushstack/eslint-patch": "^1.3.3",
+                "@tsconfig/node18": "^18.2.4",
+                "@types/jsdom": "^21.1.7",
+                "@types/lodash-es": "^4.17.12",
+                "@types/luxon": "^3.4.2",
+                "@types/node": "^18.19.3",
+                "@types/rollup-plugin-auto-external": "^2.0.5",
+                "@types/uuid": "^9.0.8",
+                "@vitejs/plugin-vue": "^5.0.4",
+                "@vitest/coverage-v8": "^1.6.1",
+                "@vue/eslint-config-prettier": "^8.0.0",
+                "@vue/eslint-config-typescript": "^12.0.0",
+                "@vue/test-utils": "^2.4.6",
+                "@vue/tsconfig": "^0.5.0",
+                "dexie": "^4.0.11",
+                "eslint": "^8.49.0",
+                "eslint-plugin-vue": "^9.17.0",
+                "express": "^4.21.2",
+                "fake-indexeddb": "^6.0.0",
+                "jsdom": "^24.1.3",
+                "prettier": "^3.0.3",
+                "rollup-plugin-auto-external": "^2.0.0",
+                "rollup-plugin-visualizer": "^6.0.3",
+                "socket.io": "^4.7.5",
+                "typescript": "~5.3.0",
+                "vite": "^5.4.20",
+                "vite-plugin-dts": "^3.9.1",
+                "vitest": "^1.6.1",
+                "vue": "^3.5.13",
+                "vue-tsc": "^1.8.27",
+                "wait-for-expect": "^3.0.2"
+            },
+            "peerDependencies": {
+                "dexie": "^4.0.11",
+                "vue": "^3.5.13"
+            }
+        },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -5562,22 +5613,8 @@
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/luminary-shared": {
-            "version": "0.0.3",
-            "resolved": "file:../shared",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/lodash.clonedeep": "^4.5.9",
-                "@types/lodash.isequal": "^4.5.8",
-                "@vueuse/core": "^10.11.0",
-                "lodash-es": "^4.17.21",
-                "luxon": "^3.4.4",
-                "socket.io-client": "^4.7.5",
-                "uuid": "^9.0.1"
-            },
-            "peerDependencies": {
-                "dexie": "^4.0.11",
-                "vue": "^3.5.13"
-            }
+            "resolved": "../shared",
+            "link": true
         },
         "node_modules/luxon": {
             "version": "3.5.0",
@@ -8348,20 +8385,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/vary": {

--- a/cms/src/components/content/ContentOverview/FilterOptionsDesktop.vue
+++ b/cms/src/components/content/ContentOverview/FilterOptionsDesktop.vue
@@ -9,9 +9,10 @@ import {
     UserGroupIcon,
     LanguageIcon,
     CloudArrowUpIcon,
+    CalendarDaysIcon,
 } from "@heroicons/vue/24/outline";
 import { type ContentOverviewQueryOptions } from "./types";
-import { type ContentDto, type GroupDto } from "luminary-shared";
+import { db, type ContentDto, type GroupDto } from "luminary-shared";
 import { computed, ref } from "vue";
 import LRadio from "@/components/forms/LRadio.vue";
 import LCombobox from "@/components/forms/LCombobox.vue";
@@ -41,6 +42,25 @@ const query = defineModel("query", { required: true });
 const showSearchIcon = computed(() => !String(query.value ?? "").length);
 
 const showSortOptions = ref(false);
+const showDateFilters = ref(false);
+
+/** ISO `datetime-local` string <-> epoch-ms bridge for the four date-range filter fields. */
+function dateRangeField(key: "publishedAfter" | "publishedBefore" | "expiresAfter" | "expiresBefore") {
+    return computed<string | undefined>({
+        get: () => {
+            const value = queryOptions.value[key];
+            return value ? db.toIsoDateTime(value) || undefined : undefined;
+        },
+        set: (val) => {
+            queryOptions.value[key] = val ? db.fromIsoDateTime(val) : undefined;
+        },
+    });
+}
+
+const publishedAfterString = dateRangeField("publishedAfter");
+const publishedBeforeString = dateRangeField("publishedBefore");
+const expiresAfterString = dateRangeField("expiresAfter");
+const expiresBeforeString = dateRangeField("expiresBefore");
 </script>
 
 <template>
@@ -183,6 +203,64 @@ const showSortOptions = ref(false);
                         </div>
                     </template>
                 </LDropdown>
+
+                <LDropdown
+                    v-model:show="showDateFilters"
+                    placement="bottom-end"
+                    padding="medium"
+                    width="auto"
+                    panel-class="!max-h-96"
+                    data-test="date-filters-display"
+                    class="h-full"
+                >
+                    <template #trigger>
+                        <LButton class="h-full" data-test="date-filters-toggle-btn">
+                            <CalendarDaysIcon class="h-full w-4" />
+                        </LButton>
+                    </template>
+
+                    <div class="flex w-64 flex-col gap-3">
+                        <div>
+                            <p class="mb-1 text-sm font-medium text-zinc-700">Published between</p>
+                            <div class="flex flex-col gap-1">
+                                <LInput
+                                    name="publishedAfter"
+                                    type="datetime-local"
+                                    label="From"
+                                    data-test="published-after-input"
+                                    v-model="publishedAfterString"
+                                />
+                                <LInput
+                                    name="publishedBefore"
+                                    type="datetime-local"
+                                    label="To"
+                                    data-test="published-before-input"
+                                    v-model="publishedBeforeString"
+                                />
+                            </div>
+                        </div>
+                        <div>
+                            <p class="mb-1 text-sm font-medium text-zinc-700">Expires between</p>
+                            <div class="flex flex-col gap-1">
+                                <LInput
+                                    name="expiresAfter"
+                                    type="datetime-local"
+                                    label="From"
+                                    data-test="expires-after-input"
+                                    v-model="expiresAfterString"
+                                />
+                                <LInput
+                                    name="expiresBefore"
+                                    type="datetime-local"
+                                    label="To"
+                                    data-test="expires-before-input"
+                                    v-model="expiresBeforeString"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </LDropdown>
+
                 <LButton @click="reset()" class="h-full w-10">
                     <ArrowUturnLeftIcon class="h-4 w-4" />
                 </LButton>

--- a/cms/src/components/content/ContentOverview/FilterOptionsMobile.vue
+++ b/cms/src/components/content/ContentOverview/FilterOptionsMobile.vue
@@ -10,7 +10,7 @@ import {
     CloudArrowUpIcon,
 } from "@heroicons/vue/24/outline";
 import { type ContentOverviewQueryOptions } from "./types";
-import type { ContentDto, GroupDto } from "luminary-shared";
+import { db, type ContentDto, type GroupDto } from "luminary-shared";
 import LButton from "@/components/button/LButton.vue";
 import LRadio from "@/components/forms/LRadio.vue";
 import LCombobox from "@/components/forms/LCombobox.vue";
@@ -40,12 +40,30 @@ const query = defineModel("query");
 const showSearchIcon = computed(() => !String(query.value ?? "").length);
 
 const showMobileQueryOptions = ref(false);
+
+/** ISO `datetime-local` string <-> epoch-ms bridge for the four date-range filter fields. */
+function dateRangeField(
+    key: "publishedAfter" | "publishedBefore" | "expiresAfter" | "expiresBefore",
+) {
+    return computed<string | undefined>({
+        get: () => {
+            const value = queryOptions.value[key];
+            return value ? db.toIsoDateTime(value) || undefined : undefined;
+        },
+        set: (val) => {
+            queryOptions.value[key] = val ? db.fromIsoDateTime(val) : undefined;
+        },
+    });
+}
+
+const publishedAfterString = dateRangeField("publishedAfter");
+const publishedBeforeString = dateRangeField("publishedBefore");
+const expiresAfterString = dateRangeField("expiresAfter");
+const expiresBeforeString = dateRangeField("expiresBefore");
 </script>
 
 <template>
-    <div
-        class="relative z-20 flex flex-col gap-1 overflow-visible"
-    >
+    <div class="relative z-20 flex flex-col gap-1 overflow-visible">
         <div class="flex h-10 w-full items-center gap-1">
             <LInput
                 type="text"
@@ -64,7 +82,11 @@ const showMobileQueryOptions = ref(false);
                     <slot name="searchButton"></slot>
                 </template>
             </LInput>
-            <LButton class="h-full" :icon="AdjustmentsVerticalIcon" @click="showMobileQueryOptions = true" />
+            <LButton
+                class="h-full"
+                :icon="AdjustmentsVerticalIcon"
+                @click="showMobileQueryOptions = true"
+            />
             <LButton class="h-full w-10" :icon="ArrowUturnLeftIcon" @click="reset()" />
         </div>
         <div
@@ -112,11 +134,12 @@ const showMobileQueryOptions = ref(false);
     </div>
     <LModal
         heading="Filter options"
+        :stick-to-edges="true"
         v-model:is-visible="showMobileQueryOptions"
         @keydown.esc="reset()"
         @keydown.enter="search()"
     >
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-2 pb-4">
             <LSelect
                 label="Translation Status"
                 data-test="filter-select"
@@ -160,7 +183,43 @@ const showMobileQueryOptions = ref(false);
                 :icon="UserGroupIcon"
             />
         </div>
-        <div class="mt-3">
+        <div class="flex flex-col gap-3 py-4">
+            <div class="flex flex-col gap-2">
+                <p class="text-sm font-medium text-zinc-700">Published between</p>
+                <LInput
+                    name="publishedAfter"
+                    type="datetime-local"
+                    label="From"
+                    data-test="published-after-input"
+                    v-model="publishedAfterString"
+                />
+                <LInput
+                    name="publishedBefore"
+                    type="datetime-local"
+                    label="To"
+                    data-test="published-before-input"
+                    v-model="publishedBeforeString"
+                />
+            </div>
+            <div class="flex flex-col gap-2">
+                <p class="text-sm font-medium text-zinc-700">Expires between</p>
+                <LInput
+                    name="expiresAfter"
+                    type="datetime-local"
+                    label="From"
+                    data-test="expires-after-input"
+                    v-model="expiresAfterString"
+                />
+                <LInput
+                    name="expiresBefore"
+                    type="datetime-local"
+                    label="To"
+                    data-test="expires-before-input"
+                    v-model="expiresBeforeString"
+                />
+            </div>
+        </div>
+        <div class="pt-4">
             <LSelect
                 label="Sort By"
                 data-test="filter-select"

--- a/cms/src/components/content/ContentOverview/__tests__/cmsLanguageSelector.spec.ts
+++ b/cms/src/components/content/ContentOverview/__tests__/cmsLanguageSelector.spec.ts
@@ -6,6 +6,7 @@ import {
     cmsLanguagePriority,
     translationStatusSelector,
     publishStatusSelector,
+    dateRangeSelector,
     isUntranslatedRow,
 } from "../cmsLanguageSelector";
 import { cmsLanguageIdAsRef, cmsDefaultLanguage, cmsLanguages } from "@/globalConfig";
@@ -153,6 +154,52 @@ describe("cmsLanguageSelector", () => {
             expect(publishStatusSelector("expired")).toEqual([
                 { status: PublishStatus.Published },
                 { expiryDate: { $lte: now } },
+            ]);
+        });
+    });
+
+    describe("dateRangeSelector", () => {
+        it("returns no clauses when no bound is set", () => {
+            expect(dateRangeSelector({})).toEqual([]);
+        });
+
+        it("adds a publishDate lower bound only when publishedAfter is set", () => {
+            expect(dateRangeSelector({ publishedAfter: 1000 })).toEqual([
+                { publishDate: { $gte: 1000 } },
+            ]);
+        });
+
+        it("adds a publishDate upper bound only when publishedBefore is set", () => {
+            expect(dateRangeSelector({ publishedBefore: 2000 })).toEqual([
+                { publishDate: { $lte: 2000 } },
+            ]);
+        });
+
+        it("adds an expiryDate lower bound only when expiresAfter is set", () => {
+            expect(dateRangeSelector({ expiresAfter: 3000 })).toEqual([
+                { expiryDate: { $gte: 3000 } },
+            ]);
+        });
+
+        it("adds an expiryDate upper bound only when expiresBefore is set", () => {
+            expect(dateRangeSelector({ expiresBefore: 4000 })).toEqual([
+                { expiryDate: { $lte: 4000 } },
+            ]);
+        });
+
+        it("combines all four bounds when all are set", () => {
+            expect(
+                dateRangeSelector({
+                    publishedAfter: 1000,
+                    publishedBefore: 2000,
+                    expiresAfter: 3000,
+                    expiresBefore: 4000,
+                }),
+            ).toEqual([
+                { publishDate: { $gte: 1000 } },
+                { publishDate: { $lte: 2000 } },
+                { expiryDate: { $gte: 3000 } },
+                { expiryDate: { $lte: 4000 } },
             ]);
         });
     });

--- a/cms/src/components/content/ContentOverview/__tests__/useContentBrowseQuery.spec.ts
+++ b/cms/src/components/content/ContentOverview/__tests__/useContentBrowseQuery.spec.ts
@@ -186,6 +186,38 @@ describe("useContentBrowseQuery", () => {
             scope.stop();
         });
 
+        it("filters by publishedAfter/publishedBefore range", async () => {
+            await db.bulkPut([
+                contentDoc({ _id: "in-range", publishDate: 500 }),
+                contentDoc({ _id: "too-early", publishDate: 100 }),
+                contentDoc({ _id: "too-late", publishDate: 900 }),
+            ]);
+
+            const { api, scope } = await run(
+                baseOptions({ publishedAfter: 400, publishedBefore: 600 }),
+            );
+            await waitForExpect(() => {
+                expect(api.docs.value.map((d) => d._id)).toEqual(["in-range"]);
+            });
+            scope.stop();
+        });
+
+        it("filters by expiresAfter/expiresBefore range", async () => {
+            await db.bulkPut([
+                contentDoc({ _id: "in-range", expiryDate: 500 }),
+                contentDoc({ _id: "too-early", expiryDate: 100 }),
+                contentDoc({ _id: "too-late", expiryDate: 900 }),
+            ]);
+
+            const { api, scope } = await run(
+                baseOptions({ expiresAfter: 400, expiresBefore: 600 }),
+            );
+            await waitForExpect(() => {
+                expect(api.docs.value.map((d) => d._id)).toEqual(["in-range"]);
+            });
+            scope.stop();
+        });
+
         it("combines tag + group + publish-status filters (AND, not OR)", async () => {
             await db.bulkPut([
                 contentDoc({

--- a/cms/src/components/content/ContentOverview/__tests__/useContentSearchQuery.spec.ts
+++ b/cms/src/components/content/ContentOverview/__tests__/useContentSearchQuery.spec.ts
@@ -118,3 +118,70 @@ describe("useContentSearchQuery strict-mode sorting", () => {
         scope.stop();
     });
 });
+
+describe("useContentSearchQuery date range filters", () => {
+    beforeEach(async () => {
+        await db.docs.clear();
+        await db.bulkPut([
+            contentDoc({
+                _id: "in-range",
+                title: "Garden A",
+                publishDate: 500,
+                expiryDate: 500,
+                fts: GARDEN_FTS,
+                ftsTokenCount: 4,
+            }),
+            contentDoc({
+                _id: "too-early",
+                title: "Garden B",
+                publishDate: 100,
+                expiryDate: 100,
+                fts: GARDEN_FTS,
+                ftsTokenCount: 4,
+            }),
+            contentDoc({
+                _id: "too-late",
+                title: "Garden C",
+                publishDate: 900,
+                expiryDate: 900,
+                fts: GARDEN_FTS,
+                ftsTokenCount: 4,
+            }),
+        ]);
+        await db.bulkPut(
+            Array.from({ length: 6 }, (_, i) =>
+                contentDoc({ _id: `noise-${i}`, title: `Other ${i}`, fts: ["xyz:1"], ftsTokenCount: 1 }),
+            ),
+        );
+        await recomputeCorpusStats();
+    });
+
+    async function run(options: ContentOverviewQueryOptions) {
+        const scope = effectScope();
+        let api!: ReturnType<typeof useContentSearchQuery>;
+        scope.run(() => {
+            api = useContentSearchQuery(() => options);
+        });
+        await new Promise((r) => setTimeout(r, 200));
+        await nextTick();
+        return { api, scope };
+    }
+
+    it("filters by publishedAfter/publishedBefore range", async () => {
+        const { api, scope } = await run(
+            baseOptions({ publishedAfter: 400, publishedBefore: 600 }),
+        );
+        await waitForExpect(() => {
+            expect(api.docs.value.map((d) => d._id)).toEqual(["in-range"]);
+        });
+        scope.stop();
+    });
+
+    it("filters by expiresAfter/expiresBefore range", async () => {
+        const { api, scope } = await run(baseOptions({ expiresAfter: 400, expiresBefore: 600 }));
+        await waitForExpect(() => {
+            expect(api.docs.value.map((d) => d._id)).toEqual(["in-range"]);
+        });
+        scope.stop();
+    });
+});

--- a/cms/src/components/content/ContentOverview/cmsLanguageSelector.ts
+++ b/cms/src/components/content/ContentOverview/cmsLanguageSelector.ts
@@ -131,3 +131,22 @@ export function publishStatusSelector(
     // expired
     return [{ status: PublishStatus.Published }, { expiryDate: { $lte: now } }];
 }
+
+/**
+ * Mango clauses (to be AND-ed) for the user-selectable publish/expiry date-range filters.
+ * Independent of {@link publishStatusSelector} — narrows further on top of whichever
+ * `publishStatus` is selected. Each bound is optional and only narrows when present.
+ */
+export function dateRangeSelector(
+    o: Pick<
+        ContentOverviewQueryOptions,
+        "publishedAfter" | "publishedBefore" | "expiresAfter" | "expiresBefore"
+    >,
+): MangoSelector[] {
+    const clauses: MangoSelector[] = [];
+    if (o.publishedAfter != null) clauses.push({ publishDate: { $gte: o.publishedAfter } });
+    if (o.publishedBefore != null) clauses.push({ publishDate: { $lte: o.publishedBefore } });
+    if (o.expiresAfter != null) clauses.push({ expiryDate: { $gte: o.expiresAfter } });
+    if (o.expiresBefore != null) clauses.push({ expiryDate: { $lte: o.expiresBefore } });
+    return clauses;
+}

--- a/cms/src/components/content/ContentOverview/types.ts
+++ b/cms/src/components/content/ContentOverview/types.ts
@@ -21,4 +21,12 @@ export type ContentOverviewQueryOptions = {
     tags?: Uuid[];
     groups?: Uuid[];
     search?: string;
+    /** Restrict to content with `publishDate >= publishedAfter`. */
+    publishedAfter?: number;
+    /** Restrict to content with `publishDate <= publishedBefore`. */
+    publishedBefore?: number;
+    /** Restrict to content with `expiryDate >= expiresAfter`. */
+    expiresAfter?: number;
+    /** Restrict to content with `expiryDate <= expiresBefore`. */
+    expiresBefore?: number;
 };

--- a/cms/src/components/content/ContentOverview/useContentBrowseQuery.ts
+++ b/cms/src/components/content/ContentOverview/useContentBrowseQuery.ts
@@ -9,6 +9,7 @@ import type { ContentOverviewQueryOptions } from "./types";
 import {
     translationStatusSelector,
     publishStatusSelector,
+    dateRangeSelector,
     isUntranslatedRow,
 } from "./cmsLanguageSelector";
 
@@ -67,6 +68,7 @@ export function useContentBrowseQuery(opts: () => ContentOverviewQueryOptions, l
             // in-memory `publishStatusFilter`, which rejected non-selected-language docs).
             if (publishStatus !== "all") clauses.push({ language: o.languageId });
             clauses.push(...publishStatusSelector(publishStatus));
+            clauses.push(...dateRangeSelector(o));
 
             return {
                 selector: { $and: clauses },

--- a/cms/src/components/content/ContentOverview/useContentSearchQuery.ts
+++ b/cms/src/components/content/ContentOverview/useContentSearchQuery.ts
@@ -50,6 +50,12 @@ export function useContentSearchQuery(
             f.status = PublishStatus.Published;
         else if (ps === "draft") f.status = PublishStatus.Draft;
 
+        // User-selectable date-range filters (independent of publishStatus).
+        if (o.publishedAfter != null) f.publishedAfter = o.publishedAfter;
+        if (o.publishedBefore != null) f.publishedBefore = o.publishedBefore;
+        if (o.expiresAfter != null) f.expiresAfter = o.expiresAfter;
+        if (o.expiresBefore != null) f.expiresBefore = o.expiresBefore;
+
         // Strict (default): substring AND on title/author. Ordered by the overview's sort
         // dropdown — except "relevance", which omits the field sort so the exact matches
         // rank by BM25. Related: omit matchAllWords/sort → fuzzy BM25 over all fields.

--- a/cms/src/components/modals/LModal.vue
+++ b/cms/src/components/modals/LModal.vue
@@ -116,7 +116,7 @@ const isMobileScreen = breakpoints.smaller("sm");
                 <div
                     :class="[
                         noDivider ? '' : 'divide-y divide-zinc-200',
-                        'flex min-h-0 flex-1 flex-col',
+                        'flex min-h-0 flex-1 flex-col overflow-y-auto',
                         noPadding ? (transparentHeader ? '-m-5' : '-m-5 mt-0') : '',
                     ]"
                 >

--- a/shared/src/api/RestApi.ts
+++ b/shared/src/api/RestApi.ts
@@ -28,6 +28,8 @@ export type ApiFtsQuery = {
     status?: PublishStatus;
     publishedAfter?: number;
     publishedBefore?: number;
+    expiresAfter?: number;
+    expiresBefore?: number;
     /** Strict mode: require every query word (≥3 chars) as a substring of the searchable fields. */
     matchAllWords?: boolean;
     /**

--- a/shared/src/fts/fts.spec.ts
+++ b/shared/src/fts/fts.spec.ts
@@ -477,6 +477,23 @@ describe("FTS Indexer and Search", () => {
             expect(ids).toEqual(["post-draft"]);
         });
 
+        it("filters by expiryDate bounds", async () => {
+            await ingestGarden({ _id: "expires-early", expiryDate: 1000 });
+            await ingestGarden({ _id: "expires-mid", expiryDate: 3000 });
+            await ingestGarden({ _id: "expires-late", expiryDate: 5000 });
+            await recomputeCorpusStats();
+
+            const ids = (
+                await ftsSearch({
+                    query: "garden",
+                    expiresAfter: 2000,
+                    expiresBefore: 4000,
+                    maxTrigramDocPercent: 100,
+                })
+            ).map((r) => r.docId);
+            expect(ids).toEqual(["expires-mid"]);
+        });
+
         it("combines filters (parity with the API path)", async () => {
             const ids = (
                 await ftsSearch({

--- a/shared/src/fts/ftsSearch.ts
+++ b/shared/src/fts/ftsSearch.ts
@@ -102,6 +102,8 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         status,
         publishedAfter,
         publishedBefore,
+        expiresAfter,
+        expiresBefore,
         matchAllWords,
         sort,
         limit = DEFAULT_LIMIT,
@@ -187,6 +189,13 @@ export async function ftsSearch(options: FtsSearchOptions): Promise<FtsSearchRes
         if (
             publishedBefore !== undefined &&
             !(doc.publishDate != null && doc.publishDate <= publishedBefore)
+        )
+            return;
+        if (expiresAfter !== undefined && !(doc.expiryDate != null && doc.expiryDate >= expiresAfter))
+            return;
+        if (
+            expiresBefore !== undefined &&
+            !(doc.expiryDate != null && doc.expiryDate <= expiresBefore)
         )
             return;
 

--- a/shared/src/fts/ftsSearchApi.spec.ts
+++ b/shared/src/fts/ftsSearchApi.spec.ts
@@ -39,7 +39,7 @@ describe("ftsSearchApi", () => {
         );
     });
 
-    it("forwards the type / tag / status / publishDate filters to the API query", async () => {
+    it("forwards the type / tag / status / publishDate / expiryDate filters to the API query", async () => {
         ftsMock.mockResolvedValue([]);
         await ftsSearchApi({
             query: "garden",
@@ -48,6 +48,8 @@ describe("ftsSearchApi", () => {
             status: "published" as any,
             publishedAfter: 100,
             publishedBefore: 200,
+            expiresAfter: 300,
+            expiresBefore: 400,
         });
         expect(ftsMock).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -56,6 +58,8 @@ describe("ftsSearchApi", () => {
                 status: "published",
                 publishedAfter: 100,
                 publishedBefore: 200,
+                expiresAfter: 300,
+                expiresBefore: 400,
             }),
         );
     });

--- a/shared/src/fts/ftsSearchApi.ts
+++ b/shared/src/fts/ftsSearchApi.ts
@@ -50,6 +50,8 @@ export async function ftsSearchApi(options: FtsSearchOptions): Promise<FtsSearch
         status: options.status,
         publishedAfter: options.publishedAfter,
         publishedBefore: options.publishedBefore,
+        expiresAfter: options.expiresAfter,
+        expiresBefore: options.expiresBefore,
         matchAllWords: options.matchAllWords,
         sort: options.sort,
         limit: options.limit,

--- a/shared/src/fts/types.ts
+++ b/shared/src/fts/types.ts
@@ -71,6 +71,10 @@ export type FtsSearchOptions = {
     publishedAfter?: number;
     /** Restrict to content with `publishDate <= publishedBefore`. */
     publishedBefore?: number;
+    /** Restrict to content with `expiryDate >= expiresAfter`. */
+    expiresAfter?: number;
+    /** Restrict to content with `expiryDate <= expiresBefore`. */
+    expiresBefore?: number;
     /**
      * Strict mode: keep only docs where every query word (≥3 chars) is a **substring**
      * of `title` or `author` (AND across words). Combined with {@link FtsSearchOptions.sort}

--- a/shared/src/fts/useFtsSearch.ts
+++ b/shared/src/fts/useFtsSearch.ts
@@ -19,6 +19,8 @@ export type FtsFilterOptions = {
     status?: PublishStatus;
     publishedAfter?: number;
     publishedBefore?: number;
+    expiresAfter?: number;
+    expiresBefore?: number;
     /** Strict mode: require every query word (≥3 chars) as a substring of title/author. */
     matchAllWords?: boolean;
     /** Strict mode: order by this field/direction instead of relevance. */


### PR DESCRIPTION
Closes the last gap in #1704 by mirroring the existing publishedAfter/publishedBefore filter with expiresAfter/expiresBefore across the API DTO/service, the shared client (FtsSearchOptions/FtsFilterOptions, ftsSearchApi, local offline search), and wires both into a new date-range picker in the CMS Content Overview filter UI (browse + search paths). Also fixes LModal's content wrapper, which had min-h-0 flex-1 but no overflow-y-auto, so a modal taller than the viewport couldn't scroll.

<img width="1377" height="493" alt="image" src="https://github.com/user-attachments/assets/947787d0-2fde-4cfd-8fdc-f1bb33eba584" />
