### PR TITLE
chore(env): remove deprecated env configuration

### DIFF
--- a/.github/workflows/api-deploy-staging.yml
+++ b/.github/workflows/api-deploy-staging.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           touch .env
           echo PORT=${{ vars.DOCKER_PORT }} >> .env
-          echo "JWT_SECRET='$( echo '${{ secrets.JWT_SECRET }}' )'" >> .env
           echo "DB_CONNECTION_STRING='$( echo '${{ secrets.DB_CONNECTION_STRING }}' )'" >> .env
           echo "DB_DATABASE='$( echo '${{ secrets.DB_DATABASE }}' )'" >> .env
           echo "ENCRYPTION_KEY='$( echo '${{ secrets.ENCRYPTION_KEY }}')'" >> .env
@@ -53,7 +52,6 @@ jobs:
           echo "S3_MEDIA_SECRET_KEY='$( echo '${{ secrets.S3_MEDIA_SECRET_KEY }}' )'" >> .env
           echo "S3_MEDIA_ENDPOINT='$( echo '${{ secrets.S3_MEDIA_ENDPOINT }}' )'" >> .env
           echo "CORS_ORIGIN='$( echo '${{ vars.CORS_ORIGIN }}' )'" >> .env
-          echo "JWT_MAPPINGS='$( echo '${{ vars.JWT_MAPPINGS }}' )'" >> .env
           echo "MAX_HTTP_BUFFER_SIZE='$( echo '${{ vars.MAX_HTTP_BUFFER_SIZE }}' )'" >> .env
 
         working-directory: api

--- a/api/.env.example
+++ b/api/.env.example
@@ -2,8 +2,6 @@ PORT=3000
 # 4174 = app, 4175 = CMS, 5173 = End to End tests
 CORS_ORIGIN=["http://localhost:4174","http://localhost:4175","https://examplewebsite.com","http://localhost:5173"]
 
-JWT_SECRET=""
-
 # encryption key for encrypting and decrypting sensitive data in the database
 ENCRYPTION_KEY="your-32-byte-encryption-key-here"
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -44,17 +44,6 @@ QUERY_RATE_LIMIT_STRIKE_DECAY_MS=600000
 # traffic shares one bucket (the proxy's IP).
 TRUST_PROXY=false
 
-# Mapping between Auth0 Javascript Web Token data and group and user assignments. All mappings are optional.
-JWT_MAPPINGS='{
-    "groups": {
-        "group-private-users": "(jwt) => jwt && jwt[\"https://your.app/metadata\"].hasMembership === true",
-        "group-public-users": "(jwt) => !jwt"
-    },
-    "userId": "(jwt) => jwt && jwt[\"https://your.app/metadata\"].userId",
-    "email": "(jwt) => jwt && jwt[\"https://your.app/metadata\"].email",
-    "name": "(jwt) => jwt && jwt[\"https://your.app/metadata\"].username"
-}'
-
 # Image Processing Configuration
 # Image quality for processed uploads (0-100, default: 80)
 S3_IMG_QUALITY=80

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -75,7 +75,7 @@ Multi-provider OIDC. `AuthProvider` documents in the DB define each provider (do
 
 **Failure-reason codes** (`AuthFailureReason`) are critical for client behavior: `provider_not_found` tells the client to evict its cached provider doc and re-pick; `token_invalid` triggers a similar eviction so Dexie can resync. The Socket.io gateway in `socketio.ts` injects these into `connect_error` payloads; the REST `AuthGuard` does the equivalent via `UnauthorizedException`.
 
-The `JwtModule` is registered globally in `app.module.ts` (no signing secret — tokens are verified against each provider's JWKS, not a shared secret). Group-membership and identity claims are derived from the claim/group mappings stored on each `AuthProvider` doc and evaluated by `AuthIdentityService` (plus `AutoGroupMappings` docs) — the legacy `JWT_SECRET`/`JWT_MAPPINGS` env vars are gone.
+The `JwtModule` is registered globally in `app.module.ts` with no signing secret — tokens are verified against each provider's JWKS. Group-membership and identity claims are derived from the claim/group mappings stored on each `AuthProvider` doc and evaluated by `AuthIdentityService` (plus `AutoGroupMappings` docs).
 
 ### Socket.io (`src/socketio.ts`)
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -75,7 +75,7 @@ Multi-provider OIDC. `AuthProvider` documents in the DB define each provider (do
 
 **Failure-reason codes** (`AuthFailureReason`) are critical for client behavior: `provider_not_found` tells the client to evict its cached provider doc and re-pick; `token_invalid` triggers a similar eviction so Dexie can resync. The Socket.io gateway in `socketio.ts` injects these into `connect_error` payloads; the REST `AuthGuard` does the equivalent via `UnauthorizedException`.
 
-The `JwtModule` is registered globally in `app.module.ts`. Group-membership and identity claims are derived from arrow-function strings in `JWT_MAPPINGS` env var — these are `eval`-equivalent so the env value is trusted config.
+The `JwtModule` is registered globally in `app.module.ts` (no signing secret — tokens are verified against each provider's JWKS, not a shared secret). Group-membership and identity claims are derived from the claim/group mappings stored on each `AuthProvider` doc and evaluated by `AuthIdentityService` (plus `AutoGroupMappings` docs) — the legacy `JWT_SECRET`/`JWT_MAPPINGS` env vars are gone.
 
 ### Socket.io (`src/socketio.ts`)
 

--- a/api/src/configuration.ts
+++ b/api/src/configuration.ts
@@ -1,8 +1,3 @@
-export type AuthConfig = {
-    jwtSecret: string;
-    jwtMappings: string;
-};
-
 export type DatabaseConfig = {
     connectionString: string;
     database: string;
@@ -104,7 +99,6 @@ export type Configuration = {
     permissionMap: string;
     s3?: S3Config;
     s3Audio?: AudioS3Config;
-    auth?: AuthConfig;
     database?: DatabaseConfig;
     sync?: SyncConfig;
     query?: QueryConfig;
@@ -115,10 +109,6 @@ export type Configuration = {
 
 export default () =>
     ({
-        auth: {
-            jwtSecret: process.env.JWT_SECRET,
-            jwtMappings: process.env.JWT_MAPPINGS,
-        } as AuthConfig,
         database: {
             connectionString: process.env.DB_CONNECTION_STRING,
             database: process.env.DB_DATABASE,

--- a/api/src/configuration.ts
+++ b/api/src/configuration.ts
@@ -96,7 +96,6 @@ export type SocketIoConfig = {
 };
 
 export type Configuration = {
-    permissionMap: string;
     s3?: S3Config;
     s3Audio?: AudioS3Config;
     database?: DatabaseConfig;
@@ -130,7 +129,6 @@ export default () =>
                 strikeDecayMs: parseInt(process.env.QUERY_RATE_LIMIT_STRIKE_DECAY_MS, 10) || 600000,
             },
         } as QueryConfig,
-        permissionMap: process.env.PERMISSION_MAP,
         imageProcessing: {
             imageQuality: parseInt(process.env.S3_IMG_QUALITY, 10) || 80,
         } as ImageProcessingConfig,

--- a/api/src/endpoints/changeRequest.service.spec.ts
+++ b/api/src/endpoints/changeRequest.service.spec.ts
@@ -13,7 +13,7 @@ describe("ChangeRequest service", () => {
 
     beforeAll(async () => {
         service = (await createTestingModule("changereq-service")).dbService;
-        changeRequestService = new ChangeRequestService(undefined, service);
+        changeRequestService = new ChangeRequestService(service);
 
         mockUserDetails = {
             userId: "user-super-admin",

--- a/api/src/endpoints/changeRequest.service.ts
+++ b/api/src/endpoints/changeRequest.service.ts
@@ -5,25 +5,17 @@ import { AckStatus, AclPermission, DocType, Uuid } from "../enums";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { Logger } from "winston";
 import { JwtUserDetails } from "../auth/authIdentity.service";
-import configuration, { Configuration } from "../configuration";
 import { processChangeRequest } from "../changeRequests/processChangeRequest";
 import { ChangeReqAckDto } from "../dto/ChangeReqAckDto";
 import { PermissionSystem } from "../permissions/permissions.service";
 
 @Injectable()
 export class ChangeRequestService {
-    private readonly test: any = [];
-    private permissionMap: any;
-    private config: Configuration;
-
     constructor(
         @Inject(WINSTON_MODULE_PROVIDER)
         private readonly logger: Logger,
         private db: DbService,
-    ) {
-        // Create config object with environmental variables
-        this.config = configuration();
-    }
+    ) {}
 
     async changeRequest(
         changeRequest: ChangeReqDto,

--- a/api/src/endpoints/changeRequest.service.ts
+++ b/api/src/endpoints/changeRequest.service.ts
@@ -1,9 +1,7 @@
 import { ChangeReqDto } from "../dto/ChangeReqDto";
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { DbService } from "../db/db.service";
 import { AckStatus, AclPermission, DocType, Uuid } from "../enums";
-import { WINSTON_MODULE_PROVIDER } from "nest-winston";
-import { Logger } from "winston";
 import { JwtUserDetails } from "../auth/authIdentity.service";
 import { processChangeRequest } from "../changeRequests/processChangeRequest";
 import { ChangeReqAckDto } from "../dto/ChangeReqAckDto";
@@ -11,11 +9,7 @@ import { PermissionSystem } from "../permissions/permissions.service";
 
 @Injectable()
 export class ChangeRequestService {
-    constructor(
-        @Inject(WINSTON_MODULE_PROVIDER)
-        private readonly logger: Logger,
-        private db: DbService,
-    ) {}
+    constructor(private db: DbService) {}
 
     async changeRequest(
         changeRequest: ChangeReqDto,

--- a/api/src/socketio.spec.ts
+++ b/api/src/socketio.spec.ts
@@ -30,15 +30,6 @@ describe("Socketio", () => {
     beforeAll(async () => {
         process.env = { ...oldEnv };
 
-        process.env.JWT_MAPPINGS = `{
-            "groups": {
-                "group-super-admins": "() => true"
-            },
-            "userId": "() => 'user-super-admin'",
-            "email": "() => 'test@123.com'",
-            "name": "() => 'Test User'"
-        }`;
-
         app = await createNestApp();
         await app.listen(process.env.PORT);
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -56,7 +56,7 @@ UI strings live in CouchDB Language documents, loaded at runtime (`src/i18n.ts`)
 
 ### Plugins
 
-`VITE_PLUGIN_PATH` env var points to an out-of-tree plugins folder. The Vite + Vitest configs copy `$VITE_PLUGIN_PATH/*` into `src/plugins/` at the start of every `dev`, `build`, and `test` run. `VITE_PLUGINS` is a JSON array of plugin names to load. Plugin filename must equal the exported class name. Full contract + injection-key + build-time virtual module pattern, diagrams, and a second-plugin walkthrough: `docs/vue-plugin-architecture/README.md`.
+Full contract + injection-key + build-time virtual module pattern, diagrams, and a second-plugin walkthrough: `docs/vue-plugin-architecture/README.md`.
 
 ### Query string parameters
 

--- a/app/src/components/navigation/navigationItems.ts
+++ b/app/src/components/navigation/navigationItems.ts
@@ -11,7 +11,7 @@ import {
  * computed/watcher (outside a setup context), where `useI18n()` would throw.
  */
 export function getNavigationItems(t: (key: string) => string) {
-    const navigationItems = [
+    return [
         {
             name: t("menu.home"),
             defaultIcon: HomeIcon,

--- a/app/src/components/navigation/navigationItems.ts
+++ b/app/src/components/navigation/navigationItems.ts
@@ -38,5 +38,4 @@ export function getNavigationItems(t: (key: string) => string) {
         },
     ];
 
-    return navigationItems;
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -34,13 +34,6 @@ export const app = createApp(App);
 // resolve a store (e.g. useNotificationStore) have an active Pinia instance.
 app.use(createPinia());
 
-if (import.meta.env.VITE_FAV_ICON) {
-    const favicon = document.getElementById("favicon") as HTMLLinkElement;
-    if (favicon) {
-        favicon.href = import.meta.env.VITE_LOGO_FAVICON;
-    }
-}
-
 initSentry(app);
 
 /**

--- a/cms/.env.example
+++ b/cms/.env.example
@@ -10,8 +10,6 @@ VITE_LOGO_FAVICON="src/assets/favicon.png"
 # Set to "true" to bypass Auth0 authentication (for development and E2E testing)
 VITE_AUTH_BYPASS=false
 
-VITE_HIDE_PRIVACY_POLICY=false
-
 VITE_SENTRY_DSN=
 
 # This is a temporary solution until a main page/dashboard is created

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -23,13 +23,6 @@ const app = createApp(App);
 // resolve a store (e.g. useNotificationStore) have an active Pinia instance.
 app.use(createPinia());
 
-if (import.meta.env.VITE_FAV_ICON) {
-    const favicon = document.getElementById("favicon") as HTMLLinkElement;
-    if (favicon) {
-        favicon.href = import.meta.env.VITE_LOGO_FAVICON;
-    }
-}
-
 if (import.meta.env.PROD) {
     Sentry.init({
         app,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,18 +107,11 @@ Auth0 handles user authentication (login/logout) for Luminary. You'll need to cr
 4. Click **Create**
 5. Copy the **Identifier** → This is your `AUTH0_AUDIENCE`
 
-### Step 4: Get Your JWT Secret
-
-1. In your API settings (from Step 3), click the **Test** tab
-2. Scroll down to find your **Access Token** or **Certificate**
-3. Copy this value → This is your `JWT_SECRET`
-
 **That's it!** The setup wizard will ask you for these values:
 
 - `AUTH0_DOMAIN` - From Application Settings
 - `AUTH0_CLIENT_ID` - From Application Settings
 - `AUTH0_AUDIENCE` - From API Identifier
-- `JWT_SECRET` - From API Test tab
 
 ## 🔑 Environment Variables
 
@@ -133,12 +126,6 @@ The setup wizard configures environment variables across three sub-projects: **a
 The wizard will ask you for these values. Here's what each one does:
 
 ### For the API
-
-**`JWT_SECRET`** - The secret key for verifying user tokens
-
-- Can be single-line or multi-line
-- Where to find it: Auth0 Dashboard → Applications → APIs → Your API → Test tab
-- The wizard supports pasting multi-line certificates
 
 **`ENCRYPTION_KEY`** - For encrypting sensitive data in the database
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -34,8 +34,6 @@ info "Detected platform: $PLATFORM"
 : "${LUMINARY_MINIO_ROOT_USER:=minio}"
 : "${LUMINARY_MINIO_ROOT_PASSWORD:=minio123}"
 
-JWT_MAPPINGS_JSON='{"groups":{"group-super-admins":"(jwt) => true"},"userId":"(jwt) => jwt && jwt[\"https://luminary-dev.com/metadata\"].userId","email":"(jwt) => jwt && jwt[\"https://luminary-dev.com/metadata\"].email","name":"(jwt) => jwt && jwt[\"https://luminary-dev.com/metadata\"].username"}'
-
 # ============================================================
 # PREREQUISITE CHECKS
 # ============================================================
@@ -151,13 +149,6 @@ setup_env_wizard() {
   echo ""
 }
 
-escape_env_value() {
-  python3 -c 'import sys
-value = sys.stdin.read()
-value = value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
-sys.stdout.write(value)' <<<"$1"
-}
-
 upsert_env_var() {
   local file="$1"
   local key="$2"
@@ -179,88 +170,10 @@ ensure_trailing_newline() {
   fi
 }
 
-remove_env_block() {
-  local file="$1"
-  local key="$2"
-  local end_regex="$3"
-
-  awk -v key="$key" -v end_regex="$end_regex" '
-    BEGIN { skip=0 }
-    $0 ~ "^" key "=" { skip=1; next }
-    skip==1 {
-      if ($0 ~ end_regex) { skip=0 }
-      next
-    }
-    { print }
-  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-}
-
-prompt_multiline_value() {
-  local prompt="$1"
-  local value=""
-
-  info "$prompt" >&2
-  info "Paste the value now." >&2
-  info "Finish by typing END on its own line and pressing Enter, or press Ctrl+D." >&2
-
-  while IFS= read -r line; do
-    if [[ "$line" == "END" ]]; then
-      break
-    fi
-    value+="$line"$'\n'
-  done || true
-
-  value="${value%$'\n'}"
-  echo "$value"
-}
-
-prompt_jwt_secret() {
-  local jwt_secret=""
-  local use_multiline=""
-
-  echo "" >&2
-  echo "==================================================================" >&2
-  echo "JWT Secret Configuration" >&2
-  echo "==================================================================" >&2
-  info "JWT_SECRET: The secret key used to sign and verify JWT tokens." >&2
-  info "  This is typically obtained from your Auth0 application settings" >&2
-  info "  under Advanced Settings > Certificates or can be your own secret." >&2
-  info "  Can be a single-line string or a multi-line PEM certificate." >&2
-  warn "Keep this secret secure - never commit it to version control!" >&2
-
-  while [[ ! "$use_multiline" =~ ^[YyNn]$ ]]; do
-    read -rp "Use multiline input? (y/n): " -n 1 -r use_multiline
-    echo "" >&2
-  done
-
-  if [[ "$use_multiline" =~ ^[Yy]$ ]]; then
-    info "Waiting for JWT_SECRET input..." >&2
-    jwt_secret=$(prompt_multiline_value "Paste JWT_SECRET")
-  else
-    read -rp "JWT_SECRET (single line): " jwt_secret
-  fi
-
-  echo "$jwt_secret"
-}
-
 apply_api_env_defaults() {
   local output_file="$1"
 
   sync_credentials_from_docker
-
-  if grep -q "JWT_SECRET" "$output_file"; then
-    remove_env_block "$output_file" "JWT_SECRET" '"$'
-    local jwt_secret=""
-    while [[ -z "$jwt_secret" ]]; do
-      jwt_secret=$(prompt_jwt_secret)
-      if [[ -z "$jwt_secret" ]]; then
-        warn "JWT_SECRET cannot be empty."
-      fi
-    done
-    local jwt_secret_escaped
-    jwt_secret_escaped=$(escape_env_value "$jwt_secret")
-    upsert_env_var "$output_file" "JWT_SECRET" "\"$jwt_secret_escaped\""
-  fi
 
   if grep -q "ENCRYPTION_KEY" "$output_file"; then
     local encryption_key=""
@@ -281,9 +194,6 @@ apply_api_env_defaults() {
     done
     upsert_env_var "$output_file" "ENCRYPTION_KEY" "\"$encryption_key\""
   fi
-
-  remove_env_block "$output_file" "JWT_MAPPINGS" "}'$"
-  upsert_env_var "$output_file" "JWT_MAPPINGS" "'$JWT_MAPPINGS_JSON'"
 
   local db_connection
   db_connection="http://${LUMINARY_COUCHDB_USER}:${LUMINARY_COUCHDB_PASSWORD}@127.0.0.1:5984"


### PR DESCRIPTION
Remove legacy JWT_MAPPINGS from API env examples because auth mappings now live in AuthProvider and AutoGroupMappings docs.

Drop unused PERMISSION_MAP configuration and the dead ChangeRequestService config fields that only existed to read it.

Remove no-op VITE_FAV_ICON runtime favicon updates from app and CMS because index.html already uses VITE_LOGO_FAVICON.

Remove CMS VITE_HIDE_PRIVACY_POLICY from the example env because CMS never reads it.

Delete stale app plugin env guidance for VITE_PLUGIN_PATH and VITE_PLUGINS because plugin targets are now wired in buildTargetVirtuals.

Remove dangling navigationItems return left by the existing branch cleanup.

Verified:
- api: npm run typecheck
- cms: npm run type-check

Note: app typecheck still fails due stale local luminary-shared installed types missing pruneUnsyncedLanguageContent; shared/src and shared/dist already export it.