### PR TITLE
fix(app): deduplicate related-content items across topic rows

### DIFF
--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -37,7 +37,7 @@ const filtered = computed(() =>
     contentDocs.value.filter((item) => item._id !== props.selectedContent._id),
 );
 
-const contentByTopic = contentByTag(filtered, toRef(props.tags));
+const contentByTopic = contentByTag(filtered, toRef(props.tags), { dedupeAcrossTags: true });
 </script>
 
 <template>

--- a/app/src/components/contentByTag.spec.ts
+++ b/app/src/components/contentByTag.spec.ts
@@ -135,4 +135,48 @@ describe("contentByTag", () => {
             expect(resultWithoutUntagged.untagged.value).toEqual([]);
         });
     });
+
+    it("dedupes content across tags when dedupeAcrossTags is true, favoring the niche tag", async () => {
+        // "1" and "2" both belong to "a" (broad, 3 matches) and "b" (niche, 2 matches).
+        // "3" only belongs to "a".
+        const content = ref([
+            { _id: "1", publishDate: 1, parentTags: ["a", "b"] } as ContentDto,
+            { _id: "2", publishDate: 2, parentTags: ["a", "b"] } as ContentDto,
+            { _id: "3", publishDate: 3, parentTags: ["a"] } as ContentDto,
+        ]);
+        const tags = ref([
+            { _id: "a", parentId: "a" } as ContentDto,
+            { _id: "b", parentId: "b" } as ContentDto,
+        ]);
+
+        const result = contentByTag(content, tags, { dedupeAcrossTags: true });
+
+        await waitForExpect(() => {
+            const byTagId = Object.fromEntries(
+                result.tagged.value.map((r) => [r.tag._id, r.content.map((c) => c._id)]),
+            );
+            // "b" has fewer matches, so it claims "1" and "2" first.
+            expect(byTagId["b"]).toEqual(["1", "2"]);
+            // "a" is left with only the content "b" didn't claim.
+            expect(byTagId["a"]).toEqual(["3"]);
+        });
+    });
+
+    it("does not dedupe across tags by default", async () => {
+        const content = ref([{ _id: "1", publishDate: 1, parentTags: ["a", "b"] } as ContentDto]);
+        const tags = ref([
+            { _id: "a", parentId: "a" } as ContentDto,
+            { _id: "b", parentId: "b" } as ContentDto,
+        ]);
+
+        const result = contentByTag(content, tags);
+
+        await waitForExpect(() => {
+            const byTagId = Object.fromEntries(
+                result.tagged.value.map((r) => [r.tag._id, r.content.map((c) => c._id)]),
+            );
+            expect(byTagId["a"]).toEqual(["1"]);
+            expect(byTagId["b"]).toEqual(["1"]);
+        });
+    });
 });

--- a/app/src/components/contentByTag.ts
+++ b/app/src/components/contentByTag.ts
@@ -16,7 +16,7 @@ export type ContentByTag = {
 export const contentByTag = (
     content: Ref<ContentDto[]> | ShallowRef<ContentDto[]>,
     tags: Ref<ContentDto[]> | ShallowRef<ContentDto[]>,
-    options: { includeUntagged?: boolean } = {},
+    options: { includeUntagged?: boolean; dedupeAcrossTags?: boolean } = {},
 ) => {
     const result = {
         tagged: ref<ContentByTag[]>([]),
@@ -33,11 +33,29 @@ export const contentByTag = (
                 }
             }
 
+            const matchesTag = (c: ContentDto, tag: ContentDto) =>
+                !!c.publishDate && !!c.parentTags && c.parentTags.includes(tag.parentId);
+
+            // When deduping, process the tag with the fewest matches first so a broad
+            // tag (e.g. "People in the Bible") doesn't claim items a niche tag needs.
+            const tagOrder = options.dedupeAcrossTags
+                ? [...tags.value].sort(
+                      (a, b) =>
+                          content.value.filter((c) => matchesTag(c, a)).length -
+                          content.value.filter((c) => matchesTag(c, b)).length,
+                  )
+                : tags.value;
+            const claimed = new Set<string>();
+
             // Add new tags to the result
-            tags.value.forEach((tag) => {
+            tagOrder.forEach((tag) => {
                 const filtered = content.value.filter(
-                    (c) => c.publishDate && c.parentTags && c.parentTags.includes(tag.parentId),
+                    (c) => matchesTag(c, tag) && !claimed.has(c._id),
                 );
+
+                if (options.dedupeAcrossTags) {
+                    filtered.forEach((c) => claimed.add(c._id));
+                }
 
                 const isPinned = tag.parentPinned && tag.parentPinned > 0;
 


### PR DESCRIPTION
## Summary
- The app's "Related" section on a content page shows one horizontal row per topic tag (e.g. "People in the Bible", "Heroes of faith"). Any item tagged with multiple topics was repeated verbatim in every matching row — same thumbnails, same order, no added value.
- `contentByTag` gains an opt-in `dedupeAcrossTags` option: it claims each content item for a single row, processing topics in ascending order of match count so a broad topic doesn't swallow items a niche topic needs.
- `RelatedContent.vue` is the only consumer that opts in. The five other callers (`HomePagePinned`, `PinnedVideo`, `UnpinnedVideo`, `PinnedTopics`, `UnpinnedTopics`) call the helper with no options, so their behavior (intentional duplication across topic browsing) is unchanged.

## Why
Fixes #1737 — related-content rows currently duplicate the same content across categories instead of surfacing distinct related items, which undermines the "related content" section's purpose of encouraging further reading.

## Test plan
- [x] `npx vitest run src/components/contentByTag.spec.ts` — 4/4 passing, including two new cases covering dedup-on and default (dedup-off) behavior
- [x] `npx vitest run src/components/content/RelatedContent.spec.ts` — 5/5 passing (unchanged)
- [x] `npx eslint` on the three changed files — clean
- [ ] Manual check in the browser that a post with overlapping topics no longer repeats items across rows (not yet done in this session)
