### PR TITLE
feat(cms): notify editors of concurrent server changes (#932)

### DIFF
--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1310,7 +1310,7 @@ describe("EditContent.vue", () => {
             // Reviewing opens the read-only diff modal.
             await wrapper.find('[data-test="incoming-changes-review"]').trigger("click");
             expect(wrapper.findComponent(IncomingChangesModal).props("open")).toBe(true);
-        });
+        }, 15000);
 
         it("does not show the banner when a remote change arrives with no local edits", async () => {
             const wrapper = mount(EditContent, {

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -25,6 +25,7 @@ import RichTextEditor from "../editor/RichTextEditor.vue";
 import EditContentText from "./EditContentText.vue";
 import LoadingBar from "../LoadingBar.vue";
 import EditContentVideo from "./EditContentVideo.vue";
+import IncomingChangesModal from "./IncomingChangesModal.vue";
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -1271,6 +1272,69 @@ describe("EditContent.vue", () => {
             await waitForExpect(() => {
                 expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
             });
+        });
+    });
+
+    describe("incoming server changes", () => {
+        it("shows the banner when the doc is changed remotely while the user is editing", async () => {
+            const wrapper = mount(EditContent, {
+                props: {
+                    docType: DocType.Post,
+                    id: mockData.mockPostDto._id,
+                    languageCode: "eng",
+                    tagOrPostType: PostType.Blog,
+                },
+            });
+
+            await waitForExpect(() => {
+                expect(wrapper.find('input[name="title"]').exists()).toBe(true);
+            });
+
+            // Local edit → dirty. Confirm via the revert button before pushing the remote change.
+            await wrapper.find('input[name="title"]').setValue("My local title");
+            await waitForExpect(() => {
+                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(true);
+            });
+
+            // Someone else changes a different field on the same content doc.
+            await db.docs.put({
+                ...mockData.mockEnglishContentDto,
+                author: "Remote Author",
+                updatedTimeUtc: Date.now(),
+            } as ContentDto);
+
+            await waitForExpect(() => {
+                expect(wrapper.find('[data-test="incoming-changes-banner"]').exists()).toBe(true);
+            });
+
+            // Reviewing opens the read-only diff modal.
+            await wrapper.find('[data-test="incoming-changes-review"]').trigger("click");
+            expect(wrapper.findComponent(IncomingChangesModal).props("open")).toBe(true);
+        });
+
+        it("does not show the banner when a remote change arrives with no local edits", async () => {
+            const wrapper = mount(EditContent, {
+                props: {
+                    docType: DocType.Post,
+                    id: mockData.mockPostDto._id,
+                    languageCode: "eng",
+                    tagOrPostType: PostType.Blog,
+                },
+            });
+
+            await waitForExpect(() => {
+                expect(wrapper.find('input[name="title"]').exists()).toBe(true);
+            });
+
+            // Remote change with no local edits: toEditable folds it in silently (no conflict).
+            await db.docs.put({
+                ...mockData.mockEnglishContentDto,
+                author: "Remote Author",
+                updatedTimeUtc: Date.now(),
+            } as ContentDto);
+            await wait(100); // let the live query propagate the change in
+
+            expect(wrapper.find('[data-test="incoming-changes-banner"]').exists()).toBe(false);
         });
     });
 });

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -42,6 +42,8 @@ import { DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import { clientAppUrl, cmsLanguages } from "@/globalConfig";
 import EditContentImage from "./EditContentImage.vue";
 import EditContentMedia from "./EditContentMedia.vue";
+import IncomingChangesModal from "./IncomingChangesModal.vue";
+import { ArrowPathIcon, ExclamationTriangleIcon } from "@heroicons/vue/20/solid";
 import LCard from "@/components/common/LCard.vue";
 import EditContentActionsWrapper from "./EditContentActionsWrapper.vue";
 import { TrashIcon } from "@heroicons/vue/24/outline";
@@ -83,15 +85,24 @@ const {
     newDocument,
     editableParent,
     editableContent,
+    existingParent,
     existingContent,
     isDirty,
     isParentDirty,
     isContentItemDirty,
     hasLocalChanges,
+    hasIncomingChanges,
+    isIncomingChange,
     isLoading,
 } = source;
 
 const showDeleteModal = ref(false);
+
+// Concurrent-edit conflict UI: banner + read-only diff modal (ticket #932). Detection is driven by
+// `hasIncomingChanges` (toEditable `isModified` under the hood); "Use server version" reloads so the
+// composable's load() re-reads the fresh doc already in Dexie, discarding the user's unsaved edits.
+const showIncomingModal = ref(false);
+const acceptServerVersion = () => window.location.reload();
 
 const icon = props.docType === DocType.Tag ? TagIcon : DocumentIcon;
 
@@ -467,6 +478,24 @@ const actionsWrapperProps = computed(() => ({
         <template #topBarActionsDesktop>
             <EditContentActionsWrapper v-bind="actionsWrapperProps" :mobile="false" />
         </template>
+        <!-- Concurrent-edit warning: someone else changed this doc on the server while we hold edits. -->
+        <div
+            v-if="hasIncomingChanges"
+            data-test="incoming-changes-banner"
+            class="mx-2 mb-2 mt-2 flex items-center gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800 lg:mx-8"
+        >
+            <ExclamationTriangleIcon class="h-5 w-5 flex-shrink-0 text-yellow-500" />
+            <span>This document was changed remotely by someone else.</span>
+            <button
+                type="button"
+                class="ml-auto flex items-center gap-1 whitespace-nowrap font-medium text-yellow-900 underline hover:text-yellow-950"
+                data-test="incoming-changes-review"
+                @click="showIncomingModal = true"
+            >
+                <ArrowPathIcon class="h-4 w-4" />
+                Review changes
+            </button>
+        </div>
         <div
             class="flex flex-col gap-0 lg:h-full lg:min-h-0 lg:flex-row lg:gap-2 lg:overflow-hidden lg:pl-8"
         >
@@ -639,6 +668,16 @@ const actionsWrapperProps = computed(() => ({
 
     <!-- modals -->
     <ConfirmBeforeLeavingModal :isDirty="isDirty && !editableParent?.deleteReq" />
+    <IncomingChangesModal
+        v-model:open="showIncomingModal"
+        :existingParent="existingParent"
+        :editableParent="editableParent"
+        :existingContent="existingContent"
+        :editableContent="editableContent"
+        :isIncomingChange="isIncomingChange"
+        @accept="acceptServerVersion"
+        @dismiss="showIncomingModal = false"
+    />
     <LDialog
         v-model:open="showDeleteModal"
         :title="`Delete ${props.tagOrPostType} and all translations`"

--- a/cms/src/components/content/IncomingChangesModal.vue
+++ b/cms/src/components/content/IncomingChangesModal.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import LDialog from "@/components/common/LDialog.vue";
+import { cmsLanguages } from "@/globalConfig";
+import type { ContentDto, ContentParentDto, Uuid } from "luminary-shared";
+import { computed } from "vue";
+import * as _ from "lodash";
+
+type Props = {
+    existingParent?: ContentParentDto;
+    editableParent?: ContentParentDto;
+    existingContent?: ContentDto[];
+    editableContent: ContentDto[];
+    /** Filters to only the docs that changed on the server (parent + content), keyed by `_id`. */
+    isIncomingChange: (id: Uuid) => boolean;
+};
+const props = defineProps<Props>();
+
+const open = defineModel<boolean>("open");
+
+const emit = defineEmits<{
+    /** User chose the server version — the caller reloads to discard local edits. */
+    accept: [];
+    /** User chose to keep their edits — dismiss and continue. */
+    dismiss: [];
+}>();
+
+// Meta fields never represent a meaningful user-visible change.
+const META = ["_rev", "updatedTimeUtc", "updatedBy"];
+
+/** Render a value for the diff list: primitives inline (strings capped), everything else "(changed)". */
+function fmt(v: unknown): string {
+    if (v === undefined || v === null || v === "") return "—";
+    if (typeof v === "string") return v.length > 120 ? v.slice(0, 120) + "…" : v;
+    if (typeof v === "number" || typeof v === "boolean") return String(v);
+    return "(changed)";
+}
+
+type Row = { field: string; server: string; mine: string };
+
+/** Top-level keys where the server (`server`) and the user's copy (`mine`) disagree. */
+function changedFields(server: Record<string, unknown>, mine: Record<string, unknown>): Row[] {
+    const keys = new Set([...Object.keys(server ?? {}), ...Object.keys(mine ?? {})]);
+    const rows: Row[] = [];
+    for (const key of keys) {
+        if (META.includes(key)) continue;
+        if (_.isEqual(server?.[key], mine?.[key])) continue;
+        rows.push({ field: key, server: fmt(server?.[key]), mine: fmt(mine?.[key]) });
+    }
+    return rows;
+}
+
+function languageName(languageId: Uuid): string {
+    return cmsLanguages.value.find((l) => l._id === languageId)?.name ?? languageId;
+}
+
+type Section = { label: string; rows: Row[] };
+
+const sections = computed<Section[]>(() => {
+    const out: Section[] = [];
+
+    const parent = props.editableParent;
+    if (parent && props.existingParent && props.isIncomingChange(parent._id)) {
+        const rows = changedFields(
+            props.existingParent as unknown as Record<string, unknown>,
+            parent as unknown as Record<string, unknown>,
+        );
+        if (rows.length) out.push({ label: "Settings", rows });
+    }
+
+    for (const content of props.editableContent) {
+        if (!props.isIncomingChange(content._id)) continue;
+        const server = props.existingContent?.find((c) => c._id === content._id);
+        if (!server) continue;
+        const rows = changedFields(
+            server as unknown as Record<string, unknown>,
+            content as unknown as Record<string, unknown>,
+        );
+        if (rows.length) out.push({ label: languageName(content.language), rows });
+    }
+
+    return out;
+});
+</script>
+
+<template>
+    <LDialog
+        v-model:open="open"
+        title="Changes from the remote"
+        description="Someone else changed this document while you were editing. Review the differences below, then either load the remote version (discards your unsaved changes) or keep editing yours."
+        primaryButtonText="Use remote version"
+        secondaryButtonText="Keep my changes"
+        context="danger"
+        largeModal
+        :primaryAction="() => emit('accept')"
+        :secondaryAction="
+            () => {
+                emit('dismiss');
+                open = false;
+            }
+        "
+        data-test="incoming-changes-modal"
+    >
+        <div class="mt-3 flex flex-col gap-4">
+            <p v-if="!sections.length" class="text-sm text-zinc-500">
+                The remote version no longer differs from yours.
+            </p>
+            <div v-for="section in sections" :key="section.label" class="flex flex-col gap-1">
+                <h3 class="text-sm font-semibold text-zinc-700">{{ section.label }}</h3>
+                <div class="overflow-x-auto rounded-md border border-zinc-200">
+                    <table class="w-full text-left text-sm">
+                        <thead class="bg-zinc-50 text-xs text-zinc-500">
+                            <tr>
+                                <th class="px-3 py-2 font-medium">Field</th>
+                                <th class="px-3 py-2 font-medium">Remote</th>
+                                <th class="px-3 py-2 font-medium">Yours</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr
+                                v-for="row in section.rows"
+                                :key="row.field"
+                                class="border-t border-zinc-100 align-top"
+                            >
+                                <td class="px-3 py-2 font-medium text-zinc-600">{{ row.field }}</td>
+                                <td class="whitespace-pre-wrap break-words px-3 py-2 text-zinc-800">
+                                    {{ row.server }}
+                                </td>
+                                <td class="whitespace-pre-wrap break-words px-3 py-2 text-zinc-800">
+                                    {{ row.mine }}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </LDialog>
+</template>

--- a/cms/src/components/content/composables/useEditContentSource.ts
+++ b/cms/src/components/content/composables/useEditContentSource.ts
@@ -50,6 +50,13 @@ export type UseEditContentSource = {
      * upload but not yet acknowledged by the server (pending offline change).
      */
     hasLocalChanges: Ref<boolean>;
+    /**
+     * True when someone else changed the parent or a content child on the server while the user
+     * holds unsaved edits (a genuine concurrent-edit conflict). Backed by toEditable's `isModified`.
+     */
+    hasIncomingChanges: Ref<boolean>;
+    /** Per-doc incoming-change check (parent or content), keyed by `_id`. */
+    isIncomingChange: ComputedRef<(id: Uuid) => boolean>;
     /** True while an existing doc has not yet hydrated (drives the loading state). */
     isLoading: Ref<boolean>;
     /** Persist the parent + edited content children and re-baseline the dirty state. */
@@ -279,6 +286,22 @@ export function useEditContentSource(options: UseEditContentSourceOptions): UseE
         return editableContent.value.some((c) => docHasLocalChange.value(c._id));
     });
 
+    // Concurrent-edit conflict: the server value diverged from our baseline while we hold unsaved
+    // edits. toEditable's `isModified` is true only in that case (an unedited doc's incoming change
+    // flows in silently), so this is exactly "someone else pushed a change to what I'm editing".
+    // ponytail: a server round-trip that adds server-owned fields (fts, availableTranslations) right
+    // after our own save can transiently read as incoming if the user resumes editing before it lands
+    // — isEqualBase (shared) doesn't normalize those and we can't tune it. Narrow; not worth solving.
+    const isIncomingChange = computed(
+        () => (id: Uuid) =>
+            parentEditable.isModified.value(id) || contentEditable.isModified.value(id),
+    );
+    const hasIncomingChanges = computed(() => {
+        const p = editableParent.value;
+        if (p && parentEditable.isModified.value(p._id)) return true;
+        return editableContent.value.some((c) => contentEditable.isModified.value(c._id));
+    });
+
     const save = async () => {
         const parent = editableParent.value;
         if (!parent) return;
@@ -333,6 +356,8 @@ export function useEditContentSource(options: UseEditContentSourceOptions): UseE
         isParentDirty,
         isContentItemDirty,
         hasLocalChanges,
+        hasIncomingChanges,
+        isIncomingChange,
         isLoading,
         save,
         deleteParent,


### PR DESCRIPTION
Surface a warning banner in EditContent when someone else changes the same document on the server while the user holds unsaved edits, backed by toEditable's existing isModified signal (no shared/ change). Clicking "Review changes" opens a read-only Remote-vs-Yours diff modal; "Use remote version" reloads to the fresh doc, "Keep my changes" dismisses.