### PR TITLE
API & CMS: Fix CMS document reverting on invalid slug submission

### DIFF
--- a/api/src/endpoints/changeRequest.service.spec.ts
+++ b/api/src/endpoints/changeRequest.service.spec.ts
@@ -100,6 +100,72 @@ describe("ChangeRequest service", () => {
         expect(res.ack).toBe(AckStatus.Accepted);
     });
 
+    it("reverts only the slug field (not the whole doc) when a redirect's slug collides with another redirect", async () => {
+        const changeRequest = {
+            doc: {
+                _id: "redirect-post2",
+                type: "redirect",
+                memberOf: ["group-private-content"],
+                redirectType: "permanent",
+                // Colliding "from" slug — already claimed by redirect-post1 (seeded).
+                slug: "post1-eng",
+                // Unrelated field the user also edited in the same submission.
+                toSlug: "new-target-eng",
+            },
+        };
+
+        const res = await changeRequestService.changeRequest(changeRequest, mockUserDetails);
+
+        expect(res.ack).toBe("rejected");
+        expect(res.message).toContain("Slug already has a redirect");
+
+        const docs: any[] = res.docs;
+        expect(docs.length).toBe(1);
+        expect(docs[0]._id).toBe("redirect-post2");
+        // Reverted to the persisted value...
+        expect(docs[0].slug).toBe("post2-eng");
+        // ...but the rest of the submitted doc (including the unrelated edit) is preserved,
+        // not clobbered by the whole prior doc.
+        expect(docs[0].toSlug).toBe("new-target-eng");
+    });
+
+    it("does not crash building the ack when a rejected Post has no prior doc but has content children", async () => {
+        const orphanPostId = `post-orphan-${Date.now()}`;
+        const orphanContentId = `content-orphan-${Date.now()}`;
+
+        // Content pointing at a post id that has never itself been persisted — e.g. the Post's
+        // own change request hasn't landed yet, or was rolled back out-of-band.
+        await service.upsertDoc({
+            _id: orphanContentId,
+            type: "content",
+            memberOf: ["group-public-content"],
+            parentId: orphanPostId,
+            parentType: "post",
+            language: "lang-eng",
+            status: "published",
+            slug: `orphan-slug-${Date.now()}`,
+            title: "Orphan content",
+        } as any);
+
+        const changeRequest = {
+            doc: {
+                _id: orphanPostId,
+                type: "post",
+                memberOf: ["group-public-content"],
+                // Deliberately missing required PostDto fields (postType, etc.) to force a
+                // validation rejection while doc.type is still "post".
+            },
+        };
+
+        // Must not throw (regression: `ack.docs.push` on an unset `ack.docs` when there is no
+        // prior doc for the rejected Post/Tag).
+        const res = await changeRequestService.changeRequest(changeRequest, mockUserDetails);
+
+        expect(res.ack).toBe("rejected");
+        expect(res.docs).toBeDefined();
+        expect(res.docs.some((d: any) => d._id === orphanContentId)).toBe(true);
+    });
+
     it("returns the post/tag document with associated content documents when a delete request is rejected", async () => {
         // Update post-blog1 so that group-super-admins do not have access to it
         const postDoc = { ...(await service.getDoc("post-blog1")).docs[0] };

--- a/api/src/endpoints/changeRequest.service.ts
+++ b/api/src/endpoints/changeRequest.service.ts
@@ -77,11 +77,20 @@ export class ChangeRequestService {
         }
 
         if (changeRequest.doc && status == AckStatus.Rejected) {
-            await this.db.getDoc(changeRequest.doc._id).then((res) => {
-                if (res.docs.length > 0) {
-                    ack.docs = [res.docs[0]];
+            const priorDocRes = await this.db.getDoc(changeRequest.doc._id);
+            const priorDoc = priorDocRes.docs.length > 0 ? priorDocRes.docs[0] : undefined;
+
+            if (priorDoc) {
+                if ("slug" in changeRequest.doc && "slug" in priorDoc) {
+                    // The slug is the only field the rejection invariant actually cares about
+                    // (see validateChangeRequest.ts). Revert just that field on the submitted
+                    // doc rather than replacing it wholesale with the persisted doc, so any
+                    // other legitimately-submitted edits aren't clobbered.
+                    ack.docs = [{ ...changeRequest.doc, slug: (priorDoc as { slug: string }).slug }];
+                } else {
+                    ack.docs = [priorDoc];
                 }
-            });
+            }
 
             // Handle rejected Post / Tag requests
             if (
@@ -100,6 +109,9 @@ export class ChangeRequestService {
                     ),
                 );
                 if (contentDocs.length > 0) {
+                    // ack.docs may still be unset here (no prior doc, e.g. the Post/Tag was
+                    // never actually persisted) — guard against pushing onto undefined.
+                    ack.docs = ack.docs ?? [];
                     ack.docs.push(...contentDocs);
                 }
             }

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -6,10 +6,13 @@ import {
     DocType,
     type ContentDto,
     type PostDto,
+    type RedirectDto,
     accessMap,
     PostType,
     PublishStatus,
     isConnected,
+    RedirectType,
+    changeReqRejectedDocs,
 } from "luminary-shared";
 import * as mockData from "@/tests/mockdata";
 import { setActivePinia } from "pinia";
@@ -100,6 +103,7 @@ describe("EditContent.vue", () => {
         await db.docs.clear();
         await db.localChanges.clear();
         vi.clearAllMocks();
+        changeReqRejectedDocs.value = [];
     });
 
     it("can load content from the database", async () => {
@@ -930,6 +934,144 @@ describe("EditContent.vue", () => {
             expect((fraRedirect!.doc as any).toSlug).toBe("new-fra-slug");
         });
     }, 15000);
+
+    it("reverts the slug instead of creating a redirect when the old slug is already claimed by another redirect", async () => {
+        await db.docs.put({
+            _id: "redirect-existing",
+            type: DocType.Redirect,
+            memberOf: ["group-public-content"],
+            updatedTimeUtc: 0,
+            redirectType: RedirectType.Permanent,
+            slug: mockData.mockEnglishContentDto.slug,
+            toSlug: "somewhere-else",
+        } as RedirectDto);
+
+        const wrapper = mount(EditContent, {
+            props: {
+                docType: DocType.Post,
+                id: mockData.mockPostDto._id,
+                languageCode: "eng",
+                tagOrPostType: PostType.Blog,
+            },
+        });
+
+        await waitForExpect(async () => {
+            expect(wrapper.find('[data-test="slugSpan"]').exists()).toBe(true);
+            await wrapper.find('[data-test="slugSpan"]').trigger("click");
+            await wrapper.find('[name="slug"]').setValue("new-slug");
+            await wrapper.find('[name="slug"]').trigger("change");
+        });
+
+        await waitForExpect(async () => {
+            await wrapper.find('[data-test="save-button"]').trigger("click");
+        });
+
+        await waitForExpect(() => {
+            const editableContent = (wrapper.vm as any).editableContent as ContentDto[];
+            const engContent = editableContent.find(
+                (c) => c.language === mockData.mockLanguageDtoEng._id,
+            );
+            expect(engContent?.slug).toBe(mockData.mockEnglishContentDto.slug);
+        });
+
+        await waitForExpect(async () => {
+            const res = await db.localChanges.toArray();
+            const redirects = res.filter((o) => o.doc?.type === DocType.Redirect);
+            expect(redirects.length).toBe(0);
+        });
+    });
+
+    it("reverts the slug instead of creating a redirect when another published content already occupies the old slug", async () => {
+        await db.docs.put({
+            ...mockData.mockEnglishContentDto,
+            _id: "content-duplicate-eng",
+            parentId: "post-duplicate",
+        } as ContentDto);
+
+        const wrapper = mount(EditContent, {
+            props: {
+                docType: DocType.Post,
+                id: mockData.mockPostDto._id,
+                languageCode: "eng",
+                tagOrPostType: PostType.Blog,
+            },
+        });
+
+        await waitForExpect(async () => {
+            expect(wrapper.find('[data-test="slugSpan"]').exists()).toBe(true);
+            await wrapper.find('[data-test="slugSpan"]').trigger("click");
+            await wrapper.find('[name="slug"]').setValue("new-slug");
+            await wrapper.find('[name="slug"]').trigger("change");
+        });
+
+        await waitForExpect(async () => {
+            await wrapper.find('[data-test="save-button"]').trigger("click");
+        });
+
+        await waitForExpect(() => {
+            const editableContent = (wrapper.vm as any).editableContent as ContentDto[];
+            const engContent = editableContent.find(
+                (c) => c.language === mockData.mockLanguageDtoEng._id,
+            );
+            expect(engContent?.slug).toBe(mockData.mockEnglishContentDto.slug);
+        });
+
+        await waitForExpect(async () => {
+            const res = await db.localChanges.toArray();
+            const redirects = res.filter((o) => o.doc?.type === DocType.Redirect);
+            expect(redirects.length).toBe(0);
+        });
+    });
+
+    it("reverts the slug via the backup watcher when a queued redirect is rejected asynchronously", async () => {
+        const wrapper = mount(EditContent, {
+            props: {
+                docType: DocType.Post,
+                id: mockData.mockPostDto._id,
+                languageCode: "eng",
+                tagOrPostType: PostType.Blog,
+            },
+        });
+
+        await waitForExpect(async () => {
+            expect(wrapper.find('[data-test="slugSpan"]').exists()).toBe(true);
+            await wrapper.find('[data-test="slugSpan"]').trigger("click");
+            await wrapper.find('[name="slug"]').setValue("new-slug");
+            await wrapper.find('[name="slug"]').trigger("change");
+        });
+
+        await waitForExpect(async () => {
+            await wrapper.find('[data-test="save-button"]').trigger("click");
+        });
+
+        await waitForExpect(async () => {
+            const res = await db.localChanges.toArray();
+            const redirects = res.filter((o) => o.doc?.type === DocType.Redirect);
+            expect(redirects.length).toBe(1);
+        });
+
+        // Simulate the queued redirect being rejected after the fact (a race the pre-check
+        // couldn't catch, e.g. another editor claimed the slug in between).
+        changeReqRejectedDocs.value = [
+            {
+                _id: "some-redirect-id",
+                type: DocType.Redirect,
+                memberOf: ["group-public-content"],
+                updatedTimeUtc: 0,
+                redirectType: RedirectType.Permanent,
+                slug: mockData.mockEnglishContentDto.slug,
+                toSlug: "new-slug",
+            } as RedirectDto,
+        ];
+
+        await waitForExpect(() => {
+            const editableContent = (wrapper.vm as any).editableContent as ContentDto[];
+            const engContent = editableContent.find(
+                (c) => c.language === mockData.mockLanguageDtoEng._id,
+            );
+            expect(engContent?.slug).toBe(mockData.mockEnglishContentDto.slug);
+        });
+    });
 
     describe("delete requests", () => {
         it("marks a post/tag document for deletion without marking associated content documents for deletion when the user deletes a post/tag", async () => {

--- a/cms/src/components/content/EditContent.vue
+++ b/cms/src/components/content/EditContent.vue
@@ -12,11 +12,14 @@ import {
     TagType,
     type ContentDto,
     type LanguageDto,
+    type RedirectDto,
     type TagDto,
     type Uuid,
     verifyAccess,
     PostType,
+    changeReqRejectedDocs,
 } from "luminary-shared";
+import { Slug } from "@/util/slug";
 import { useEditContentSource } from "./composables/useEditContentSource";
 import { useContentLanguage } from "./composables/useContentLanguage";
 import { useContentPermissions } from "./composables/useContentPermissions";
@@ -153,19 +156,63 @@ const createTranslation = (language: LanguageDto) => {
 const isValid = ref(true);
 
 // Create redirects (old slug → new slug) for any published translation whose slug
-// changed and the user has redirect-edit access to.
+// changed and the user has redirect-edit access to. Each candidate is checked against
+// the same invariants the server enforces (a redirect's "from" slug must be unique and
+// must not be claimed by other currently-published content) before it is queued — a
+// candidate that would be rejected server-side has its originating translation's slug
+// reverted here instead, so the CMS never saves a rename with no working redirect behind it.
 const createRedirect = async () => {
     if (!existingContent.value) return;
-    const redirects = buildRedirects(editableContent.value, existingContent.value);
-    await Promise.all(redirects.map((redirect) => db.upsert({ doc: redirect })));
-    redirects.forEach((redirect) =>
+    const candidates = buildRedirects(editableContent.value, existingContent.value);
+
+    for (const { redirect, contentId } of candidates) {
+        const isSlugUnique = await Slug.checkUnique(redirect.slug, redirect._id, DocType.Redirect);
+        const publishedCollision = await Slug.hasPublishedContentCollision(
+            redirect.slug,
+            contentId,
+        );
+
+        if (!isSlugUnique || publishedCollision) {
+            const content = editableContent.value.find((c) => c._id === contentId);
+            if (content) content.slug = redirect.slug;
+            notify(
+                "error",
+                "Slug change reverted",
+                `The slug "${redirect.slug}" is still in use, so the rename to "${redirect.toSlug}" was reverted.`,
+            );
+            continue;
+        }
+
+        await db.upsert({ doc: redirect });
         notify(
             "info",
             "Redirect created",
             `A redirect was created from ${redirect.slug} to ${redirect.toSlug}`,
-        ),
-    );
+        );
+    }
 };
+
+// Backup for the races the pre-check above can't catch (e.g. another editor claims the slug
+// between the check and the server processing the request): if a redirect we just queued is
+// rejected after the fact, revert the matching translation's slug so the CMS doesn't keep
+// displaying a rename that has no working redirect behind it.
+watch(changeReqRejectedDocs, (docs) => {
+    for (const doc of docs) {
+        if (doc.type !== DocType.Redirect) continue;
+        const redirect = doc as RedirectDto;
+        if (!redirect.toSlug) continue;
+
+        const content = editableContent.value.find((c) => c.slug === redirect.toSlug);
+        if (!content) continue;
+
+        content.slug = redirect.slug;
+        notify(
+            "error",
+            "Slug change reverted",
+            `The rename to "${redirect.toSlug}" could not be completed, so the slug was reverted to "${redirect.slug}".`,
+        );
+    }
+});
 
 // Guards against a rapid second save re-entering while the first is still in flight — e.g.
 // buildRedirects reading stale existingContent (not yet refreshed by the first save's write)

--- a/cms/src/components/content/util/buildRedirects.ts
+++ b/cms/src/components/content/util/buildRedirects.ts
@@ -6,8 +6,15 @@ import {
     RedirectType,
     type ContentDto,
     type RedirectDto,
+    type Uuid,
     verifyAccess,
 } from "luminary-shared";
+
+/** A candidate redirect paired with the `_id` of the Content translation it was derived from. */
+export type RedirectCandidate = {
+    redirect: RedirectDto;
+    contentId: Uuid;
+};
 
 /**
  * Compute the redirects to create when content slugs change: one Permanent redirect
@@ -16,13 +23,15 @@ import {
  * - had its slug changed, and
  * - the user has Redirect-edit access to.
  *
- * Returns new `RedirectDto`s; the inputs are not mutated.
+ * Each candidate is paired with the `_id` of the Content doc it came from, so a caller that
+ * rejects a candidate (e.g. a slug uniqueness pre-check) can revert that specific translation's
+ * slug edit. Returns new `RedirectDto`s; the inputs are not mutated.
  */
 export function buildRedirects(
     editableContent: ContentDto[],
     existingContent: ContentDto[],
-): RedirectDto[] {
-    const redirects: RedirectDto[] = [];
+): RedirectCandidate[] {
+    const redirects: RedirectCandidate[] = [];
     const now = Date.now();
 
     for (const content of editableContent) {
@@ -49,13 +58,16 @@ export function buildRedirects(
             continue;
 
         redirects.push({
-            _id: db.uuid(),
-            type: DocType.Redirect,
-            updatedTimeUtc: now,
-            memberOf: [...content.memberOf],
-            slug: existing.slug,
-            redirectType: RedirectType.Permanent,
-            toSlug: content.slug,
+            contentId: content._id,
+            redirect: {
+                _id: db.uuid(),
+                type: DocType.Redirect,
+                updatedTimeUtc: now,
+                memberOf: [...content.memberOf],
+                slug: existing.slug,
+                redirectType: RedirectType.Permanent,
+                toSlug: content.slug,
+            },
         });
     }
 

--- a/cms/src/components/redirects/CreateOrEditRedirectModal.vue
+++ b/cms/src/components/redirects/CreateOrEditRedirectModal.vue
@@ -13,6 +13,7 @@ import {
     useHybridQuery,
     useSharedHybridQuery,
     toEditable,
+    changeReqRejectedDocs,
 } from "luminary-shared";
 import LInput from "@/components/forms/LInput.vue";
 import LButton from "@/components/button/LButton.vue";
@@ -234,6 +235,23 @@ const deleteRedirect = async () => {
 const revertChanges = () => {
     redirectEditable.revert(currentId.value);
 };
+
+// The optimistic local save (toEditable's persistOffline path) always reports success
+// immediately; the actual accept/reject only arrives later via the local-change sync. If the
+// server then rejects this redirect's slug (invariant violation — e.g. another redirect or
+// currently-published content already claims it), snap just the slug back to the persisted
+// value, keeping any other in-progress edits (toSlug, type, group membership) intact.
+watch(changeReqRejectedDocs, (docs) => {
+    const rejected = docs.find((d) => d._id === currentId.value) as RedirectDto | undefined;
+    if (!rejected || !("slug" in rejected) || !editable.value) return;
+
+    editable.value.slug = rejected.slug;
+    addNotification({
+        title: "Slug change reverted",
+        description: `This slug is already in use, so the change was reverted to "${rejected.slug}".`,
+        state: "error",
+    });
+});
 </script>
 
 <template>

--- a/cms/src/components/redirects/CreateOrEditRedirectModel.spec.ts
+++ b/cms/src/components/redirects/CreateOrEditRedirectModel.spec.ts
@@ -4,7 +4,7 @@ import { mount } from "@vue/test-utils";
 import CreateOrEditRedirectModal from "./CreateOrEditRedirectModal.vue";
 import { setActivePinia } from "pinia";
 import { createTestingPinia } from "@pinia/testing";
-import { accessMap, db } from "luminary-shared";
+import { accessMap, changeReqRejectedDocs, db, type RedirectDto } from "luminary-shared";
 import { mockRedirectDto, superAdminAccessMap } from "@/tests/mockdata";
 import waitForExpect from "wait-for-expect";
 import LDialog from "../common/LDialog.vue";
@@ -22,6 +22,7 @@ describe("CreateOrEditRedirectModal.vue", () => {
         // Clear the database after each test
         await db.docs.clear();
         await db.localChanges.clear();
+        changeReqRejectedDocs.value = [];
     });
 
     describe("create mode", () => {
@@ -127,6 +128,42 @@ describe("CreateOrEditRedirectModal.vue", () => {
 
         // Assert the close event was emitted
         expect(wrapper.emitted().close).toBeTruthy();
+    });
+
+    it("reverts the slug but keeps other edits when the server rejects the redirect's slug", async () => {
+        const wrapper = mount(CreateOrEditRedirectModal, {
+            props: {
+                isVisible: true,
+                redirect: { ...mockRedirectDto },
+            },
+        });
+
+        await waitForExpect(() => {
+            const fromInput = wrapper.find("[name='RedirectFromSlug']").element as HTMLInputElement;
+            expect(fromInput.value).toBe("vod");
+        });
+
+        // User edits both the From slug (to something that will collide server-side) and the
+        // To slug in the same session.
+        await wrapper.find("[name='RedirectFromSlug']").setValue("taken-slug");
+        await wrapper.find("[name='RedirectFromSlug']").trigger("change");
+        await wrapper.find("[name='RedirectToSlug']").setValue("new-to-slug");
+        await wrapper.find("[name='RedirectToSlug']").trigger("change");
+
+        // Simulate the server rejecting the optimistic local save (async, after the modal
+        // already reported success) and returning the corrected doc: slug reverted, toSlug
+        // preserved from the submission.
+        changeReqRejectedDocs.value = [
+            { ...mockRedirectDto, slug: "vod", toSlug: "new-to-slug" } as RedirectDto,
+        ];
+
+        await waitForExpect(() => {
+            const fromInput = wrapper.find("[name='RedirectFromSlug']").element as HTMLInputElement;
+            expect(fromInput.value).toBe("vod");
+        });
+
+        const toInput = wrapper.find("[name='RedirectToSlug']").element as HTMLInputElement;
+        expect(toInput.value).toBe("new-to-slug");
     });
 
     it("can delete a redirect", async () => {

--- a/cms/src/util/slug.spec.ts
+++ b/cms/src/util/slug.spec.ts
@@ -1,7 +1,7 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, afterEach } from "vitest";
 import { Slug } from "./slug";
-import { db, type ContentDto } from "luminary-shared";
+import { db, PublishStatus, type ContentDto } from "luminary-shared";
 import { mockEnglishContentDto } from "@/tests/mockdata";
 
 describe("Slug", () => {
@@ -33,6 +33,46 @@ describe("Slug", () => {
         const generatedSlug = await Slug.generate(title, mockEnglishContentDto._id);
 
         expect(generatedSlug).toBe("sample-title");
+    });
+
+    describe("hasPublishedContentCollision", () => {
+        it("returns false when no content occupies the slug", async () => {
+            const result = await Slug.hasPublishedContentCollision("free-slug", "some-id");
+            expect(result).toBe(false);
+        });
+
+        it("returns true when other published content occupies the slug", async () => {
+            await db.docs.put({ ...mockEnglishContentDto } as ContentDto);
+
+            const result = await Slug.hasPublishedContentCollision(
+                mockEnglishContentDto.slug,
+                "a-different-content-id",
+            );
+            expect(result).toBe(true);
+        });
+
+        it("excludes the given content id (the doc being renamed) from the collision check", async () => {
+            await db.docs.put({ ...mockEnglishContentDto } as ContentDto);
+
+            const result = await Slug.hasPublishedContentCollision(
+                mockEnglishContentDto.slug,
+                mockEnglishContentDto._id,
+            );
+            expect(result).toBe(false);
+        });
+
+        it("returns false when the occupying content is not published", async () => {
+            await db.docs.put({
+                ...mockEnglishContentDto,
+                status: PublishStatus.Draft,
+            } as ContentDto);
+
+            const result = await Slug.hasPublishedContentCollision(
+                mockEnglishContentDto.slug,
+                "a-different-content-id",
+            );
+            expect(result).toBe(false);
+        });
     });
 
     describe("generateNonUnique - bug prevention tests", () => {

--- a/cms/src/util/slug.ts
+++ b/cms/src/util/slug.ts
@@ -1,5 +1,5 @@
 import { slugify } from "transliteration";
-import { db, DocType, type Uuid } from "luminary-shared";
+import { db, DocType, PublishStatus, type ContentDto, type Uuid } from "luminary-shared";
 
 /**
  * Functions to generate and validate slugs
@@ -66,5 +66,25 @@ export class Slug {
         }
 
         return true;
+    }
+
+    /**
+     * Returns true if a currently-published Content document (other than `excludeContentId`)
+     * already occupies `slug`. Mirrors the server's redirect-over-published-content invariant
+     * (`api/src/changeRequests/validateChangeRequest.ts`) so callers can check client-side
+     * before submitting a change request that the server would reject.
+     */
+    public static async hasPublishedContentCollision(slug: string, excludeContentId: Uuid) {
+        const matches = await db.docs
+            .where("slug")
+            .equals(slug)
+            .and((doc) => doc.type === DocType.Content)
+            .toArray();
+
+        return matches.some(
+            (doc) =>
+                doc._id !== excludeContentId &&
+                (doc as ContentDto).status === PublishStatus.Published,
+        );
     }
 }

--- a/shared/src/api/syncLocalChanges.ts
+++ b/shared/src/api/syncLocalChanges.ts
@@ -4,7 +4,7 @@ import { getRest } from "./RestApi";
 import { ChangeReqAckDto, LocalChangeDto } from "../types";
 import { db } from "../db/database";
 import { LFormData } from "../util/LFormData";
-import { changeReqErrors, changeReqWarnings } from "../config";
+import { changeReqErrors, changeReqRejectedDocs, changeReqWarnings } from "../config";
 
 async function send(change: LocalChangeDto): Promise<boolean> {
     const formData = new LFormData();
@@ -15,6 +15,7 @@ async function send(change: LocalChangeDto): Promise<boolean> {
 
     changeReqWarnings.value = [];
     changeReqErrors.value = [];
+    changeReqRejectedDocs.value = [];
     await db.applyLocalChangeAck(res, change);
     return true;
 }

--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -1,9 +1,19 @@
 import { ref, Ref } from "vue";
-import { Uuid } from "./types";
+import { BaseDocumentDto, Uuid } from "./types";
 import { OPEN_MIN } from "./api/sync/utils";
 
 export const changeReqWarnings = ref<string[]>([]);
 export const changeReqErrors = ref<string[]>([]);
+
+/**
+ * Docs returned by a rejected change request ack (`ChangeReqAckDto.docs`), corrected to the
+ * server's actual persisted state. Populated in `Database.applyLocalChangeAck`, cleared at the
+ * start of the next `syncLocalChanges` send. Consumers that hold their own `toEditable` shadow
+ * copy (which does not re-sync from a Dexie `bulkPut` while the user has unsaved edits) watch
+ * this to reconcile specific fields — e.g. snapping a rejected slug change back — without
+ * clobbering the rest of the user's in-progress edit.
+ */
+export const changeReqRejectedDocs = ref<BaseDocumentDto[]>([]);
 
 /**
  * Signal emitted when an HTTP request fails with a 5xx status. Consumers

--- a/shared/src/db/database.ts
+++ b/shared/src/db/database.ts
@@ -21,7 +21,7 @@ import { filterAsync, someAsync } from "../util/asyncArray";
 import { watchValue } from "../util/watchValue";
 import { accessMap, getAccessibleGroups, verifyAccess } from "../permissions/permissions";
 import { config } from "../config";
-import { changeReqErrors, changeReqWarnings } from "../config";
+import { changeReqErrors, changeReqRejectedDocs, changeReqWarnings } from "../config";
 import { cloneDeep } from "lodash-es";
 
 const dbName: string = "luminary-db";
@@ -559,6 +559,10 @@ class Database extends Dexie {
             if (ack.docs && Array.isArray(ack.docs)) {
                 // Replace our local copy(s) with the provided database version
                 await this.docs.bulkPut(ack.docs);
+
+                // Surface the corrected docs for consumers holding their own `toEditable`
+                // shadow copy, which won't pick up this bulkPut while the item is dirty.
+                changeReqRejectedDocs.value = ack.docs;
             } else {
                 // Otherwise attempt to delete the item, as it might have been a rejected create action
                 await this.docs.delete(localChange.doc._id);

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(
             environment: "jsdom",
             exclude: [...configDefaults.exclude, "e2e/*"],
             root: fileURLToPath(new URL("./", import.meta.url)),
-            setupFiles: ["vitest.setup.ts"],
+            setupFiles: ["vitest.localstorage.ts", "vitest.setup.ts"],
             coverage: {
                 provider: "v8",
                 exclude: [

--- a/shared/vitest.localstorage.ts
+++ b/shared/vitest.localstorage.ts
@@ -1,0 +1,32 @@
+// Node 26's jsdom doesn't expose a working localStorage, so every module that reads it at
+// load time (database.ts) crashes before any test runs. Provide a minimal in-memory shim,
+// loaded before vitest.setup.ts.
+//
+// Defined directly on `Storage.prototype` (not as own-properties on a plain object) so
+// `vi.spyOn(Storage.prototype, "setItem")` — used by responseCache.spec.ts's quota-overflow
+// tests — actually intercepts calls made through this shim; an object-literal shim would
+// shadow the prototype and make that spy a no-op.
+if (typeof globalThis.localStorage === "undefined" && typeof Storage !== "undefined") {
+    const store = new Map<string, string>();
+    Object.defineProperties(Storage.prototype, {
+        length: { configurable: true, get: () => store.size },
+        clear: { configurable: true, writable: true, value: () => store.clear() },
+        getItem: {
+            configurable: true,
+            writable: true,
+            value: (k: string) => (store.has(k) ? store.get(k)! : null),
+        },
+        key: {
+            configurable: true,
+            writable: true,
+            value: (i: number) => [...store.keys()][i] ?? null,
+        },
+        removeItem: { configurable: true, writable: true, value: (k: string) => void store.delete(k) },
+        setItem: {
+            configurable: true,
+            writable: true,
+            value: (k: string, v: string) => void store.set(k, String(v)),
+        },
+    });
+    globalThis.localStorage = Object.create(Storage.prototype) as Storage;
+}


### PR DESCRIPTION
Closes #1699

## The issue

The CMS writes documents to IndexedDB optimistically (`shared/src/db/database.ts` `upsert()`) before the API responds, so a redirect modal or a post/tag rename reports success immediately. When the server later rejects the change — the slug-invariant guard in `validateChangeRequest.ts` catches a slug collision — the CMS never reverted the local editable state, so it kept showing a slug the server never actually accepted. Two flows were affected: editing an existing redirect's "From" slug directly, and renaming a published post/tag, which auto-creates a redirect behind the scenes.

## The fix

**API (`changeRequest.service.ts`)** — a rejection ack used to replace the whole submitted doc with the persisted version, which would have clobbered any other legitimately-edited fields in the same submission. It now reverts only the `slug` field (guarded by `"slug" in doc`) and keeps the rest of what the client sent. Also fixed a latent crash: `ack.docs.push(...)` ran unguarded when a rejected Post/Tag had content children but no prior doc of its own.

**Shared** — added a `changeReqRejectedDocs` reactive signal (mirrors the existing `changeReqErrors` pattern), populated in `applyLocalChangeAck` and cleared at the start of the next sync send. This exists because `toEditable`'s shadow copy doesn't pick up a Dexie `bulkPut` while the user still has an in-progress edit, so components need an explicit signal to revert just the stale field.

**CMS**
- The redirect modal watches `changeReqRejectedDocs` and snaps just `slug` back on rejection, keeping any other in-progress edits (`toSlug`, type, group membership).
- The post/tag rename flow now checks each candidate redirect against the same invariants the server enforces (`Slug.checkUnique` + a new `Slug.hasPublishedContentCollision`, mirroring the server's redirect-over-published-content rule) *before* queuing it, and reverts that translation's slug in place if it would be rejected — so the CMS never saves a rename with no working redirect behind it. A `changeReqRejectedDocs` watcher backs this up for races the pre-check can't catch (e.g. another editor claims the slug in between).

Also ported the `localStorage` jsdom shim from `app`/`cms` into `shared` (it was missing there), needed to actually run `shared`'s test suite locally under Node 26.

## Tests

- `api/src/endpoints/changeRequest.service.spec.ts` — slug-only revert, and the ack.docs.push crash guard
- `cms/src/util/slug.spec.ts` — `hasPublishedContentCollision`
- `cms/src/components/redirects/CreateOrEditRedirectModel.spec.ts` — slug snap-back on rejection
- `cms/src/components/content/EditContent.spec.ts` — pre-check revert (redirect-slug collision, published-content collision) and the backup watcher

All touched packages lint, typecheck, and test clean (api: 8/8, shared: 1248/1248, cms: 84/84 across the touched files).