### PR TITLE
fix(auth): stabilize provider resolution for CMS access maps

### DIFF
--- a/api/src/auth/authIdentity.service.spec.ts
+++ b/api/src/auth/authIdentity.service.spec.ts
@@ -1024,6 +1024,65 @@ describe("AuthGuard (Integrated)", () => {
         expect(groups).not.toContain("group-readonly");
     });
 
+    it("should warn when provider scoping removes all static groups from a matched user", async () => {
+        mockJwtService.verifyAsync = jest
+            .fn()
+            .mockResolvedValue({ sub: "auth0|123", email: "test@bccsa.org", email_verified: true });
+
+        const docOtherProvider = {
+            _id: "user-other",
+            _rev: "1-bbb",
+            email: "test@bccsa.org",
+            name: "Test User",
+            providerId: "other-provider",
+            memberOf: ["group-super-admins"],
+        };
+
+        mockDbService.executeFindQuery
+            .mockResolvedValueOnce({ docs: [{ groupIds: ["group-public"], type: "autoGroupMappings" }] }) // getDefaultGroups
+            .mockResolvedValueOnce({ docs: [] }) // getAutoGroupMappings(providerId)
+            .mockResolvedValueOnce({ docs: [] }) // userId lookup – no match
+            .mockResolvedValueOnce({ docs: [] }) // externalUserId lookup – no match
+            .mockResolvedValueOnce({ docs: [docOtherProvider] }) // email lookup – primary
+            .mockResolvedValueOnce({ docs: [docOtherProvider] }); // email merge query
+
+        const warnSpy = jest
+            .spyOn((authIdentityService as any).logger, "warn")
+            .mockImplementation(() => undefined);
+
+        let capturedUser: any;
+        const mockContext = {
+            switchToHttp: () => ({
+                getRequest: () => {
+                    const req: any = {
+                        headers: {
+                            authorization: "Bearer valid-token",
+                            "x-auth-provider-id": "provider-id",
+                        },
+                    };
+                    Object.defineProperty(req, "user", {
+                        set(val) {
+                            capturedUser = val;
+                        },
+                        get() {
+                            return capturedUser;
+                        },
+                    });
+                    return req;
+                },
+            }),
+        } as any;
+
+        await guard.canActivate(mockContext);
+
+        expect(capturedUser.groups).toEqual(["group-public"]);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("no static groups apply for providerId=provider-id"),
+        );
+
+        warnSpy.mockRestore();
+    });
+
     it("should include memberOf from provider-less docs regardless of the current provider", async () => {
         mockJwtService.verifyAsync = jest
             .fn()

--- a/api/src/auth/authIdentity.service.spec.ts
+++ b/api/src/auth/authIdentity.service.spec.ts
@@ -1032,7 +1032,7 @@ describe("AuthGuard (Integrated)", () => {
         const docOtherProvider = {
             _id: "user-other",
             _rev: "1-bbb",
-            email: "test@bccsa.org",
+            email: "test@user.org",
             name: "Test User",
             providerId: "other-provider",
             memberOf: ["group-super-admins"],

--- a/api/src/auth/authIdentity.service.spec.ts
+++ b/api/src/auth/authIdentity.service.spec.ts
@@ -1027,7 +1027,7 @@ describe("AuthGuard (Integrated)", () => {
     it("should warn when provider scoping removes all static groups from a matched user", async () => {
         mockJwtService.verifyAsync = jest
             .fn()
-            .mockResolvedValue({ sub: "auth0|123", email: "test@bccsa.org", email_verified: true });
+            .mockResolvedValue({ sub: "auth0|123", email: "test@user.org", email_verified: true });
 
         const docOtherProvider = {
             _id: "user-other",

--- a/api/src/auth/authIdentity.service.ts
+++ b/api/src/auth/authIdentity.service.ts
@@ -451,6 +451,17 @@ export class AuthIdentityService implements OnModuleInit {
                 allMemberOf = primaryUser.memberOf ?? [];
             }
 
+            if (allMemberOf.length === 0) {
+                // A matched user with zero applicable static groups is almost always
+                // provider scoping (user doc stamped with a different providerId).
+                // The client silently receives a reduced access map — surface it.
+                this.logger.warn(
+                    `User ${primaryUser._id} matched but no static groups apply for providerId=${providerId} ` +
+                        `(user doc providerId=${primaryUser.providerId ?? "unset"}) — ` +
+                        `access map reduced to default + dynamic groups`,
+                );
+            }
+
             // Persist identity link and lastLogin
             await this.dbService.upsertDoc({ ...primaryUser, lastLogin: Date.now() });
 

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -19,6 +19,10 @@ vi.mock("@auth0/auth0-vue", () => ({
     createAuth0: mockCreateAuth0,
 }));
 
+vi.mock("@auth0/auth0-spa-js", () => ({
+    createAuth0Client: vi.fn(async () => ({ loginWithRedirect: vi.fn() })),
+}));
+
 vi.mock("@sentry/vue", () => ({
     captureMessage: vi.fn(),
     captureException: vi.fn(),
@@ -28,6 +32,7 @@ import {
     ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuth0Cache,
+    loginWithProvider,
     openProviderModal,
     persistActiveProvider,
     readPersistedProvider,
@@ -141,6 +146,35 @@ describe("auth", () => {
                 JSON.stringify({ state: "s" }),
             );
             history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("prefers the persisted provider over key-scan order when two providers' session caches coexist", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerB.clientId}::${providerB.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider(providerB);
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerB._id);
+        });
+
+        it("falls back to the key scan when the persisted provider has no Auth0 session cache", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            // Stale persisted pointer: Auth0 holds no session for provider B.
+            persistActiveProvider(providerB);
 
             const resolved = await resolveActiveProvider();
             expect(resolved?._id).toBe(providerA._id);
@@ -281,6 +315,26 @@ describe("auth", () => {
             );
 
             expect(await resolveActiveProvider()).toBeNull();
+        });
+    });
+
+    describe("loginWithProvider", () => {
+        it("evicts other providers' Auth0 localStorage caches so resolution stays deterministic", async () => {
+            localStorage.setItem(`@@auth0spajs@@::${providerA.clientId}::aud::scope`, "{}");
+            localStorage.setItem(`@@auth0spajs@@::${providerA.clientId}::@@user@@`, "{}");
+            localStorage.setItem(`@@auth0spajs@@::${providerB.clientId}::aud::scope`, "{}");
+
+            await loginWithProvider(providerB);
+
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerA.clientId}::aud::scope`),
+            ).toBeNull();
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerA.clientId}::@@user@@`),
+            ).toBeNull();
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerB.clientId}::aud::scope`),
+            ).not.toBeNull();
         });
     });
 

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -105,6 +105,29 @@ function setProviderIdHeader(id: string | null): void {
 export async function resolveActiveProvider(): Promise<ProviderConfig | null> {
     if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
 
+    // Deterministic fast path: trust the explicitly persisted provider when it
+    // still has an Auth0 session cache. The key scan below depends on
+    // localStorage enumeration order — with two providers' cache key sets
+    // present, the picked provider could flip between page loads, silently
+    // alternating x-auth-provider-id (the server then provider-scopes the
+    // user's static groups away and returns a reduced accessMap).
+    const persistedProvider = readPersistedProvider();
+    if (persistedProvider) {
+        const persistedDocs = await queryLocal<AuthProviderDto>({
+            selector: { type: DocType.AuthProvider },
+        });
+        const persistedDoc = persistedDocs.find((p) => p._id === persistedProvider._id);
+        if (persistedDoc && hasAuth0SessionCache(persistedDoc.clientId)) {
+            persistActiveProvider(persistedDoc); // refresh a possibly-stale persisted domain
+            return {
+                _id: persistedDoc._id,
+                domain: persistedDoc.domain,
+                clientId: persistedDoc.clientId,
+                audience: persistedDoc.audience,
+            };
+        }
+    }
+
     // The standard Auth0 token cache key is `<prefix><clientId>::<audience>::<scope>`,
     // so clientId + audience are both recoverable from it. (The sibling id-token
     // key `<prefix><clientId>::@@user@@` has no audience segment — skip it.)
@@ -158,6 +181,14 @@ export async function resolveActiveProvider(): Promise<ProviderConfig | null> {
         return { _id: persisted._id, domain: persisted.domain, clientId, audience };
     }
     return null;
+}
+
+/** True when Auth0 holds a session cache (token/user keys) for this clientId. */
+function hasAuth0SessionCache(clientId: string): boolean {
+    for (let i = 0; i < localStorage.length; i++) {
+        if (localStorage.key(i)?.startsWith(`${AUTH0_CACHE_PREFIX}${clientId}::`)) return true;
+    }
+    return false;
 }
 
 /**
@@ -296,6 +327,18 @@ export async function loginWithProvider(
     // Evict stale PKCE transactions from aborted attempts so the next
     // callback matches the fresh code_verifier.
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
+    // Evict other providers' Auth0 session caches: two coexisting
+    // @@auth0spajs@@ key sets make resolveActiveProvider's key-scan fallback
+    // enumeration-order dependent, so the active provider could flip between
+    // page loads.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+        const key = localStorage.key(i);
+        if (
+            key?.startsWith(AUTH0_CACHE_PREFIX) &&
+            !key.startsWith(`${AUTH0_CACHE_PREFIX}${provider.clientId}::`)
+        )
+            localStorage.removeItem(key);
+    }
     const client = await createAuth0Client(buildAuth0Options(provider));
     await client.loginWithRedirect({
         authorizationParams: opts?.prompt ? { prompt: opts.prompt } : undefined,

--- a/cms/src/auth.spec.ts
+++ b/cms/src/auth.spec.ts
@@ -15,10 +15,15 @@ vi.mock("@auth0/auth0-vue", () => ({
     createAuth0: mockCreateAuth0,
 }));
 
+vi.mock("@auth0/auth0-spa-js", () => ({
+    createAuth0Client: vi.fn(async () => ({ loginWithRedirect: vi.fn() })),
+}));
+
 import {
     ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuth0Cache,
+    loginWithProvider,
     openProviderModal,
     persistActiveProvider,
     readPersistedProvider,
@@ -123,6 +128,35 @@ describe("auth", () => {
                 JSON.stringify({ state: "s" }),
             );
             history.replaceState(null, "", "/?code=abc&state=xyz");
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerA._id);
+        });
+
+        it("prefers the persisted provider over key-scan order when two providers' session caches coexist", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerB.clientId}::${providerB.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            persistActiveProvider(providerB);
+
+            const resolved = await resolveActiveProvider();
+            expect(resolved?._id).toBe(providerB._id);
+        });
+
+        it("falls back to the key scan when the persisted provider has no Auth0 session cache", async () => {
+            await db.docs.bulkPut([providerA, providerB]);
+            localStorage.setItem(
+                `@@auth0spajs@@::${providerA.clientId}::${providerA.audience}::openid profile email offline_access`,
+                JSON.stringify({ body: {} }),
+            );
+            // Stale persisted pointer — Auth0 holds no session for provider B.
+            persistActiveProvider(providerB);
 
             const resolved = await resolveActiveProvider();
             expect(resolved?._id).toBe(providerA._id);
@@ -263,6 +297,26 @@ describe("auth", () => {
             );
 
             expect(await resolveActiveProvider()).toBeNull();
+        });
+    });
+
+    describe("loginWithProvider", () => {
+        it("evicts other providers' Auth0 localStorage caches so resolution stays deterministic", async () => {
+            localStorage.setItem(`@@auth0spajs@@::${providerA.clientId}::aud::scope`, "{}");
+            localStorage.setItem(`@@auth0spajs@@::${providerA.clientId}::@@user@@`, "{}");
+            localStorage.setItem(`@@auth0spajs@@::${providerB.clientId}::aud::scope`, "{}");
+
+            await loginWithProvider(providerB);
+
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerA.clientId}::aud::scope`),
+            ).toBeNull();
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerA.clientId}::@@user@@`),
+            ).toBeNull();
+            expect(
+                localStorage.getItem(`@@auth0spajs@@::${providerB.clientId}::aud::scope`),
+            ).not.toBeNull();
         });
     });
 

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -85,6 +85,14 @@ export function readPersistedProvider(): PersistedProvider | null {
     }
 }
 
+/** True when Auth0 holds a session cache (token/user keys) for this clientId. */
+function hasAuth0SessionCache(clientId: string): boolean {
+    for (let i = 0; i < localStorage.length; i++) {
+        if (localStorage.key(i)?.startsWith(`${AUTH0_CACHE_PREFIX}${clientId}::`)) return true;
+    }
+    return false;
+}
+
 function setProviderIdHeader(id: string | null): void {
     activeProviderId.value = id;
     if (id) setCustomHeader("x-auth-provider-id", id);
@@ -107,6 +115,31 @@ function setProviderIdHeader(id: string | null): void {
  */
 export async function resolveActiveProvider(): Promise<ProviderConfig | null> {
     if (typeof sessionStorage === "undefined" || typeof localStorage === "undefined") return null;
+
+    // Deterministic fast path: trust the explicitly persisted provider when it
+    // still has an Auth0 session cache. The key scan below depends on
+    // localStorage enumeration order — with two providers' cache key sets
+    // present, the picked provider could flip between page loads, silently
+    // alternating x-auth-provider-id (the server then provider-scopes the
+    // user's static groups away and returns a reduced accessMap).
+    const persistedProvider = readPersistedProvider();
+    if (persistedProvider) {
+        const persistedDoc = (await db.docs.get(persistedProvider._id)) as
+            | AuthProviderDto
+            | undefined;
+        if (
+            persistedDoc?.type === DocType.AuthProvider &&
+            hasAuth0SessionCache(persistedDoc.clientId)
+        ) {
+            persistActiveProvider(persistedDoc); // refresh a possibly-stale persisted domain
+            return {
+                _id: persistedDoc._id,
+                domain: persistedDoc.domain,
+                clientId: persistedDoc.clientId,
+                audience: persistedDoc.audience,
+            };
+        }
+    }
 
     // The standard Auth0 token cache key is `<prefix><clientId>::<audience>::<scope>`,
     // so clientId + audience are both recoverable from it. (The sibling id-token
@@ -276,6 +309,18 @@ export async function loginWithProvider(
     // Evict stale PKCE transactions from aborted attempts so the next
     // callback matches the fresh code_verifier.
     clearStoragePrefix(sessionStorage, AUTH0_TX_PREFIX);
+    // Evict other providers' Auth0 session caches: two coexisting
+    // @@auth0spajs@@ key sets make resolveActiveProvider's key-scan fallback
+    // enumeration-order dependent, so the active provider could flip between
+    // page loads.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+        const key = localStorage.key(i);
+        if (
+            key?.startsWith(AUTH0_CACHE_PREFIX) &&
+            !key.startsWith(`${AUTH0_CACHE_PREFIX}${provider.clientId}::`)
+        )
+            localStorage.removeItem(key);
+    }
     const client = await createAuth0Client(buildAuth0Options(provider));
     await client.loginWithRedirect({
         authorizationParams: opts?.prompt ? { prompt: opts.prompt } : undefined,

--- a/cms/src/main.ts
+++ b/cms/src/main.ts
@@ -12,7 +12,7 @@ import {
     serverError,
 } from "luminary-shared";
 import { apiUrl, initLanguage } from "@/globalConfig";
-import auth, { isAuthBypassed } from "./auth";
+import auth, { isAuthBypassed, readPersistedProvider } from "./auth";
 import { useNotificationStore } from "./stores/notification";
 import { initAuthLangSync, initSync } from "./sync";
 import { CMS_DOCS_INDEX } from "./docsIndex";
@@ -98,7 +98,13 @@ async function Startup() {
     }
 
     await auth.setupAuth(app);
-    socket.connect(); // ensure socket connects for public users (no-op if auth already called reconnect())
+    // Ensure the socket connects for visitors with no session (no-op if auth
+    // already called reconnect()). Skip when a persisted provider session
+    // exists but auth didn't complete (e.g. transient silent-refresh failure):
+    // an anonymous handshake would replace the persisted accessMap with the
+    // default-groups map and deleteRevoked would purge local data. The pending
+    // re-login/refresh connects the socket instead.
+    if (!(readPersistedProvider() && !auth.activeProviderId.value)) socket.connect();
 
     // Show notification on server error (5xx), debounced to avoid flooding.
     // CMS has no i18n layer; copy is owned here rather than in the shared lib.


### PR DESCRIPTION
Prefer the persisted active provider when a matching Auth0 session cache exists, clear stale provider cache keys during login, and guard CMS startup from anonymous socket handshakes that can purge local content.

Add app parity tests and API warning coverage for provider-scoped group loss.