### PR TITLE
fix(cms): infinite scrolling in UserOverview (and RedirectOverview)

### DIFF
--- a/cms/src/components/redirects/RedirectOverview.vue
+++ b/cms/src/components/redirects/RedirectOverview.vue
@@ -58,7 +58,9 @@ const {
     { live: true },
 );
 
-const { visible: visibleRedirects } = useInfiniteScrollList(redirects, { pageSize: 20 });
+const { visible: visibleRedirects, sentinel: browseSentinel } = useInfiniteScrollList(redirects, {
+    pageSize: 20,
+});
 
 // --- Search (≥3 chars): server-side strict FTS over slug + toSlug. The search term is already
 // debounced above, so the composable's own debounce is disabled. ---
@@ -110,9 +112,7 @@ const hasAnyContent = computed(() => (redirects.value?.length ?? 0) > 0);
         </template>
 
         <template v-if="hasAnyContent" #internalPageHeader>
-            <div
-                class="relative z-20 flex flex-col gap-1 overflow-visible"
-            >
+            <div class="relative z-20 flex flex-col gap-1 overflow-visible">
                 <div class="flex h-10 w-full items-center gap-1">
                     <LInput
                         type="text"
@@ -143,12 +143,17 @@ const hasAnyContent = computed(() => (redirects.value?.length ?? 0) > 0);
                 :class="{ 'mb-4': i === displayedRedirects.length - 1 }"
             />
 
+            <!-- Infinite-scroll trigger for the in-memory browse window -->
+            <div v-if="!searchActive" ref="browseSentinel" class="h-px w-full"></div>
+
             <EmptyState
                 v-if="!browseLoading && !hasAnyContent"
                 title="No redirects yet"
                 description="Create a redirect to send visitors from one URL to another."
                 :button-text="canCreateNew ? 'Create redirect' : undefined"
-                :button-action="canCreateNew ? () => (isCreateOrEditModalVisible = true) : undefined"
+                :button-action="
+                    canCreateNew ? () => (isCreateOrEditModalVisible = true) : undefined
+                "
                 :button-permission="canCreateNew"
                 show-back-button
             />

--- a/cms/src/components/users/UserOverview.spec.ts
+++ b/cms/src/components/users/UserOverview.spec.ts
@@ -2,6 +2,7 @@ import "fake-indexeddb/auto";
 import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from "vitest";
 import { mount } from "@vue/test-utils";
 import UserOverview from "./UserOverview.vue";
+import UserDisplayCard from "./UserDisplayCard.vue";
 import CreateOrEditUser from "./CreateOrEditUser.vue";
 import LCombobox from "../forms/LCombobox.vue";
 import { createTestingPinia } from "@pinia/testing";
@@ -34,6 +35,35 @@ vi.mock("vue-router", async (importOriginal) => {
     };
 });
 
+// Capture every IntersectionObserver callback the page registers (browse sentinel + search
+// sentinel), so a test can simulate a sentinel scrolling into view. `vi.hoisted` because
+// `vi.mock` factories run before the module body initialises its consts.
+const { observerCallbacks } = vi.hoisted(() => ({
+    observerCallbacks: [] as Array<(entries: Partial<IntersectionObserverEntry>[]) => void>,
+}));
+
+vi.mock("@vueuse/core", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@vueuse/core")>();
+    const { ref: vueRef } = await import("vue");
+    return {
+        ...actual,
+        useIntersectionObserver: (_target: unknown, callback: unknown) => {
+            observerCallbacks.push(callback as (typeof observerCallbacks)[number]);
+            return {
+                isSupported: vueRef(true),
+                isActive: vueRef(true),
+                pause: vi.fn(),
+                resume: vi.fn(),
+                stop: vi.fn(),
+            };
+        },
+    };
+});
+
+/** Fire every registered sentinel. Guards inside each composable ignore the irrelevant ones. */
+const scrollSentinelsIntoView = () =>
+    observerCallbacks.forEach((cb) => cb([{ isIntersecting: true }]));
+
 vi.mock("@auth0/auth0-vue", async (importOriginal) => {
     const actual = await importOriginal();
     return {
@@ -57,12 +87,13 @@ app.use(express.json());
 const port = 12347;
 
 let mockQuerySelector: { type?: string } | undefined;
-const mockUsers = [
+const defaultMockUsers = [
     mockUserDto,
     { ...mockUserDto, _id: "2", name: "User 2" },
     { ...mockUserDto, _id: "3", name: "User 3" },
     { ...mockUserDto, _id: "4", name: "User 4" },
 ];
+let mockUsers = defaultMockUsers;
 
 // User is non-synced → served API-only via HybridQuery, which POSTs to /query.
 app.post("/query", (req, res) => {
@@ -104,6 +135,8 @@ describe("UserOverview", () => {
     afterEach(async () => {
         await db.docs.clear();
         await db.localChanges.clear();
+        mockUsers = defaultMockUsers;
+        observerCallbacks.length = 0;
         vi.clearAllMocks();
     });
 
@@ -242,5 +275,49 @@ describe("UserOverview", () => {
         });
 
         expect(wrapper.findComponent({ name: "LPaginator" }).exists()).toBe(false);
+    });
+
+    // Regression for #1797. The browse window used to be driven by an inject of BasePage's
+    // scroll container — but UserOverview *renders* BasePage, so the inject resolved to its
+    // fallback and the window never grew past the first page.
+    describe("browse infinite scroll", () => {
+        const manyUsers = Array.from({ length: 25 }, (_, i) => ({
+            ...mockUserDto,
+            _id: `user-${i}`,
+            name: `User ${i}`,
+        }));
+
+        it("renders a sentinel and grows the window when it scrolls into view", async () => {
+            mockUsers = manyUsers;
+            const wrapper = mount(UserOverview);
+
+            await waitForExpect(() => {
+                expect(wrapper.findAllComponents(UserDisplayCard).length).toBe(20);
+            });
+
+            // The browse sentinel must be registered for the window to ever grow.
+            expect(observerCallbacks.length).toBeGreaterThan(0);
+
+            scrollSentinelsIntoView();
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.findAllComponents(UserDisplayCard).length).toBe(25);
+        });
+
+        it("stops growing once every user is visible", async () => {
+            mockUsers = manyUsers;
+            const wrapper = mount(UserOverview);
+
+            await waitForExpect(() => {
+                expect(wrapper.findAllComponents(UserDisplayCard).length).toBe(20);
+            });
+
+            scrollSentinelsIntoView();
+            await wrapper.vm.$nextTick();
+            scrollSentinelsIntoView(); // no-op — hasMore is false
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.findAllComponents(UserDisplayCard).length).toBe(25);
+        });
     });
 });

--- a/cms/src/components/users/UserOverview.vue
+++ b/cms/src/components/users/UserOverview.vue
@@ -107,7 +107,7 @@ const filteredUsers = computed(() => {
     });
 });
 
-const { visible: visibleUsers } = useInfiniteScrollList(filteredUsers, {
+const { visible: visibleUsers, sentinel: browseSentinel } = useInfiniteScrollList(filteredUsers, {
     pageSize: 20,
     resetWhen: [() => queryOptions.value.search, () => queryOptions.value.groups],
 });
@@ -194,6 +194,8 @@ const hasAnyContent = computed(() => (users.value?.length ?? 0) > 0);
                 v-model="isEditUserModalVisible"
                 @edit="(id) => (selectedUserId = id)"
             />
+
+            <div v-if="!searchActive" ref="browseSentinel" class="h-px w-full"></div>
 
             <EmptyState
                 v-if="!isFetching && !hasAnyContent"

--- a/cms/src/composables/useInfiniteScrollList.spec.ts
+++ b/cms/src/composables/useInfiniteScrollList.spec.ts
@@ -1,14 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, defineComponent, nextTick } from "vue";
 import { mount } from "@vue/test-utils";
 import { useInfiniteScrollList, useInfiniteScrollLoadMore } from "./useInfiniteScrollList";
-import { basePageScrollKey } from "@/keys/basePageScroll";
 
 vi.mock("@vueuse/core", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@vueuse/core")>();
     return {
         ...actual,
-        useInfiniteScroll: vi.fn(),
         useIntersectionObserver: vi.fn(),
     };
 });
@@ -25,6 +23,26 @@ function stubIntersectionObserverReturn(): UseIntersectionObserverReturn {
     };
 }
 
+/**
+ * Capture the observer callback the composable registers, so a test can simulate the
+ * sentinel scrolling into view.
+ */
+function captureObserver() {
+    let observerCallback: ((entries: Partial<IntersectionObserverEntry>[]) => void) | undefined;
+    vi.mocked(useIntersectionObserver).mockImplementation((_target, callback) => {
+        observerCallback = callback as typeof observerCallback;
+        return stubIntersectionObserverReturn();
+    });
+    return {
+        intersect: () => observerCallback?.([{ isIntersecting: true }]),
+    };
+}
+
+beforeEach(() => {
+    vi.mocked(useIntersectionObserver).mockReset();
+    vi.mocked(useIntersectionObserver).mockReturnValue(stubIntersectionObserverReturn());
+});
+
 describe("useInfiniteScrollList", () => {
     it("reveals an initial page-sized window", () => {
         const source = ref([1, 2, 3, 4, 5]);
@@ -37,16 +55,77 @@ describe("useInfiniteScrollList", () => {
             },
         });
 
-        mount(Host, {
-            global: {
-                provide: { [basePageScrollKey as symbol]: ref(null) },
-            },
-        });
+        mount(Host);
 
         expect(visible!.value).toEqual([1, 2]);
     });
 
+    /**
+     * Regression for #1797: the window used to grow only when BasePage's `provide`d scroll
+     * container fired. An overview page renders BasePage as a *child*, so its `inject` always
+     * resolved to the fallback and the container was never observed. The composable must not
+     * depend on any ancestor providing anything — mounting it bare has to still page.
+     */
+    it("grows the window when the sentinel intersects, with no provider in the tree", () => {
+        const observer = captureObserver();
+        const source = ref([1, 2, 3, 4, 5]);
+        let visible: ReturnType<typeof useInfiniteScrollList<number>>["visible"] | undefined;
+
+        const Host = defineComponent({
+            setup() {
+                ({ visible } = useInfiniteScrollList(source, { pageSize: 2 }));
+                return () => null;
+            },
+        });
+
+        mount(Host); // note: no `global.provide`
+
+        expect(visible!.value).toEqual([1, 2]);
+        observer.intersect();
+        expect(visible!.value).toEqual([1, 2, 3, 4]);
+        observer.intersect();
+        expect(visible!.value).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("observes a sentinel element rather than a scroll container", () => {
+        const source = ref([1, 2, 3]);
+        let sentinel: ReturnType<typeof useInfiniteScrollList<number>>["sentinel"] | undefined;
+
+        const Host = defineComponent({
+            setup() {
+                ({ sentinel } = useInfiniteScrollList(source, { pageSize: 2 }));
+                return () => null;
+            },
+        });
+
+        mount(Host);
+
+        // The observed target is the composable's own sentinel ref, not an injected element.
+        expect(vi.mocked(useIntersectionObserver).mock.calls[0]![0]).toBe(sentinel);
+    });
+
+    it("stops growing once the whole source is visible", () => {
+        const observer = captureObserver();
+        const source = ref([1, 2, 3]);
+        let visible: ReturnType<typeof useInfiniteScrollList<number>>["visible"] | undefined;
+
+        const Host = defineComponent({
+            setup() {
+                ({ visible } = useInfiniteScrollList(source, { pageSize: 2 }));
+                return () => null;
+            },
+        });
+
+        mount(Host);
+
+        observer.intersect();
+        expect(visible!.value).toEqual([1, 2, 3]);
+        observer.intersect(); // no-op — hasMore is false
+        expect(visible!.value).toEqual([1, 2, 3]);
+    });
+
     it("resets the window when resetWhen deps change", async () => {
+        const observer = captureObserver();
         const source = ref(["a", "b", "c", "d"]);
         const filter = ref("x");
         let visible: ReturnType<typeof useInfiniteScrollList<string>>["visible"] | undefined;
@@ -61,28 +140,43 @@ describe("useInfiniteScrollList", () => {
             },
         });
 
-        mount(Host, {
-            global: {
-                provide: { [basePageScrollKey as symbol]: ref(null) },
-            },
-        });
+        mount(Host);
 
-        visible!.value;
+        observer.intersect();
+        expect(visible!.value).toEqual(["a", "b", "c", "d"]);
+
         filter.value = "y";
         await nextTick();
         expect(visible!.value).toEqual(["a", "b"]);
+    });
+
+    it("resets the window when the source shrinks", async () => {
+        const observer = captureObserver();
+        const source = ref(["a", "b", "c", "d"]);
+        let visible: ReturnType<typeof useInfiniteScrollList<string>>["visible"] | undefined;
+
+        const Host = defineComponent({
+            setup() {
+                ({ visible } = useInfiniteScrollList(source, { pageSize: 2 }));
+                return () => null;
+            },
+        });
+
+        mount(Host);
+
+        observer.intersect();
+        expect(visible!.value).toEqual(["a", "b", "c", "d"]);
+
+        source.value = ["a"];
+        await nextTick();
+        expect(visible!.value).toEqual(["a"]);
     });
 });
 
 describe("useInfiniteScrollLoadMore", () => {
     it("calls onLoadMore when the sentinel intersects", () => {
         const onLoadMore = vi.fn();
-        let observerCallback: ((entries: Partial<IntersectionObserverEntry>[]) => void) | undefined;
-
-        vi.mocked(useIntersectionObserver).mockImplementation((_target, callback) => {
-            observerCallback = callback as typeof observerCallback;
-            return stubIntersectionObserverReturn();
-        });
+        const observer = captureObserver();
 
         const Host = defineComponent({
             setup() {
@@ -97,18 +191,13 @@ describe("useInfiniteScrollLoadMore", () => {
 
         mount(Host);
 
-        observerCallback?.([{ isIntersecting: true }]);
+        observer.intersect();
         expect(onLoadMore).toHaveBeenCalledOnce();
     });
 
     it("does not call onLoadMore while loading or when there is nothing more", () => {
         const onLoadMore = vi.fn();
-        let observerCallback: ((entries: Partial<IntersectionObserverEntry>[]) => void) | undefined;
-
-        vi.mocked(useIntersectionObserver).mockImplementation((_target, callback) => {
-            observerCallback = callback as typeof observerCallback;
-            return stubIntersectionObserverReturn();
-        });
+        const observer = captureObserver();
 
         const hasMore = ref(true);
         const isLoading = ref(true);
@@ -126,12 +215,12 @@ describe("useInfiniteScrollLoadMore", () => {
 
         mount(Host);
 
-        observerCallback?.([{ isIntersecting: true }]);
+        observer.intersect();
         expect(onLoadMore).not.toHaveBeenCalled();
 
         isLoading.value = false;
         hasMore.value = false;
-        observerCallback?.([{ isIntersecting: true }]);
+        observer.intersect();
         expect(onLoadMore).not.toHaveBeenCalled();
     });
 });

--- a/cms/src/composables/useInfiniteScrollList.ts
+++ b/cms/src/composables/useInfiniteScrollList.ts
@@ -1,22 +1,13 @@
-import {
-    computed,
-    inject,
-    ref,
-    toValue,
-    watch,
-    type MaybeRefOrGetter,
-    type Ref,
-} from "vue";
-import { useInfiniteScroll, useIntersectionObserver } from "@vueuse/core";
-import { basePageScrollKey } from "@/keys/basePageScroll";
+import { computed, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from "vue";
+import { useIntersectionObserver } from "@vueuse/core";
 
 export type UseInfiniteScrollListOptions = {
     /** Rows revealed per scroll step (and the initial window). Default 20. */
     pageSize?: number;
     /** When any of these change, the visible window resets to one page. */
     resetWhen?: MaybeRefOrGetter<unknown>[];
-    /** Distance (px) from the scroll bottom before loading more. Default 150. */
-    distance?: number;
+    /** IntersectionObserver rootMargin for the sentinel. Default "200px". */
+    rootMargin?: string;
 };
 
 export type UseInfiniteScrollLoadMoreOptions = {
@@ -32,6 +23,19 @@ export type UseInfiniteScrollLoadMoreOptions = {
  * {@link BasePage} content area. Use when the full result set is already in a
  * ref (e.g. synced HybridQuery lists like Redirects).
  *
+ * Bind the returned `sentinel` to an element rendered *after* the list, inside
+ * BasePage's default slot:
+ *
+ * ```vue
+ * <div v-if="!searchActive" ref="sentinel" class="h-px w-full" />
+ * ```
+ *
+ * The window grows when that element scrolls into view. This deliberately does NOT
+ * watch BasePage's scroll container: the container is `provide`d by BasePage, and an
+ * overview page is BasePage's *parent*, so injecting it from the page's own `setup`
+ * only ever yields the fallback (see #1797). An IntersectionObserver on a sentinel
+ * needs no ancestor lookup and works from either side of the slot boundary.
+ *
  * For query-level paging ({@link useHybridQuery} `$limit` growth, {@link useFtsSearch}
  * `loadMore`), use {@link useInfiniteScrollLoadMore} instead — the caller owns the window.
  */
@@ -40,7 +44,6 @@ export function useInfiniteScrollList<T>(
     options: UseInfiniteScrollListOptions = {},
 ) {
     const pageSize = options.pageSize ?? 20;
-    const distance = options.distance ?? 150;
 
     const visibleCount = ref(pageSize);
 
@@ -62,17 +65,17 @@ export function useInfiniteScrollList<T>(
     const visible = computed(() => source.value.slice(0, visibleCount.value));
     const hasMore = computed(() => visibleCount.value < source.value.length);
 
-    const scrollEl = inject(basePageScrollKey, ref(null));
+    const loadMore = () => {
+        if (hasMore.value) visibleCount.value += pageSize;
+    };
 
-    useInfiniteScroll(
-        () => scrollEl.value,
-        () => {
-            if (hasMore.value) visibleCount.value += pageSize;
-        },
-        { distance },
-    );
+    const { sentinel } = useInfiniteScrollLoadMore({
+        hasMore,
+        onLoadMore: loadMore,
+        rootMargin: options.rootMargin,
+    });
 
-    return { visible, hasMore, reset };
+    return { visible, hasMore, reset, loadMore, sentinel };
 }
 
 /**


### PR DESCRIPTION
Fixes #1797

## The bug

`useInfiniteScrollList` grew its visible window by watching BasePage's scroll container, obtained with `inject(basePageScrollKey)`.

But an overview page **renders** `BasePage` — it is BasePage's *parent*, not its descendant. `provide`/`inject` only flows downward, so the inject always resolved to its `ref(null)` fallback:

```ts
const scrollEl = inject(basePageScrollKey, ref(null)); // always null in a page's setup
useInfiniteScroll(() => scrollEl.value, ...);          // → no listener ever attached
```

The browse list therefore stayed frozen at the first 20 rows, forever.

Search paging was never affected: it uses an `IntersectionObserver` on a sentinel element, which needs no ancestor lookup. That is exactly why the bug reads as *"scrolling works when I search, but not otherwise"*.

## The fix

Apply the sentinel mechanism to the browse window too. `useInfiniteScrollList` now owns a `sentinel` ref, which the page binds to a zero-height div rendered after the list:

```vue
<div v-if="!searchActive" ref="browseSentinel" class="h-px w-full"></div>
```

No ancestor lookup, so it works from either side of the slot boundary.

## Scope

`RedirectOverview` calls the same composable the same way and had the **identical latent bug** — nobody had noticed because the redirect list is short. Fixing the composable fixes both, so both call sites are updated here.

`usePinnedToolbarBelowTopbar` also injects `basePageScrollKey`, but it is used from `RichTextEditor`, which sits *inside* BasePage's slot. It is correct and untouched.

## Why the tests didn't catch it

The old spec mocked `useInfiniteScroll` away entirely and supplied `basePageScrollKey` through `global.provide` — something production never does. It asserted the window logic while stubbing out the very wiring that was broken.

The rewritten spec mounts bare, with **no provider in the tree**, and drives the real observer.

## Verification

- Full CMS suite: 115 files, 934 tests pass (up from 932).
- Both new page-level tests and the four new composable tests were confirmed to **fail against the pre-fix code** (`expected 20 to be 25`) and pass after — they are real regression guards, not tautologies.
- `npm run type-check`, eslint, prettier — clean.

**Not verified in a browser.** No Docker daemon or `api/.env` available on the machine this was written on, so there is no CouchDB/API to serve the `User` docs `UserOverview` reads (User is a non-synced, API-only type). Paging is covered by the page-level test against a mocked `/query`, but the real scroll-into-view geometry has not been exercised against a running CMS. Worth a manual check with >20 users before merge.