### PR TITLE
fix(app): vertically center horizontal tile scroll arrows (#1804)

### DIFF
--- a/app/src/components/content/HorizontalContentTileCollection.spec.ts
+++ b/app/src/components/content/HorizontalContentTileCollection.spec.ts
@@ -295,7 +295,10 @@ describe("HorizontalContentTileCollection", () => {
         await wrapper.vm.$nextTick();
 
         // Both spin buttons should be hidden in portrait mode
-        // The ArrowLeftCircleIcon and ArrowRightCircleIcon use v-if, so they won't be in the DOM
-        expect(wrapper.find(".mt-7.h-10.w-10").exists()).toBe(false);
+        // The ArrowLeftCircleIcon and ArrowRightCircleIcon use v-if, so their SVGs
+        // won't be in the DOM (checked via the spin-button containers, robust to styling).
+        const spinContainers = wrapper.findAll(".group.absolute");
+        expect(spinContainers[0].find("svg").exists()).toBe(false);
+        expect(spinContainers[1].find("svg").exists()).toBe(false);
     });
 });

--- a/app/src/components/content/HorizontalContentTileCollection.vue
+++ b/app/src/components/content/HorizontalContentTileCollection.vue
@@ -113,27 +113,21 @@ useInfiniteScroll(
 
         <div class="relative">
             <div
-                class="group absolute left-0 top-0 z-30 h-full cursor-pointer px-6"
+                class="group absolute left-0 top-0 z-30 flex h-full cursor-pointer items-center px-6"
                 @click="spinLeft()"
             >
                 <ArrowLeftCircleIcon
                     v-if="showLeftSpin"
-                    :class="[
-                        'mt-7 h-10 w-10 text-zinc-100 opacity-80 transition-opacity duration-200 group-hover:opacity-100 md:h-14 md:w-14',
-                        computedTitlePosition === 'overlay' ? 'md:mt-20' : 'md:mt-10',
-                    ]"
+                    class="h-10 w-10 text-zinc-100 opacity-80 transition-opacity duration-200 group-hover:opacity-100 md:h-14 md:w-14"
                 />
             </div>
             <div
-                class="group absolute right-0 top-0 z-30 h-full cursor-pointer px-6"
+                class="group absolute right-0 top-0 z-30 flex h-full cursor-pointer items-center px-6"
                 @click="spinRight()"
             >
                 <ArrowRightCircleIcon
                     v-if="showRightSpin"
-                    :class="[
-                        'mt-7 h-10 w-10 text-zinc-100 opacity-80 transition-opacity duration-200 group-hover:opacity-100 md:h-14 md:w-14',
-                        computedTitlePosition === 'overlay' ? 'md:mt-20' : 'md:mt-10',
-                    ]"
+                    class="h-10 w-10 text-zinc-100 opacity-80 transition-opacity duration-200 group-hover:opacity-100 md:h-14 md:w-14"
                 />
             </div>
 


### PR DESCRIPTION
Fixes #1804

## The bug
The left/right scroll arrows on explore-page horizontal tile rows (`HorizontalContentTileCollection`) weren't vertically centered — see the screenshot on the issue.

## Cause
Each arrow lives in a full-height container (`absolute top-0 h-full`), but was positioned with **hardcoded top margins** — `mt-7`, plus `md:mt-20`/`md:mt-10` chosen by title position — that only *approximate* the row's vertical center. As tile height varies (aspect ratio, image size, title position), the approximation drifts off-center.

## Fix
Center the arrow within its full-height container with `flex items-center` and remove the magic margins. This centers on the actual row height regardless of tile dimensions or title position — no per-case tuning.

```diff
-  class="group absolute left-0 top-0 z-30 h-full cursor-pointer px-6"
+  class="group absolute left-0 top-0 z-30 flex h-full cursor-pointer items-center px-6"
   ...
-  :class="['mt-7 h-10 w-10 … md:h-14 md:w-14', computedTitlePosition === 'overlay' ? 'md:mt-20' : 'md:mt-10']"
+  class="h-10 w-10 … md:h-14 md:w-14"
```

CSS-only; no behaviour change to scrolling or visibility logic.

## Tests
- The portrait-mode test keyed off the now-removed `mt-7` class (which would have made its selector silently match nothing). Retargeted it to assert the arrow SVGs are absent from the spin-button containers — consistent with the overflow test and robust to styling.
- `type-check`, eslint, prettier clean; `HorizontalContentTileCollection.spec.ts` 15/15 pass.

## ⚠️ Verification note
The change is a textbook flex vertical-center, and the unit suite passes — but I did **not** verify it pixel-level in a running browser. The arrows only appear when a tile row overflows and isn't in portrait, which needs a data-backed app (API + content) to render on the explore page. Worth a quick visual confirm on the explore page ("Big topics" row) before merge.