### PR TITLE
CMS: Fix auth provider labels not appearing (#1714)

### DIFF
--- a/cms/src/components/authProvider/LabelAndType.vue
+++ b/cms/src/components/authProvider/LabelAndType.vue
@@ -10,7 +10,7 @@ const provider = defineModel<AuthProviderDto>("provider", { required: true });
 </script>
 
 <template>
-    <div class="min-w-0 w-full max-w-full">
+    <div class="w-full min-w-0 max-w-full">
         <label for="provider-label" class="mb-1 block text-xs font-medium text-zinc-700">
             Label
         </label>
@@ -21,7 +21,7 @@ const provider = defineModel<AuthProviderDto>("provider", { required: true });
             type="text"
             placeholder="e.g. login.provider.button"
             :disabled="disabled"
-            @update:model-value="provider.label = $event"
+            @update:model-value="provider.label = String($event)"
         />
 
         <div class="mt-2">
@@ -29,8 +29,8 @@ const provider = defineModel<AuthProviderDto>("provider", { required: true });
                 Display name
             </label>
             <p class="mb-1 text-[11px] text-zinc-500">
-                You can use embedded translation lookups with [[key.path]] or enter a translation key
-                directly (key.subkey).
+                You can use embedded translation lookups with [[key.path]] or enter a translation
+                key directly (key.subkey).
             </p>
             <LInput
                 id="provider-display-name"
@@ -39,7 +39,7 @@ const provider = defineModel<AuthProviderDto>("provider", { required: true });
                 type="text"
                 placeholder="e.g. Sign in with [[organization.name]] or login.provider.button"
                 :disabled="disabled"
-                @update:model-value="provider.displayName = $event"
+                @update:model-value="provider.displayName = String($event)"
             />
             <p class="mt-1 text-[11px] text-zinc-500">
                 This name is shown in CMS lists and dialogs.

--- a/cms/src/components/users/CreateOrEditUser.vue
+++ b/cms/src/components/users/CreateOrEditUser.vue
@@ -147,7 +147,7 @@ const authProviders = useSharedHybridQuery<AuthProviderDto>(
 const providerOptions = computed(() => [
     { label: "Choose a provider this user belongs to", value: "" },
     ...authProviders.value.map((p) => ({
-        label: p.displayName || p.domain || "Unnamed provider",
+        label: p.label || p.domain || "Unnamed provider",
         value: p._id,
     })),
 ]);

--- a/cms/src/components/users/EditUser.spec.ts
+++ b/cms/src/components/users/EditUser.spec.ts
@@ -32,7 +32,7 @@ const mockAuthProvider: AuthProviderDto = {
     domain: "example.auth0.com",
     audience: "https://example.auth0.com",
     clientId: "client-abc",
-    label: "login.bcc.button",
+    label: "login.test.button",
     displayName: "Example",
     memberOf: ["group-super-admins"],
     updatedTimeUtc: 1704114000000,
@@ -252,7 +252,7 @@ describe("CreateOrEditUser.vue", () => {
             expect(providerSelect.exists()).toBe(true);
             const options = providerSelect.props("options") as { label: string }[];
             expect(options.some((o) => o.label.includes("Choose a provider"))).toBe(true);
-            expect(options.some((o) => o.label === "login.bcc.button")).toBe(true);
+            expect(options.some((o) => o.label === "login.login.button")).toBe(true);
         });
     });
 

--- a/cms/src/components/users/EditUser.spec.ts
+++ b/cms/src/components/users/EditUser.spec.ts
@@ -252,7 +252,7 @@ describe("CreateOrEditUser.vue", () => {
             expect(providerSelect.exists()).toBe(true);
             const options = providerSelect.props("options") as { label: string }[];
             expect(options.some((o) => o.label.includes("Choose a provider"))).toBe(true);
-            expect(options.some((o) => o.label === "Example")).toBe(true);
+            expect(options.some((o) => o.label === "login.bcc.button")).toBe(true);
         });
     });
 

--- a/cms/src/components/users/EditUser.spec.ts
+++ b/cms/src/components/users/EditUser.spec.ts
@@ -252,7 +252,7 @@ describe("CreateOrEditUser.vue", () => {
             expect(providerSelect.exists()).toBe(true);
             const options = providerSelect.props("options") as { label: string }[];
             expect(options.some((o) => o.label.includes("Choose a provider"))).toBe(true);
-            expect(options.some((o) => o.label === "login.login.button")).toBe(true);
+            expect(options.some((o) => o.label === "login.test.button")).toBe(true);
         });
     });
 

--- a/cms/src/components/users/UserDisplayCard.vue
+++ b/cms/src/components/users/UserDisplayCard.vue
@@ -52,7 +52,7 @@ const userProvider = computed(() =>
 const userProviderLabel = computed(() => {
     const provider = userProvider.value;
     if (!provider) return "";
-    return provider.displayName || provider.domain || "Auth provider";
+    return provider.label || provider.domain || "Auth provider";
 });
 </script>
 


### PR DESCRIPTION
CMS: Auth Provider dropdown when editing a user shows the API URL instead of a descriptive provider name