### PR TITLE
fix(app): correct 1px video shift on desktop Safari too (#813)

### DIFF
--- a/app/src/components/content/VideoPlayer.css
+++ b/app/src/components/content/VideoPlayer.css
@@ -194,11 +194,10 @@
     display: none !important;
 }
 
-/* iOS Safari renders the video-js tech element 1px lower than its absolutely-positioned
-   .video-player container, leaving a 1px gap at the top and an overhang at the bottom
-   (issue #813). Same iOS-Safari feature-query technique used in LHighlightable.vue. */
-@supports (-webkit-touch-callout: none) {
-    .video-player {
-        transform: translateY(-1px);
-    }
+/* Safari renders the video 1px lower than its absolutely-positioned .video-player
+   container, leaving a 1px gap at the top and an overhang at the bottom (issue #813).
+   Affects Safari on both macOS and iOS but not Chrome/Firefox, so the component toggles
+   `.safari-shift-fix` using video.js's browser detection (IS_SAFARI || IS_IOS). */
+.video-player.safari-shift-fix {
+    transform: translateY(-1px);
 }

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -35,6 +35,8 @@ const autoPlay = queryParams.get("autoplay") === "true";
 const autoFullscreen = queryParams.get("autofullscreen") === "true";
 const keepAudioAlive = ref<HTMLAudioElement | null>(null);
 const isRestoringTrack = ref<boolean>(false);
+// Safari (macOS + iOS) renders the video 1px too low; corrected via CSS (issue #813).
+const isSafariRendering = ref<boolean>(false);
 
 // YouTube detection
 const isYouTube = ref<boolean>(false);
@@ -143,6 +145,9 @@ onMounted(async () => {
     await new Promise((resolve) => requestAnimationFrame(resolve));
 
     const videojs = (await import("video.js")).default;
+
+    // Detect Safari for the 1px shift correction; same source used for nativeAudioTracks.
+    isSafariRendering.value = videojs.browser.IS_SAFARI || videojs.browser.IS_IOS;
 
     // Lazy load videojs-youtube only if we're playing a YouTube video
     if (isYouTube.value) {
@@ -566,7 +571,10 @@ watch(
             :parent-image-bucket-id="content.parentImageBucketId"
         />
 
-        <div class="video-player absolute bottom-0 left-0 right-0 top-0">
+        <div
+            class="video-player absolute bottom-0 left-0 right-0 top-0"
+            :class="{ 'safari-shift-fix': isSafariRendering }"
+        >
             <video
                 playsinline
                 ref="playerElement"
@@ -579,8 +587,17 @@ watch(
         </div>
 
         <!-- audio tag to keep player alive -->
-        <audio ref="keepAudioAlive" loop muted preload="auto" style="display: none">
-            <source src="../../assets/silence.wav" type="audio/wav" />
+        <audio
+            ref="keepAudioAlive"
+            loop
+            muted
+            preload="auto"
+            style="display: none"
+        >
+            <source
+                src="../../assets/silence.wav"
+                type="audio/wav"
+            />
         </audio>
 
         <transition


### PR DESCRIPTION
Re-opens #813 — the 1px downward video shift is back on **desktop (macOS) Safari**.

## Problem
`.video-player` is absolutely positioned, and Safari renders the video 1px lower than that container — a 1px gap at the top and an overhang at the bottom. This affects Safari on **both macOS and iOS**, but not Chrome/Firefox.

The existing correction was gated behind `@supports (-webkit-touch-callout: none)`, which only matches **iOS** — `-webkit-touch-callout` isn't supported by desktop macOS Safari, so the −1px correction never applied there. That's the "safari web" case in the screenshot on the issue.

## Fix
Drive the correction off the platform, not a CSS feature query. The component sets an `isSafariRendering` flag from **video.js's own browser detection** (`videojs.browser.IS_SAFARI || IS_IOS`) — the same source already used for `nativeAudioTracks` — and toggles a `.safari-shift-fix` class. The CSS applies `transform: translateY(-1px)` to that class.

This covers desktop macOS Safari **and** iOS, and excludes Chrome/Firefox (which don't have the shift, so they must not be nudged).

## Tests
- `VideoPlayer.spec.ts`: 12/12. `type-check` + eslint clean.

## ⚠️ Not verified on Safari
This is a Safari-specific rendering fix and I can't drive macOS/iOS Safari in this environment, so it's **verified by reasoning + the existing unit suite, not visually on Safari**. Worth a 10-second look before merge: open a video in **desktop Safari** and confirm the 1px gap/overhang is gone, and in **Chrome** confirm nothing moved (no new 1px misalignment). `videojs.browser.IS_SAFARI` is the same detection the player already trusts, so the risk is low — but low isn't verified.