### PR TITLE
feat(app): redesign related content as a "Read more" list (#1737)

### DIFF
--- a/api/src/db/seedingDocs/lang-eng.json
+++ b/api/src/db/seedingDocs/lang-eng.json
@@ -60,6 +60,7 @@
         "watch.title": "Watch",
         "home.newest": "Newest",
         "content.related_title": "Related",
+        "content.read_more": "Read more",
         "content.coming_soon": "Coming soon",
         "content.continueReading.prompt": "Continue where you left off?",
         "content.continueReading.action": "Continue where you left off",

--- a/api/src/db/seedingDocs/lang-fra.json
+++ b/api/src/db/seedingDocs/lang-fra.json
@@ -60,6 +60,7 @@
         "watch.title": "Regarde",
         "home.newest": "Nouveaux",
         "content.related_title": "Contenus similaires",
+        "content.read_more": "Lire plus",
         "content.coming_soon": "Bientôt disponible",
         "content.continueReading.prompt": "Reprendre où vous vous êtes arrêté ?",
         "content.continueReading.action": "Reprendre où vous vous êtes arrêté",

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -129,9 +129,7 @@ describe("ReadMore", () => {
             },
         ] as ContentDto[]);
 
-        const wrapper = mountList([
-            makeItem({ parentTags: ["category-1", "topic-1"] }),
-        ]);
+        const wrapper = mountList([makeItem({ parentTags: ["category-1", "topic-1"] })]);
 
         await waitForExpect(() => {
             const tags = wrapper.get('[data-test="content-tags"]');
@@ -140,6 +138,8 @@ describe("ReadMore", () => {
             expect(tags.classes()).toContain("overflow-x-auto");
             expect(tags.classes()).toContain("scrollbar-hide");
             expect(tags.classes()).toContain("sm:hidden");
+            // Categories are pinned to the bottom of the card.
+            expect(tags.classes()).toContain("mt-auto");
         });
     });
 

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -1,0 +1,58 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ReadMore, { type ReadMoreItem } from "./ReadMore.vue";
+
+const makeItem = (overrides: Partial<ReadMoreItem> = {}): ReadMoreItem => ({
+    content: {
+        _id: "content-1",
+        slug: "post-1",
+        title: "A short title",
+        summary: "A short summary",
+        publishDate: 1_700_000_000_000,
+        parentId: "post-1",
+    } as any,
+    tags: [],
+    ...overrides,
+});
+
+const mountList = (items: ReadMoreItem[]) =>
+    mount(ReadMore, {
+        props: { items },
+        global: {
+            stubs: {
+                // Render the link's slot without pulling in the router; skip image internals.
+                RouterLink: { template: "<a><slot /></a>" },
+                LImage: true,
+            },
+        },
+    });
+
+describe("ReadMore", () => {
+    it("shows every tag when there are only a few", () => {
+        const wrapper = mountList([makeItem({ tags: ["Category 1", "Topic A"] })]);
+
+        expect(wrapper.text()).toContain("Category 1");
+        expect(wrapper.text()).toContain("Topic A");
+        expect(wrapper.text()).not.toContain("+");
+    });
+
+    it("collapses extra tags into a +N chip", () => {
+        const wrapper = mountList([
+            makeItem({ tags: ["Category 1", "Topic A", "Topic B", "Topic C"] }),
+        ]);
+
+        // First two are shown, the remaining two are summarised as "+2".
+        expect(wrapper.text()).toContain("Category 1");
+        expect(wrapper.text()).toContain("Topic A");
+        expect(wrapper.text()).not.toContain("Topic B");
+        expect(wrapper.text()).not.toContain("Topic C");
+        expect(wrapper.text()).toContain("+2");
+    });
+
+    it("keeps the title to a single truncated line", () => {
+        const wrapper = mountList([makeItem({ content: { ...makeItem().content, title: "T" } })]);
+
+        expect(wrapper.get("h3").classes()).toContain("truncate");
+    });
+});

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -106,6 +106,15 @@ describe("ReadMore", () => {
         expect(summaryClampFor(3)).toBe("line-clamp-1");
     });
 
+    it("uses even top/bottom/right spacing around the mobile text content", () => {
+        const wrapper = mountList([makeItem()]);
+
+        const textArea = wrapper.get("p").element.parentElement!;
+        // p-2 gives an equal 8px on every side; pl-0 drops the left (the thumbnail gap sets it).
+        expect(textArea.classList).toContain("p-2");
+        expect(textArea.classList).toContain("pl-0");
+    });
+
     it("shows the content tags in a horizontally scrollable mobile row", async () => {
         await db.docs.bulkPut([
             mockLanguageDtoEng,
@@ -148,6 +157,8 @@ describe("ReadMore", () => {
             expect(tags.classes()).toContain("sm:hidden");
             // Categories are pinned to the bottom of the card.
             expect(tags.classes()).toContain("mt-auto");
+            // No extra bottom padding, so the space below the chips matches the top/right.
+            expect(tags.classes()).not.toContain("pb-1");
         });
     });
 

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -159,6 +159,8 @@ describe("ReadMore", () => {
             expect(tags.classes()).toContain("mt-auto");
             // No extra bottom padding, so the space below the chips matches the top/right.
             expect(tags.classes()).not.toContain("pb-1");
+            // The row carries an edge-fade mask so it dissolves toward the card edge.
+            expect(tags.attributes("style") ?? "").toContain("linear-gradient");
         });
     });
 

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -2,10 +2,11 @@ import "fake-indexeddb/auto";
 import { describe, it, expect, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import ReadMore, { type ReadMoreItem } from "./ReadMore.vue";
+import { type ContentDto } from "luminary-shared";
+import ReadMore from "./ReadMore.vue";
 
-// Capture the observer callback so tests can simulate the mobile infinite-scroll
-// sentinel entering the viewport (jsdom has no layout, so it never fires on its own).
+// Capture the observer callback so tests can simulate the infinite-scroll sentinel
+// entering the viewport (jsdom has no layout, so it never fires on its own).
 let intersect: (entries: Array<{ isIntersecting: boolean }>) => void;
 beforeEach(() => {
     window.IntersectionObserver = class {
@@ -18,20 +19,23 @@ beforeEach(() => {
     } as unknown as typeof IntersectionObserver;
 });
 
-const makeItem = (overrides: Partial<ReadMoreItem> = {}): ReadMoreItem => ({
-    content: {
+const makeItem = (overrides: Partial<ContentDto> = {}): ContentDto =>
+    ({
         _id: "content-1",
         slug: "post-1",
         title: "A short title",
         summary: "A short summary",
         publishDate: 1_700_000_000_000,
         parentId: "post-1",
-    } as any,
-    tags: [],
-    ...overrides,
-});
+        ...overrides,
+    }) as ContentDto;
 
-const mountList = (items: ReadMoreItem[]) =>
+const makeItems = (count: number): ContentDto[] =>
+    Array.from({ length: count }, (_, i) =>
+        makeItem({ _id: `content-${i}`, slug: `post-${i}`, title: `Post ${i}` }),
+    );
+
+const mountList = (items: ContentDto[]) =>
     mount(ReadMore, {
         props: { items },
         global: {
@@ -44,69 +48,45 @@ const mountList = (items: ReadMoreItem[]) =>
     });
 
 describe("ReadMore", () => {
-    it("shows every tag when there are only a few", () => {
-        const wrapper = mountList([makeItem({ tags: ["Category 1", "Topic A"] })]);
+    it("keeps the mobile title to a single truncated line", () => {
+        const wrapper = mountList([makeItem()]);
 
-        expect(wrapper.text()).toContain("Category 1");
-        expect(wrapper.text()).toContain("Topic A");
-        expect(wrapper.text()).not.toContain("+");
+        const mobileTitle = wrapper.findAll("h3").find((h) => h.classes().includes("sm:hidden"));
+        expect(mobileTitle).toBeDefined();
+        expect(mobileTitle!.classes()).toContain("truncate");
     });
 
-    it("collapses extra tags into a +N chip", () => {
-        const wrapper = mountList([
-            makeItem({ tags: ["Category 1", "Topic A", "Topic B", "Topic C"] }),
-        ]);
+    it("wraps the card title on the image instead of truncating it", () => {
+        const wrapper = mountList([makeItem()]);
 
-        // First two are shown, the remaining two are summarised as "+2".
-        expect(wrapper.text()).toContain("Category 1");
-        expect(wrapper.text()).toContain("Topic A");
-        expect(wrapper.text()).not.toContain("Topic B");
-        expect(wrapper.text()).not.toContain("Topic C");
-        expect(wrapper.text()).toContain("+2");
+        const cardTitle = wrapper.findAll("h3").find((h) => !h.classes().includes("sm:hidden"));
+        expect(cardTitle).toBeDefined();
+        expect(cardTitle!.text()).toBe("A short title");
+        expect(cardTitle!.classes()).not.toContain("truncate");
+        expect(cardTitle!.classes().some((c) => c.startsWith("line-clamp"))).toBe(false);
     });
 
-    it("keeps the title to a single truncated line", () => {
-        const wrapper = mountList([makeItem({ content: { ...makeItem().content, title: "T" } })]);
+    it("clamps the summary to one line on mobile and two lines on the card", () => {
+        const wrapper = mountList([makeItem()]);
 
-        expect(wrapper.get("h3").classes()).toContain("truncate");
+        const summary = wrapper.get("p");
+        expect(summary.text()).toBe("A short summary");
+        expect(summary.classes()).toContain("line-clamp-1");
+        expect(summary.classes()).toContain("sm:line-clamp-2");
     });
 
-    const makeItems = (count: number): ReadMoreItem[] =>
-        Array.from({ length: count }, (_, i) =>
-            makeItem({
-                content: {
-                    ...makeItem().content,
-                    _id: `content-${i}`,
-                    slug: `post-${i}`,
-                    title: `Post ${i}`,
-                } as ReadMoreItem["content"],
-            }),
-        );
-
-    it("renders every card for the desktop row but only one batch on mobile", () => {
+    it("shows one batch initially and reveals the next when the sentinel intersects", async () => {
         const wrapper = mountList(makeItems(20));
 
-        const cards = wrapper.findAll("li");
-        expect(cards).toHaveLength(20);
-        // The first batch is visible everywhere...
-        expect(cards[7].classes()).not.toContain("hidden");
-        // ...the rest are hidden on mobile only (still shown from tablet up).
-        expect(cards[8].classes()).toContain("hidden");
-        expect(cards[8].classes()).toContain("sm:block");
-    });
-
-    it("reveals the next mobile batch when the sentinel intersects", async () => {
-        const wrapper = mountList(makeItems(20));
+        expect(wrapper.findAll("li")).toHaveLength(8);
 
         intersect([{ isIntersecting: true }]);
         await nextTick();
-        expect(wrapper.findAll("li")[15].classes()).not.toContain("hidden");
-        expect(wrapper.findAll("li")[16].classes()).toContain("hidden");
+        expect(wrapper.findAll("li")).toHaveLength(16);
 
         intersect([{ isIntersecting: true }]);
         await nextTick();
-        const cards = wrapper.findAll("li");
-        expect(cards.every((card) => !card.classes().includes("hidden"))).toBe(true);
+        expect(wrapper.findAll("li")).toHaveLength(20);
 
         // Fully revealed — further intersections change nothing.
         intersect([{ isIntersecting: true }]);

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { db, DocType, PublishStatus, TagType, type ContentDto } from "luminary-shared";
-import ReadMore from "./ReadMore.vue";
+import ReadMore, { summaryClampFor } from "./ReadMore.vue";
 import waitForExpect from "wait-for-expect";
 import { mockLanguageDtoEng } from "@/tests/mockdata";
 import { appLanguageIdsAsRef } from "@/globalConfig";
@@ -68,12 +68,13 @@ describe("ReadMore", () => {
         expect(card.classes()).toContain("sm:flex-col");
     });
 
-    it("keeps the mobile title to a single truncated line", () => {
+    it("lets the mobile title wrap onto up to two lines", () => {
         const wrapper = mountList([makeItem()]);
 
         const mobileTitle = wrapper.findAll("h3").find((h) => h.classes().includes("sm:hidden"));
         expect(mobileTitle).toBeDefined();
-        expect(mobileTitle!.classes()).toContain("truncate");
+        expect(mobileTitle!.classes()).toContain("line-clamp-2");
+        expect(mobileTitle!.classes()).not.toContain("truncate");
     });
 
     it("wraps the card title on the image instead of truncating it", () => {
@@ -86,16 +87,23 @@ describe("ReadMore", () => {
         expect(cardTitle!.classes().some((c) => c.startsWith("line-clamp"))).toBe(false);
     });
 
-    it("clamps the summary to one line on mobile and two lines on the card", () => {
+    it("gives a short-title card a two-line summary, and always two on the card", () => {
         const wrapper = mountList([makeItem()]);
 
         const summary = wrapper.get("p");
         const summaryArea = summary.element.parentElement!;
         expect(summary.text()).toBe("A short summary");
-        expect(summary.classes()).toContain("line-clamp-1");
+        // Default (one-line title) → the summary gets two lines on mobile.
+        expect(summary.classes()).toContain("line-clamp-2");
         expect(summary.classes()).toContain("sm:line-clamp-2");
-        expect(summary.classes()).not.toContain("sm:mx-auto");
         expect(summaryArea.classList).toContain("sm:justify-center");
+    });
+
+    it("maps the measured title line count to the summary clamp", () => {
+        // One-line title leaves room for a two-line summary; a two-line title leaves one.
+        expect(summaryClampFor(1)).toBe("line-clamp-2");
+        expect(summaryClampFor(2)).toBe("line-clamp-1");
+        expect(summaryClampFor(3)).toBe("line-clamp-1");
     });
 
     it("shows the content tags in a horizontally scrollable mobile row", async () => {

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -1,7 +1,22 @@
 import "fake-indexeddb/auto";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
 import ReadMore, { type ReadMoreItem } from "./ReadMore.vue";
+
+// Capture the observer callback so tests can simulate the mobile infinite-scroll
+// sentinel entering the viewport (jsdom has no layout, so it never fires on its own).
+let intersect: (entries: Array<{ isIntersecting: boolean }>) => void;
+beforeEach(() => {
+    window.IntersectionObserver = class {
+        constructor(cb: IntersectionObserverCallback) {
+            intersect = cb as unknown as typeof intersect;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+});
 
 const makeItem = (overrides: Partial<ReadMoreItem> = {}): ReadMoreItem => ({
     content: {
@@ -54,5 +69,48 @@ describe("ReadMore", () => {
         const wrapper = mountList([makeItem({ content: { ...makeItem().content, title: "T" } })]);
 
         expect(wrapper.get("h3").classes()).toContain("truncate");
+    });
+
+    const makeItems = (count: number): ReadMoreItem[] =>
+        Array.from({ length: count }, (_, i) =>
+            makeItem({
+                content: {
+                    ...makeItem().content,
+                    _id: `content-${i}`,
+                    slug: `post-${i}`,
+                    title: `Post ${i}`,
+                } as ReadMoreItem["content"],
+            }),
+        );
+
+    it("renders every card for the desktop row but only one batch on mobile", () => {
+        const wrapper = mountList(makeItems(20));
+
+        const cards = wrapper.findAll("li");
+        expect(cards).toHaveLength(20);
+        // The first batch is visible everywhere...
+        expect(cards[7].classes()).not.toContain("hidden");
+        // ...the rest are hidden on mobile only (still shown from tablet up).
+        expect(cards[8].classes()).toContain("hidden");
+        expect(cards[8].classes()).toContain("sm:block");
+    });
+
+    it("reveals the next mobile batch when the sentinel intersects", async () => {
+        const wrapper = mountList(makeItems(20));
+
+        intersect([{ isIntersecting: true }]);
+        await nextTick();
+        expect(wrapper.findAll("li")[15].classes()).not.toContain("hidden");
+        expect(wrapper.findAll("li")[16].classes()).toContain("hidden");
+
+        intersect([{ isIntersecting: true }]);
+        await nextTick();
+        const cards = wrapper.findAll("li");
+        expect(cards.every((card) => !card.classes().includes("hidden"))).toBe(true);
+
+        // Fully revealed — further intersections change nothing.
+        intersect([{ isIntersecting: true }]);
+        await nextTick();
+        expect(wrapper.findAll("li")).toHaveLength(20);
     });
 });

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -1,9 +1,12 @@
 import "fake-indexeddb/auto";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { type ContentDto } from "luminary-shared";
+import { db, DocType, PublishStatus, TagType, type ContentDto } from "luminary-shared";
 import ReadMore from "./ReadMore.vue";
+import waitForExpect from "wait-for-expect";
+import { mockLanguageDtoEng } from "@/tests/mockdata";
+import { appLanguageIdsAsRef } from "@/globalConfig";
 
 // Capture the observer callback so tests can simulate the infinite-scroll sentinel
 // entering the viewport (jsdom has no layout, so it never fires on its own).
@@ -17,6 +20,11 @@ beforeEach(() => {
         unobserve() {}
         disconnect() {}
     } as unknown as typeof IntersectionObserver;
+    appLanguageIdsAsRef.value = ["lang-eng"];
+});
+
+afterEach(async () => {
+    await db.docs.clear();
 });
 
 const makeItem = (overrides: Partial<ContentDto> = {}): ContentDto =>
@@ -48,6 +56,18 @@ const mountList = (items: ContentDto[]) =>
     });
 
 describe("ReadMore", () => {
+    it("uses a card surface while keeping the mobile image-and-text row", () => {
+        const wrapper = mountList([makeItem()]);
+
+        const card = wrapper.get("a");
+        expect(card.classes()).toContain("rounded-lg");
+        expect(card.classes()).toContain("overflow-hidden");
+        expect(card.classes()).toContain("shadow");
+        expect(card.classes()).not.toContain("p-1");
+        expect(card.classes()).toContain("flex");
+        expect(card.classes()).toContain("sm:flex-col");
+    });
+
     it("keeps the mobile title to a single truncated line", () => {
         const wrapper = mountList([makeItem()]);
 
@@ -70,9 +90,57 @@ describe("ReadMore", () => {
         const wrapper = mountList([makeItem()]);
 
         const summary = wrapper.get("p");
+        const summaryArea = summary.element.parentElement!;
         expect(summary.text()).toBe("A short summary");
         expect(summary.classes()).toContain("line-clamp-1");
         expect(summary.classes()).toContain("sm:line-clamp-2");
+        expect(summary.classes()).not.toContain("sm:mx-auto");
+        expect(summaryArea.classList).toContain("sm:justify-center");
+    });
+
+    it("shows the content tags in a horizontally scrollable mobile row", async () => {
+        await db.docs.bulkPut([
+            mockLanguageDtoEng,
+            {
+                ...makeItem(),
+                _id: "content-category-1",
+                type: DocType.Content,
+                parentId: "category-1",
+                parentType: DocType.Tag,
+                parentTagType: TagType.Category,
+                language: "lang-eng",
+                title: "Category 1",
+                slug: "category-1",
+                parentTags: [],
+                status: PublishStatus.Published,
+            },
+            {
+                ...makeItem(),
+                _id: "content-topic-1",
+                type: DocType.Content,
+                parentId: "topic-1",
+                parentType: DocType.Tag,
+                parentTagType: TagType.Topic,
+                language: "lang-eng",
+                title: "Topic 1",
+                slug: "topic-1",
+                parentTags: [],
+                status: PublishStatus.Published,
+            },
+        ] as ContentDto[]);
+
+        const wrapper = mountList([
+            makeItem({ parentTags: ["category-1", "topic-1"] }),
+        ]);
+
+        await waitForExpect(() => {
+            const tags = wrapper.get('[data-test="content-tags"]');
+            expect(tags.text()).toContain("Category 1");
+            expect(tags.text()).toContain("Topic 1");
+            expect(tags.classes()).toContain("overflow-x-auto");
+            expect(tags.classes()).toContain("scrollbar-hide");
+            expect(tags.classes()).toContain("sm:hidden");
+        });
     });
 
     it("shows one batch initially and reveals the next when the sentinel intersects", async () => {

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { onMounted, onUnmounted, nextTick, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { DateTime } from "luxon";
 import { type ContentDto } from "luminary-shared";
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/24/solid";
 import LImage from "../images/LImage.vue";
 
 export type ReadMoreItem = {
@@ -9,7 +11,7 @@ export type ReadMoreItem = {
     tags: string[];
 };
 
-defineProps<{ items: ReadMoreItem[] }>();
+const props = defineProps<{ items: ReadMoreItem[] }>();
 
 const summaryText = (content: ContentDto): string => content.summary?.trim() ?? "";
 
@@ -22,87 +24,143 @@ const dateText = (content: ContentDto): string =>
 const MAX_VISIBLE_TAGS = 2;
 const visibleTags = (tags: string[]): string[] => tags.slice(0, MAX_VISIBLE_TAGS);
 const extraTagCount = (tags: string[]): number => Math.max(0, tags.length - MAX_VISIBLE_TAGS);
+
+// From tablet up the cards sit in a horizontal scroll row. The arrows only show on desktop
+// (where a mouse can't scroll sideways) and only when there's more to reveal in that direction.
+const scrollEl = ref<HTMLElement | null>(null);
+const showLeft = ref(false);
+const showRight = ref(false);
+
+const updateArrows = () => {
+    const el = scrollEl.value;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    showLeft.value = el.scrollLeft > 5;
+    showRight.value = maxScroll > 5 && el.scrollLeft < maxScroll - 5;
+};
+
+const scrollByCards = (direction: 1 | -1) => {
+    scrollEl.value?.scrollBy({ left: direction * 320, behavior: "smooth" });
+};
+
+onMounted(() => {
+    updateArrows();
+    window.addEventListener("resize", updateArrows);
+});
+onUnmounted(() => window.removeEventListener("resize", updateArrows));
+watch(
+    () => props.items,
+    () => nextTick(updateArrows),
+);
 </script>
 
 <template>
-    <!-- Mobile is a single-column list of image-left rows. From tablet up it becomes a grid of
-         image-on-top cards (the layout most content sites use for "related" — vertical cards
-         tile better than wide rows). More columns as the screen grows keeps each tile compact,
-         matching the Explore page: 2 → 3 → 4. -->
-    <ul class="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-8 md:grid-cols-3 lg:grid-cols-4">
-        <li
-            v-for="item in items"
-            :key="item.content._id"
-            class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:border-0"
+    <div class="relative">
+        <!-- Desktop scroll controls (touch devices scroll the row directly). -->
+        <button
+            v-if="showLeft"
+            type="button"
+            aria-label="Scroll left"
+            class="absolute left-1 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-white/90 p-1 text-zinc-700 shadow ring-1 ring-black/5 hover:bg-white dark:bg-slate-800/90 dark:text-slate-100 dark:ring-white/10 sm:flex"
+            @click="scrollByCards(-1)"
         >
-            <RouterLink
-                :to="{ name: 'content', params: { slug: item.content.slug } }"
-                class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:flex-col sm:gap-2 sm:py-0"
-            >
-                <!-- Mobile: small thumbnail on the left. -->
-                <div class="shrink-0 sm:hidden">
-                    <LImage
-                        :image="item.content.parentImageData"
-                        :content-parent-id="item.content.parentId"
-                        :parent-image-bucket-id="item.content.parentImageBucketId"
-                        aspectRatio="classic"
-                        size="thumbnailCompact"
-                    />
-                </div>
+            <ChevronLeftIcon class="h-5 w-5" />
+        </button>
+        <button
+            v-if="showRight"
+            type="button"
+            aria-label="Scroll right"
+            class="absolute right-1 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-white/90 p-1 text-zinc-700 shadow ring-1 ring-black/5 hover:bg-white dark:bg-slate-800/90 dark:text-slate-100 dark:ring-white/10 sm:flex"
+            @click="scrollByCards(1)"
+        >
+            <ChevronRightIcon class="h-5 w-5" />
+        </button>
 
-                <!-- Tablet and up: full-width image on top of the card. Only the visible image
-                     loads (both are lazy), so this doesn't fetch two files per card. -->
-                <div class="hidden sm:block">
-                    <LImage
-                        :image="item.content.parentImageData"
-                        :content-parent-id="item.content.parentId"
-                        :parent-image-bucket-id="item.content.parentImageBucketId"
-                        aspectRatio="classic"
-                        size="card"
-                    />
-                </div>
-
-                <div class="flex min-w-0 flex-1 flex-col gap-1">
-                    <h3 class="truncate font-semibold text-zinc-800 dark:text-slate-50">
-                        {{ item.content.title }}
-                    </h3>
-
-                    <p
-                        v-if="summaryText(item.content)"
-                        class="line-clamp-2 text-sm text-zinc-500 dark:text-slate-400"
+        <!-- Mobile: a padded single-column list of image-left rows. From tablet up: a full-bleed
+             horizontal scroll row of image-on-top cards (the scroll container spans the full
+             width; the inner list keeps an edge inset), matching the Explore content rows. -->
+        <div
+            ref="scrollEl"
+            class="sm:overflow-x-auto sm:scrollbar-hide"
+            @scroll="updateArrows"
+        >
+            <ul class="flex flex-col px-4 sm:flex-row sm:gap-4">
+                <li
+                    v-for="item in items"
+                    :key="item.content._id"
+                    class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:w-48 sm:shrink-0 sm:border-0"
+                >
+                    <RouterLink
+                        :to="{ name: 'content', params: { slug: item.content.slug } }"
+                        class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:flex-col sm:gap-2 sm:py-0"
                     >
-                        {{ summaryText(item.content) }}
-                    </p>
+                        <!-- Mobile: small thumbnail on the left. -->
+                        <div class="shrink-0 sm:hidden">
+                            <LImage
+                                :image="item.content.parentImageData"
+                                :content-parent-id="item.content.parentId"
+                                :parent-image-bucket-id="item.content.parentImageBucketId"
+                                aspectRatio="classic"
+                                size="thumbnailCompact"
+                            />
+                        </div>
 
-                    <p
-                        v-if="dateText(item.content)"
-                        class="text-xs text-zinc-400 dark:text-slate-500"
-                    >
-                        {{ dateText(item.content) }}
-                    </p>
+                        <!-- Tablet and up: full-width image on top of the card. Only the visible
+                             image loads (both are lazy), so this doesn't fetch two files per card. -->
+                        <div class="hidden sm:block">
+                            <LImage
+                                :image="item.content.parentImageData"
+                                :content-parent-id="item.content.parentId"
+                                :parent-image-bucket-id="item.content.parentImageBucketId"
+                                aspectRatio="classic"
+                                size="card"
+                            />
+                        </div>
 
-                    <!-- One line of category chips (same colour as the category tags under the
-                         bookmark icon, without the tag icon), with a "+N" chip for any extras. -->
-                    <div
-                        v-if="item.tags.length"
-                        class="mt-0.5 flex gap-1.5 overflow-hidden"
-                    >
-                        <span
-                            v-for="tag in visibleTags(item.tags)"
-                            :key="tag"
-                            class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
-                        >
-                            {{ tag }}
-                        </span>
-                        <span
-                            v-if="extraTagCount(item.tags)"
-                            class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
-                        >
-                            +{{ extraTagCount(item.tags) }}
-                        </span>
-                    </div>
-                </div>
-            </RouterLink>
-        </li>
-    </ul>
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                            <h3 class="truncate font-semibold text-zinc-800 dark:text-slate-50">
+                                {{ item.content.title }}
+                            </h3>
+
+                            <p
+                                v-if="summaryText(item.content)"
+                                class="line-clamp-2 text-sm text-zinc-500 dark:text-slate-400"
+                            >
+                                {{ summaryText(item.content) }}
+                            </p>
+
+                            <p
+                                v-if="dateText(item.content)"
+                                class="text-xs text-zinc-400 dark:text-slate-500"
+                            >
+                                {{ dateText(item.content) }}
+                            </p>
+
+                            <!-- One line of category chips (same colour as the category tags under
+                                 the bookmark icon, without the tag icon), with a "+N" chip for the
+                                 rest. -->
+                            <div
+                                v-if="item.tags.length"
+                                class="mt-0.5 flex gap-1.5 overflow-hidden"
+                            >
+                                <span
+                                    v-for="tag in visibleTags(item.tags)"
+                                    :key="tag"
+                                    class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
+                                >
+                                    {{ tag }}
+                                </span>
+                                <span
+                                    v-if="extraTagCount(item.tags)"
+                                    class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
+                                >
+                                    +{{ extraTagCount(item.tags) }}
+                                </span>
+                            </div>
+                        </div>
+                    </RouterLink>
+                </li>
+            </ul>
+        </div>
+    </div>
 </template>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -192,7 +192,7 @@ watch(visibleItems, () => nextTick(remeasureAll));
                         <h3
                             :data-id="item._id"
                             data-mobile-title
-                            class="line-clamp-2 font-semibold text-zinc-800 dark:text-slate-50 sm:hidden"
+                            class="-mt-1 line-clamp-2 font-semibold text-zinc-800 dark:text-slate-50 sm:hidden"
                         >
                             {{ item.title }}
                         </h3>
@@ -207,14 +207,11 @@ watch(visibleItems, () => nextTick(remeasureAll));
                             {{ summaryText(item) }}
                         </p>
 
-                        <!-- Categories sit at the bottom of the card (mt-auto) and fade toward
-                             the card edge as the row scrolls (the fade is a mask, so the row
-                             keeps its margins). -->
                         <div
                             v-if="tagsFor(item).length"
                             :data-id="item._id"
                             data-tags-row
-                            class="mt-auto flex max-w-full gap-1 overflow-x-auto scrollbar-hide sm:hidden"
+                            class="-ml-2 mt-auto flex gap-1 overflow-x-auto pl-2 scrollbar-hide sm:hidden"
                             :style="tagFadeStyle(item._id)"
                             data-test="content-tags"
                             @scroll="(e) => updateTagFade(item._id, e.target as HTMLElement)"

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -17,6 +17,11 @@ const dateText = (content: ContentDto): string =>
     content.publishDate
         ? DateTime.fromMillis(content.publishDate).toLocaleString(DateTime.DATE_MED)
         : "";
+
+// Keep the chips to a single line: show the first few, then a "+N" chip for the rest.
+const MAX_VISIBLE_TAGS = 2;
+const visibleTags = (tags: string[]): string[] => tags.slice(0, MAX_VISIBLE_TAGS);
+const extraTagCount = (tags: string[]): number => Math.max(0, tags.length - MAX_VISIBLE_TAGS);
 </script>
 
 <template>
@@ -57,7 +62,7 @@ const dateText = (content: ContentDto): string =>
                 </div>
 
                 <div class="flex min-w-0 flex-1 flex-col gap-1">
-                    <h3 class="line-clamp-2 font-semibold text-zinc-800 dark:text-slate-50">
+                    <h3 class="truncate font-semibold text-zinc-800 dark:text-slate-50">
                         {{ item.content.title }}
                     </h3>
 
@@ -75,18 +80,24 @@ const dateText = (content: ContentDto): string =>
                         {{ dateText(item.content) }}
                     </p>
 
-                    <!-- Tags scroll horizontally when they overflow (same chip colour as the
-                         category tags under the bookmark icon, without the tag icon). -->
+                    <!-- One line of category chips (same colour as the category tags under the
+                         bookmark icon, without the tag icon), with a "+N" chip for any extras. -->
                     <div
                         v-if="item.tags.length"
-                        class="mt-0.5 flex gap-1.5 overflow-x-auto scrollbar-hide"
+                        class="mt-0.5 flex gap-1.5 overflow-hidden"
                     >
                         <span
-                            v-for="tag in item.tags"
+                            v-for="tag in visibleTags(item.tags)"
                             :key="tag"
                             class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
                         >
                             {{ tag }}
+                        </span>
+                        <span
+                            v-if="extraTagCount(item.tags)"
+                            class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
+                        >
+                            +{{ extraTagCount(item.tags) }}
                         </span>
                     </div>
                 </div>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -27,8 +27,9 @@ const extraTagCount = (tags: string[]): number => Math.max(0, tags.length - MAX_
 <template>
     <!-- Mobile is a single-column list of image-left rows. From tablet up it becomes a grid of
          image-on-top cards (the layout most content sites use for "related" — vertical cards
-         tile better than wide rows): two columns on tablet, three on desktop. -->
-    <ul class="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-8 lg:grid-cols-3">
+         tile better than wide rows). More columns as the screen grows keeps each tile compact,
+         matching the Explore page: 2 → 3 → 4. -->
+    <ul class="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-8 md:grid-cols-3 lg:grid-cols-4">
         <li
             v-for="item in items"
             :key="item.content._id"

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -9,9 +9,7 @@ const props = defineProps<{ items: ContentDto[] }>();
 
 const summaryText = (content: ContentDto): string => content.summary?.trim() ?? "";
 
-const tagIds = computed(() => [
-    ...new Set(props.items.flatMap((item) => item.parentTags ?? [])),
-]);
+const tagIds = computed(() => [...new Set(props.items.flatMap((item) => item.parentTags ?? []))]);
 const tagDocs = useContentQuery(
     () => [{ parentId: { $in: tagIds.value.length ? tagIds.value : [] } }],
     { includeScheduled: false },
@@ -62,7 +60,7 @@ watch(
             >
                 <RouterLink
                     :to="{ name: 'content', params: { slug: item.slug } }"
-                    class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:brightness-[1.15] hover:shadow-lg dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
+                    class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:shadow-lg hover:brightness-[1.15] dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
                 >
                     <!-- Mobile: small thumbnail on the left. -->
                     <div class="shrink-0 sm:hidden">
@@ -119,9 +117,11 @@ watch(
                             {{ summaryText(item) }}
                         </p>
 
+                        <!-- Categories sit at the bottom of the card: mt-auto pushes them below
+                             the title and summary when the row is taller than the text. -->
                         <div
                             v-if="tagsFor(item).length"
-                            class="flex max-w-full gap-1 overflow-x-auto pb-1 scrollbar-hide sm:hidden"
+                            class="mt-auto flex max-w-full gap-1 overflow-x-auto pb-1 scrollbar-hide sm:hidden"
                             data-test="content-tags"
                         >
                             <span

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -1,18 +1,25 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
-import { DateTime } from "luxon";
 import { type ContentDto } from "luminary-shared";
+import { useContentQuery } from "@/composables/useContentQuery";
 import LImage from "../images/LImage.vue";
 
 const props = defineProps<{ items: ContentDto[] }>();
 
 const summaryText = (content: ContentDto): string => content.summary?.trim() ?? "";
 
-const dateText = (content: ContentDto): string =>
-    content.publishDate
-        ? DateTime.fromMillis(content.publishDate).toLocaleString(DateTime.DATE_MED)
-        : "";
+const tagIds = computed(() => [
+    ...new Set(props.items.flatMap((item) => item.parentTags ?? [])),
+]);
+const tagDocs = useContentQuery(
+    () => [{ parentId: { $in: tagIds.value.length ? tagIds.value : [] } }],
+    { includeScheduled: false },
+);
+const tagsFor = (content: ContentDto): ContentDto[] => {
+    const ids = new Set(content.parentTags ?? []);
+    return tagDocs.value.filter((tag) => ids.has(tag.parentId));
+};
 
 // Infinite list on every breakpoint: start with one batch and reveal the next whenever
 // the sentinel below the list scrolls into view (the grid grows vertically too, so the
@@ -47,16 +54,15 @@ watch(
              image-top cards with the title bottom-aligned on the image. Fewer columns than
              the Explore rows so the images stay large. -->
         <ul
-            class="flex flex-col px-4 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-6 sm:px-8 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+            class="flex flex-col gap-3 px-4 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-6 sm:px-8 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
         >
             <li
                 v-for="item in visibleItems"
                 :key="item._id"
-                class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:border-0"
             >
                 <RouterLink
                     :to="{ name: 'content', params: { slug: item.slug } }"
-                    class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:h-full sm:flex-col sm:gap-2 sm:overflow-hidden sm:rounded-lg sm:bg-white sm:py-0 sm:shadow sm:ring-1 sm:ring-zinc-950/10 sm:hover:shadow-lg dark:sm:bg-slate-800 dark:sm:ring-white/10"
+                    class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:brightness-[1.15] hover:shadow-lg dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
                 >
                     <!-- Mobile: small thumbnail on the left. -->
                     <div class="shrink-0 sm:hidden">
@@ -66,6 +72,7 @@ watch(
                             :parent-image-bucket-id="item.parentImageBucketId"
                             aspectRatio="classic"
                             size="thumbnailCompact"
+                            :rounded="false"
                         />
                     </div>
 
@@ -86,7 +93,7 @@ watch(
                             :rounded="false"
                         />
                         <div
-                            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 via-black/40 to-black/0 px-3 pb-1.5 pt-6"
+                            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 via-black/40 to-black/0 px-2 pb-1.5 pt-6"
                         >
                             <h3 class="font-semibold text-white">
                                 {{ item.title }}
@@ -94,7 +101,9 @@ watch(
                         </div>
                     </div>
 
-                    <div class="flex min-w-0 flex-1 flex-col gap-1 sm:px-3 sm:pb-3">
+                    <div
+                        class="flex min-w-0 flex-1 flex-col gap-1 py-2 pr-2 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
+                    >
                         <!-- Mobile only: title beside the thumbnail (on the card it sits on
                              the image instead). -->
                         <h3
@@ -110,12 +119,19 @@ watch(
                             {{ summaryText(item) }}
                         </p>
 
-                        <p
-                            v-if="dateText(item)"
-                            class="text-xs text-zinc-400 dark:text-slate-500"
+                        <div
+                            v-if="tagsFor(item).length"
+                            class="flex max-w-full gap-1 overflow-x-auto pb-1 scrollbar-hide sm:hidden"
+                            data-test="content-tags"
                         >
-                            {{ dateText(item) }}
-                        </p>
+                            <span
+                                v-for="tag in tagsFor(item)"
+                                :key="tag._id"
+                                class="shrink-0 rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-700 dark:bg-yellow-500/15 dark:text-yellow-400"
+                            >
+                                {{ tag.title }}
+                            </span>
+                        </div>
                     </div>
                 </RouterLink>
             </li>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -35,13 +35,13 @@ const subtitle = (content: ContentDto): string => {
                 :to="{ name: 'content', params: { slug: item.content.slug } }"
                 class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15]"
             >
-                <div class="w-24 shrink-0 sm:w-28">
+                <div class="shrink-0">
                     <LImage
                         :image="item.content.parentImageData"
                         :content-parent-id="item.content.parentId"
                         :parent-image-bucket-id="item.content.parentImageBucketId"
                         aspectRatio="classic"
-                        size="thumbnail"
+                        size="small"
                     />
                 </div>
 

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -20,25 +20,39 @@ const dateText = (content: ContentDto): string =>
 </script>
 
 <template>
-    <!-- Dynamic columns: the grid fits as many ~18rem cards as the width allows, so it is
-         one column on a phone and several on a wide screen with no fixed breakpoints. -->
-    <ul class="grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-x-6">
+    <!-- Mobile is a single-column list of image-left rows. From tablet up it becomes a grid of
+         image-on-top cards (the layout most content sites use for "related" — vertical cards
+         tile better than wide rows): two columns on tablet, three on desktop. -->
+    <ul class="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-8 lg:grid-cols-3">
         <li
             v-for="item in items"
             :key="item.content._id"
-            class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700"
+            class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:border-0"
         >
             <RouterLink
                 :to="{ name: 'content', params: { slug: item.content.slug } }"
-                class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15]"
+                class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:flex-col sm:gap-2 sm:py-0"
             >
-                <div class="shrink-0">
+                <!-- Mobile: small thumbnail on the left. -->
+                <div class="shrink-0 sm:hidden">
                     <LImage
                         :image="item.content.parentImageData"
                         :content-parent-id="item.content.parentId"
                         :parent-image-bucket-id="item.content.parentImageBucketId"
                         aspectRatio="classic"
                         size="thumbnailCompact"
+                    />
+                </div>
+
+                <!-- Tablet and up: full-width image on top of the card. Only the visible image
+                     loads (both are lazy), so this doesn't fetch two files per card. -->
+                <div class="hidden sm:block">
+                    <LImage
+                        :image="item.content.parentImageData"
+                        :content-parent-id="item.content.parentId"
+                        :parent-image-bucket-id="item.content.parentImageBucketId"
+                        aspectRatio="classic"
+                        size="card"
                     />
                 </div>
 

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -142,8 +142,10 @@ watch(visibleItems, () => nextTick(measureTitles));
                         </div>
                     </div>
 
+                    <!-- Even spacing on mobile: the same 8px above the title, below the tags,
+                         and to the right of the text (the thumbnail gap sets the left). -->
                     <div
-                        class="flex min-w-0 flex-1 flex-col gap-1 py-2 pr-2 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
+                        class="flex min-w-0 flex-1 flex-col gap-1 p-2 pl-0 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
                     >
                         <!-- Mobile only: title beside the thumbnail (on the card it sits on
                              the image instead). Up to two lines; the summary adapts below. -->
@@ -169,7 +171,7 @@ watch(visibleItems, () => nextTick(measureTitles));
                              the title and summary when the row is taller than the text. -->
                         <div
                             v-if="tagsFor(item).length"
-                            class="mt-auto flex max-w-full gap-1 overflow-x-auto pb-1 scrollbar-hide sm:hidden"
+                            class="mt-auto flex max-w-full gap-1 overflow-x-auto scrollbar-hide sm:hidden"
                             data-test="content-tags"
                         >
                             <span

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -142,8 +142,11 @@ watch(visibleItems, () => nextTick(remeasureAll));
                     :to="{ name: 'content', params: { slug: item.slug } }"
                     class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:shadow-lg hover:brightness-[1.15] dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
                 >
-                    <!-- Mobile: small thumbnail on the left. -->
-                    <div class="shrink-0 sm:hidden">
+                    <!-- Mobile: left thumbnail with fixed width; the h-full overrides stretch
+                         LImage's 4:3 box to fill the card's height without gaps. -->
+                    <div
+                        class="shrink-0 overflow-hidden sm:hidden [&>div>div]:!h-full [&>div]:h-full [&_img]:!h-full"
+                    >
                         <LImage
                             :image="item.parentImageData"
                             :content-parent-id="item.parentId"

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import { DateTime } from "luxon";
+import { type ContentDto } from "luminary-shared";
+import LImage from "../images/LImage.vue";
+
+export type ReadMoreItem = {
+    content: ContentDto;
+    tags: string[];
+};
+
+defineProps<{ items: ReadMoreItem[] }>();
+
+// Prefer the summary; fall back to the publish date so a post with no summary isn't
+// left blank. The summary itself is clamped to two lines in the template.
+const subtitle = (content: ContentDto): string => {
+    const summary = content.summary?.trim();
+    if (summary) return summary;
+    return content.publishDate
+        ? DateTime.fromMillis(content.publishDate).toLocaleString(DateTime.DATE_MED)
+        : "";
+};
+</script>
+
+<template>
+    <!-- Dynamic columns: the grid fits as many ~18rem cards as the width allows, so it is
+         one column on a phone and several on a wide screen with no fixed breakpoints. -->
+    <ul class="grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-x-6">
+        <li
+            v-for="item in items"
+            :key="item.content._id"
+            class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700"
+        >
+            <RouterLink
+                :to="{ name: 'content', params: { slug: item.content.slug } }"
+                class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15]"
+            >
+                <div class="w-24 shrink-0 sm:w-28">
+                    <LImage
+                        :image="item.content.parentImageData"
+                        :content-parent-id="item.content.parentId"
+                        :parent-image-bucket-id="item.content.parentImageBucketId"
+                        aspectRatio="classic"
+                        size="thumbnail"
+                    />
+                </div>
+
+                <div class="flex min-w-0 flex-1 flex-col gap-1">
+                    <h3 class="line-clamp-2 font-semibold text-zinc-800 dark:text-slate-50">
+                        {{ item.content.title }}
+                    </h3>
+
+                    <p
+                        v-if="subtitle(item.content)"
+                        class="line-clamp-2 text-sm text-zinc-500 dark:text-slate-400"
+                    >
+                        {{ subtitle(item.content) }}
+                    </p>
+
+                    <!-- Tags scroll horizontally when they overflow (same chip colour as the
+                         category tags under the bookmark icon, without the tag icon). -->
+                    <div
+                        v-if="item.tags.length"
+                        class="mt-0.5 flex gap-1.5 overflow-x-auto scrollbar-hide"
+                    >
+                        <span
+                            v-for="tag in item.tags"
+                            :key="tag"
+                            class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
+                        >
+                            {{ tag }}
+                        </span>
+                    </div>
+                </div>
+            </RouterLink>
+        </li>
+    </ul>
+</template>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -11,15 +11,12 @@ export type ReadMoreItem = {
 
 defineProps<{ items: ReadMoreItem[] }>();
 
-// Prefer the summary; fall back to the publish date so a post with no summary isn't
-// left blank. The summary itself is clamped to two lines in the template.
-const subtitle = (content: ContentDto): string => {
-    const summary = content.summary?.trim();
-    if (summary) return summary;
-    return content.publishDate
+const summaryText = (content: ContentDto): string => content.summary?.trim() ?? "";
+
+const dateText = (content: ContentDto): string =>
+    content.publishDate
         ? DateTime.fromMillis(content.publishDate).toLocaleString(DateTime.DATE_MED)
         : "";
-};
 </script>
 
 <template>
@@ -51,10 +48,17 @@ const subtitle = (content: ContentDto): string => {
                     </h3>
 
                     <p
-                        v-if="subtitle(item.content)"
+                        v-if="summaryText(item.content)"
                         class="line-clamp-2 text-sm text-zinc-500 dark:text-slate-400"
                     >
-                        {{ subtitle(item.content) }}
+                        {{ summaryText(item.content) }}
+                    </p>
+
+                    <p
+                        v-if="dateText(item.content)"
+                        class="text-xs text-zinc-400 dark:text-slate-500"
+                    >
+                        {{ dateText(item.content) }}
                     </p>
 
                     <!-- Tags scroll horizontally when they overflow (same chip colour as the

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -1,17 +1,11 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, nextTick, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { DateTime } from "luxon";
 import { type ContentDto } from "luminary-shared";
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/24/solid";
 import LImage from "../images/LImage.vue";
 
-export type ReadMoreItem = {
-    content: ContentDto;
-    tags: string[];
-};
-
-const props = defineProps<{ items: ReadMoreItem[] }>();
+const props = defineProps<{ items: ContentDto[] }>();
 
 const summaryText = (content: ContentDto): string => content.summary?.trim() ?? "";
 
@@ -20,44 +14,17 @@ const dateText = (content: ContentDto): string =>
         ? DateTime.fromMillis(content.publishDate).toLocaleString(DateTime.DATE_MED)
         : "";
 
-// Keep the chips to a single line: show the first few, then a "+N" chip for the rest.
-const MAX_VISIBLE_TAGS = 2;
-const visibleTags = (tags: string[]): string[] => tags.slice(0, MAX_VISIBLE_TAGS);
-const extraTagCount = (tags: string[]): number => Math.max(0, tags.length - MAX_VISIBLE_TAGS);
-
-// Mobile is an infinite list: start with one batch and reveal the next whenever the
-// sentinel below the list scrolls into view. Every card is rendered up front — the
-// tablet/desktop scroll row shows them all (images are lazy, so off-screen cards cost
-// nothing), while mobile hides the ones past `visibleCount`. The sentinel is mobile-only
-// (display:none never intersects), so the observer can't fire on desktop.
+// Infinite list on every breakpoint: start with one batch and reveal the next whenever
+// the sentinel below the list scrolls into view (the grid grows vertically too, so the
+// same mechanism serves mobile and desktop).
 const BATCH_SIZE = 8;
 const visibleCount = ref(BATCH_SIZE);
+const visibleItems = computed(() => props.items.slice(0, visibleCount.value));
 
 const sentinel = ref<HTMLElement | null>(null);
 let observer: IntersectionObserver | undefined;
 
-// From tablet up the cards sit in a horizontal scroll row. The arrows only show on desktop
-// (where a mouse can't scroll sideways) and only when there's more to reveal in that direction.
-const scrollEl = ref<HTMLElement | null>(null);
-const showLeft = ref(false);
-const showRight = ref(false);
-
-const updateArrows = () => {
-    const el = scrollEl.value;
-    if (!el) return;
-    const maxScroll = el.scrollWidth - el.clientWidth;
-    showLeft.value = el.scrollLeft > 5;
-    showRight.value = maxScroll > 5 && el.scrollLeft < maxScroll - 5;
-};
-
-const scrollByCards = (direction: 1 | -1) => {
-    scrollEl.value?.scrollBy({ left: direction * 320, behavior: "smooth" });
-};
-
 onMounted(() => {
-    updateArrows();
-    window.addEventListener("resize", updateArrows);
-
     observer = new IntersectionObserver((entries) => {
         if (entries.some((e) => e.isIntersecting) && visibleCount.value < props.items.length) {
             visibleCount.value += BATCH_SIZE;
@@ -65,134 +32,99 @@ onMounted(() => {
     });
     if (sentinel.value) observer.observe(sentinel.value);
 });
-onUnmounted(() => {
-    window.removeEventListener("resize", updateArrows);
-    observer?.disconnect();
-});
+onUnmounted(() => observer?.disconnect());
 watch(
     () => props.items,
     () => {
         visibleCount.value = BATCH_SIZE;
-        nextTick(updateArrows);
     },
 );
 </script>
 
 <template>
-    <div class="relative">
-        <!-- Desktop scroll controls (touch devices scroll the row directly). -->
-        <button
-            v-if="showLeft"
-            type="button"
-            aria-label="Scroll left"
-            class="absolute left-1 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-white/90 p-1 text-zinc-700 shadow ring-1 ring-black/5 hover:bg-white dark:bg-slate-800/90 dark:text-slate-100 dark:ring-white/10 sm:flex"
-            @click="scrollByCards(-1)"
+    <div>
+        <!-- Mobile: a single-column list of image-left rows. From tablet up: a grid of
+             image-top cards with the title bottom-aligned on the image. Fewer columns than
+             the Explore rows so the images stay large. -->
+        <ul
+            class="flex flex-col px-4 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-6 sm:px-8 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
         >
-            <ChevronLeftIcon class="h-5 w-5" />
-        </button>
-        <button
-            v-if="showRight"
-            type="button"
-            aria-label="Scroll right"
-            class="absolute right-1 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-white/90 p-1 text-zinc-700 shadow ring-1 ring-black/5 hover:bg-white dark:bg-slate-800/90 dark:text-slate-100 dark:ring-white/10 sm:flex"
-            @click="scrollByCards(1)"
-        >
-            <ChevronRightIcon class="h-5 w-5" />
-        </button>
-
-        <!-- Mobile: a padded single-column list of image-left rows. From tablet up: a full-bleed
-             horizontal scroll row of image-on-top cards (the scroll container spans the full
-             width; the inner list keeps an edge inset), matching the Explore content rows. -->
-        <div
-            ref="scrollEl"
-            class="sm:overflow-x-auto sm:scrollbar-hide"
-            @scroll="updateArrows"
-        >
-            <ul class="flex flex-col px-4 sm:flex-row sm:gap-4">
-                <li
-                    v-for="(item, index) in items"
-                    :key="item.content._id"
-                    class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:w-48 sm:shrink-0 sm:border-0"
-                    :class="{ 'hidden sm:block': index >= visibleCount }"
+            <li
+                v-for="item in visibleItems"
+                :key="item._id"
+                class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:border-0"
+            >
+                <RouterLink
+                    :to="{ name: 'content', params: { slug: item.slug } }"
+                    class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:h-full sm:flex-col sm:gap-2 sm:overflow-hidden sm:rounded-lg sm:bg-white sm:py-0 sm:shadow sm:ring-1 sm:ring-zinc-950/10 sm:hover:shadow-lg dark:sm:bg-slate-800 dark:sm:ring-white/10"
                 >
-                    <RouterLink
-                        :to="{ name: 'content', params: { slug: item.content.slug } }"
-                        class="ease-out-expo group flex gap-3 py-3 transition hover:brightness-[1.15] sm:flex-col sm:gap-2 sm:py-0"
-                    >
-                        <!-- Mobile: small thumbnail on the left. -->
-                        <div class="shrink-0 sm:hidden">
-                            <LImage
-                                :image="item.content.parentImageData"
-                                :content-parent-id="item.content.parentId"
-                                :parent-image-bucket-id="item.content.parentImageBucketId"
-                                aspectRatio="classic"
-                                size="thumbnailCompact"
-                            />
-                        </div>
+                    <!-- Mobile: small thumbnail on the left. -->
+                    <div class="shrink-0 sm:hidden">
+                        <LImage
+                            :image="item.parentImageData"
+                            :content-parent-id="item.parentId"
+                            :parent-image-bucket-id="item.parentImageBucketId"
+                            aspectRatio="classic"
+                            size="thumbnailCompact"
+                        />
+                    </div>
 
-                        <!-- Tablet and up: full-width image on top of the card. Only the visible
-                             image loads (both are lazy), so this doesn't fetch two files per card. -->
-                        <div class="hidden sm:block">
-                            <LImage
-                                :image="item.content.parentImageData"
-                                :content-parent-id="item.content.parentId"
-                                :parent-image-bucket-id="item.content.parentImageBucketId"
-                                aspectRatio="classic"
-                                size="card"
-                            />
-                        </div>
-
-                        <div class="flex min-w-0 flex-1 flex-col gap-1">
-                            <h3 class="truncate font-semibold text-zinc-800 dark:text-slate-50">
-                                {{ item.content.title }}
+                    <!-- Tablet and up: full-width image with the title laid over its bottom
+                         edge. The gradient box is anchored to the bottom and grows upward, so
+                         a long title wraps over more of the image instead of truncating. Only
+                         the visible image loads (both are lazy), so this doesn't fetch two
+                         files per card. -->
+                    <div class="relative hidden sm:block">
+                        <!-- Square corners: the image sits flush against the card's edges and
+                             the card's own rounded-lg + overflow-hidden clips the top corners. -->
+                        <LImage
+                            :image="item.parentImageData"
+                            :content-parent-id="item.parentId"
+                            :parent-image-bucket-id="item.parentImageBucketId"
+                            aspectRatio="classic"
+                            size="card"
+                            :rounded="false"
+                        />
+                        <div
+                            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 via-black/40 to-black/0 px-3 pb-1.5 pt-6"
+                        >
+                            <h3 class="font-semibold text-white">
+                                {{ item.title }}
                             </h3>
-
-                            <p
-                                v-if="summaryText(item.content)"
-                                class="line-clamp-1 text-sm text-zinc-500 dark:text-slate-400 sm:line-clamp-2"
-                            >
-                                {{ summaryText(item.content) }}
-                            </p>
-
-                            <p
-                                v-if="dateText(item.content)"
-                                class="text-xs text-zinc-400 dark:text-slate-500"
-                            >
-                                {{ dateText(item.content) }}
-                            </p>
-
-                            <!-- One line of category chips (same colour as the category tags under
-                                 the bookmark icon, without the tag icon), with a "+N" chip for the
-                                 rest. -->
-                            <div
-                                v-if="item.tags.length"
-                                class="mt-0.5 flex gap-1.5 overflow-hidden"
-                            >
-                                <span
-                                    v-for="tag in visibleTags(item.tags)"
-                                    :key="tag"
-                                    class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
-                                >
-                                    {{ tag }}
-                                </span>
-                                <span
-                                    v-if="extraTagCount(item.tags)"
-                                    class="shrink-0 whitespace-nowrap rounded-lg border border-yellow-500/25 bg-yellow-500/10 px-2 py-0.5 text-xs text-zinc-700 dark:bg-slate-700 dark:text-slate-100"
-                                >
-                                    +{{ extraTagCount(item.tags) }}
-                                </span>
-                            </div>
                         </div>
-                    </RouterLink>
-                </li>
-            </ul>
-        </div>
+                    </div>
 
-        <!-- Mobile infinite-scroll sentinel: reveals the next batch when it enters the
-             viewport. Hidden from tablet up, where the row is horizontally scrollable. -->
+                    <div class="flex min-w-0 flex-1 flex-col gap-1 sm:px-3 sm:pb-3">
+                        <!-- Mobile only: title beside the thumbnail (on the card it sits on
+                             the image instead). -->
+                        <h3
+                            class="truncate font-semibold text-zinc-800 dark:text-slate-50 sm:hidden"
+                        >
+                            {{ item.title }}
+                        </h3>
+
+                        <p
+                            v-if="summaryText(item)"
+                            class="line-clamp-1 text-sm text-zinc-500 dark:text-slate-400 sm:line-clamp-2"
+                        >
+                            {{ summaryText(item) }}
+                        </p>
+
+                        <p
+                            v-if="dateText(item)"
+                            class="text-xs text-zinc-400 dark:text-slate-500"
+                        >
+                            {{ dateText(item) }}
+                        </p>
+                    </div>
+                </RouterLink>
+            </li>
+        </ul>
+
+        <!-- Infinite-scroll sentinel: reveals the next batch when it enters the viewport. -->
         <div
             ref="sentinel"
-            class="h-px sm:hidden"
+            class="h-px"
             aria-hidden="true"
         ></div>
     </div>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -62,6 +62,43 @@ const measureTitles = () => {
     });
 };
 
+// A card's category row scrolls horizontally when it has more chips than fit. Fade whichever
+// edge still has hidden chips beyond it, so the row dissolves toward the card edge instead of
+// cutting a chip off — and the fade follows the scroll position.
+const tagFade = reactive<Record<string, { left: boolean; right: boolean }>>({});
+
+const FADE_WIDTH = "1rem";
+const tagFadeStyle = (id: string) => {
+    const fade = tagFade[id];
+    const start = fade?.left ? "transparent" : "#000";
+    const end = fade?.right ? "transparent" : "#000";
+    // A full-black mask leaves the row untouched; a transparent stop fades that edge.
+    const mask = `linear-gradient(to right, ${start} 0, #000 ${FADE_WIDTH}, #000 calc(100% - ${FADE_WIDTH}), ${end} 100%)`;
+    return { maskImage: mask, WebkitMaskImage: mask };
+};
+
+const updateTagFade = (id: string, el: HTMLElement) => {
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    tagFade[id] = {
+        left: el.scrollLeft > 4,
+        right: maxScroll > 4 && el.scrollLeft < maxScroll - 4,
+    };
+};
+
+const measureTagFades = () => {
+    const root = rootEl.value;
+    if (!root) return;
+    root.querySelectorAll<HTMLElement>("[data-tags-row]").forEach((el) => {
+        if (el.dataset.id) updateTagFade(el.dataset.id, el);
+    });
+};
+
+// Titles and category fades both derive from rendered layout, so recompute them together.
+const remeasureAll = () => {
+    measureTitles();
+    measureTagFades();
+};
+
 onMounted(() => {
     observer = new IntersectionObserver((entries) => {
         if (entries.some((e) => e.isIntersecting) && visibleCount.value < props.items.length) {
@@ -70,10 +107,10 @@ onMounted(() => {
     });
     if (sentinel.value) observer.observe(sentinel.value);
 
-    // Re-measure titles when the layout reflows (e.g. rotating the device changes wrapping).
-    resizeObserver = new ResizeObserver(() => measureTitles());
+    // Recompute title line counts and category fades when the layout reflows (e.g. rotating).
+    resizeObserver = new ResizeObserver(() => remeasureAll());
     if (rootEl.value) resizeObserver.observe(rootEl.value);
-    nextTick(measureTitles);
+    nextTick(remeasureAll);
 });
 onUnmounted(() => {
     observer?.disconnect();
@@ -85,8 +122,8 @@ watch(
         visibleCount.value = BATCH_SIZE;
     },
 );
-// Newly revealed cards (infinite scroll, or a new related set) need measuring once rendered.
-watch(visibleItems, () => nextTick(measureTitles));
+// Newly revealed cards (infinite scroll, or a new related set) need re-measuring once rendered.
+watch(visibleItems, () => nextTick(remeasureAll));
 </script>
 
 <template>
@@ -167,12 +204,17 @@ watch(visibleItems, () => nextTick(measureTitles));
                             {{ summaryText(item) }}
                         </p>
 
-                        <!-- Categories sit at the bottom of the card: mt-auto pushes them below
-                             the title and summary when the row is taller than the text. -->
+                        <!-- Categories sit at the bottom of the card (mt-auto) and fade toward
+                             the card edge as the row scrolls (the fade is a mask, so the row
+                             keeps its margins). -->
                         <div
                             v-if="tagsFor(item).length"
+                            :data-id="item._id"
+                            data-tags-row
                             class="mt-auto flex max-w-full gap-1 overflow-x-auto scrollbar-hide sm:hidden"
+                            :style="tagFadeStyle(item._id)"
                             data-test="content-tags"
+                            @scroll="(e) => updateTagFade(item._id, e.target as HTMLElement)"
                         >
                             <span
                                 v-for="tag in tagsFor(item)"

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -41,7 +41,7 @@ const subtitle = (content: ContentDto): string => {
                         :content-parent-id="item.content.parentId"
                         :parent-image-bucket-id="item.content.parentImageBucketId"
                         aspectRatio="classic"
-                        size="small"
+                        size="thumbnailCompact"
                     />
                 </div>
 

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -1,5 +1,13 @@
+<script lang="ts">
+// When the mobile title wraps onto two lines there's only room for a one-line summary; a
+// single-line title leaves room for two. (On the card, the summary always uses two lines —
+// see the template's sm: clamp.)
+export const summaryClampFor = (mobileTitleLines: number): string =>
+    mobileTitleLines >= 2 ? "line-clamp-1" : "line-clamp-2";
+</script>
+
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { type ContentDto } from "luminary-shared";
 import { useContentQuery } from "@/composables/useContentQuery";
@@ -29,6 +37,31 @@ const visibleItems = computed(() => props.items.slice(0, visibleCount.value));
 const sentinel = ref<HTMLElement | null>(null);
 let observer: IntersectionObserver | undefined;
 
+// How many lines each card's mobile title wraps onto, so the summary can take the remaining
+// room (see summaryClampFor). Measured from the rendered height because CSS can't make one
+// element's clamp depend on another element's line count.
+const rootEl = ref<HTMLElement | null>(null);
+const mobileTitleLines = reactive<Record<string, number>>({});
+let resizeObserver: ResizeObserver | undefined;
+
+const measureTitles = () => {
+    const root = rootEl.value;
+    if (!root) return;
+    root.querySelectorAll<HTMLElement>("[data-mobile-title]").forEach((el) => {
+        const id = el.dataset.id;
+        if (!id) return;
+        // Hidden (desktop) titles report no height; treat as one line so the summary keeps
+        // its two-line clamp — the sm: breakpoint governs the card there anyway.
+        if (!el.clientHeight) {
+            mobileTitleLines[id] = 1;
+            return;
+        }
+        const styles = getComputedStyle(el);
+        const lineHeight = parseFloat(styles.lineHeight) || parseFloat(styles.fontSize) * 1.5 || 20;
+        mobileTitleLines[id] = Math.max(1, Math.round(el.clientHeight / lineHeight));
+    });
+};
+
 onMounted(() => {
     observer = new IntersectionObserver((entries) => {
         if (entries.some((e) => e.isIntersecting) && visibleCount.value < props.items.length) {
@@ -36,18 +69,28 @@ onMounted(() => {
         }
     });
     if (sentinel.value) observer.observe(sentinel.value);
+
+    // Re-measure titles when the layout reflows (e.g. rotating the device changes wrapping).
+    resizeObserver = new ResizeObserver(() => measureTitles());
+    if (rootEl.value) resizeObserver.observe(rootEl.value);
+    nextTick(measureTitles);
 });
-onUnmounted(() => observer?.disconnect());
+onUnmounted(() => {
+    observer?.disconnect();
+    resizeObserver?.disconnect();
+});
 watch(
     () => props.items,
     () => {
         visibleCount.value = BATCH_SIZE;
     },
 );
+// Newly revealed cards (infinite scroll, or a new related set) need measuring once rendered.
+watch(visibleItems, () => nextTick(measureTitles));
 </script>
 
 <template>
-    <div>
+    <div ref="rootEl">
         <!-- Mobile: a single-column list of image-left rows. From tablet up: a grid of
              image-top cards with the title bottom-aligned on the image. Fewer columns than
              the Explore rows so the images stay large. -->
@@ -103,16 +146,21 @@ watch(
                         class="flex min-w-0 flex-1 flex-col gap-1 py-2 pr-2 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
                     >
                         <!-- Mobile only: title beside the thumbnail (on the card it sits on
-                             the image instead). -->
+                             the image instead). Up to two lines; the summary adapts below. -->
                         <h3
-                            class="truncate font-semibold text-zinc-800 dark:text-slate-50 sm:hidden"
+                            :data-id="item._id"
+                            data-mobile-title
+                            class="line-clamp-2 font-semibold text-zinc-800 dark:text-slate-50 sm:hidden"
                         >
                             {{ item.title }}
                         </h3>
 
+                        <!-- Summary takes whatever lines the title leaves: two when the title is
+                             one line, one when the title wrapped to two. -->
                         <p
                             v-if="summaryText(item)"
-                            class="line-clamp-1 text-sm text-zinc-500 dark:text-slate-400 sm:line-clamp-2"
+                            class="text-sm text-zinc-500 dark:text-slate-400 sm:line-clamp-2"
+                            :class="summaryClampFor(mobileTitleLines[item._id] ?? 1)"
                         >
                             {{ summaryText(item) }}
                         </p>

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -25,6 +25,17 @@ const MAX_VISIBLE_TAGS = 2;
 const visibleTags = (tags: string[]): string[] => tags.slice(0, MAX_VISIBLE_TAGS);
 const extraTagCount = (tags: string[]): number => Math.max(0, tags.length - MAX_VISIBLE_TAGS);
 
+// Mobile is an infinite list: start with one batch and reveal the next whenever the
+// sentinel below the list scrolls into view. Every card is rendered up front — the
+// tablet/desktop scroll row shows them all (images are lazy, so off-screen cards cost
+// nothing), while mobile hides the ones past `visibleCount`. The sentinel is mobile-only
+// (display:none never intersects), so the observer can't fire on desktop.
+const BATCH_SIZE = 8;
+const visibleCount = ref(BATCH_SIZE);
+
+const sentinel = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | undefined;
+
 // From tablet up the cards sit in a horizontal scroll row. The arrows only show on desktop
 // (where a mouse can't scroll sideways) and only when there's more to reveal in that direction.
 const scrollEl = ref<HTMLElement | null>(null);
@@ -46,11 +57,24 @@ const scrollByCards = (direction: 1 | -1) => {
 onMounted(() => {
     updateArrows();
     window.addEventListener("resize", updateArrows);
+
+    observer = new IntersectionObserver((entries) => {
+        if (entries.some((e) => e.isIntersecting) && visibleCount.value < props.items.length) {
+            visibleCount.value += BATCH_SIZE;
+        }
+    });
+    if (sentinel.value) observer.observe(sentinel.value);
 });
-onUnmounted(() => window.removeEventListener("resize", updateArrows));
+onUnmounted(() => {
+    window.removeEventListener("resize", updateArrows);
+    observer?.disconnect();
+});
 watch(
     () => props.items,
-    () => nextTick(updateArrows),
+    () => {
+        visibleCount.value = BATCH_SIZE;
+        nextTick(updateArrows);
+    },
 );
 </script>
 
@@ -86,9 +110,10 @@ watch(
         >
             <ul class="flex flex-col px-4 sm:flex-row sm:gap-4">
                 <li
-                    v-for="item in items"
+                    v-for="(item, index) in items"
                     :key="item.content._id"
                     class="border-b border-zinc-100 last:border-b-0 dark:border-slate-700 sm:w-48 sm:shrink-0 sm:border-0"
+                    :class="{ 'hidden sm:block': index >= visibleCount }"
                 >
                     <RouterLink
                         :to="{ name: 'content', params: { slug: item.content.slug } }"
@@ -124,7 +149,7 @@ watch(
 
                             <p
                                 v-if="summaryText(item.content)"
-                                class="line-clamp-2 text-sm text-zinc-500 dark:text-slate-400"
+                                class="line-clamp-1 text-sm text-zinc-500 dark:text-slate-400 sm:line-clamp-2"
                             >
                                 {{ summaryText(item.content) }}
                             </p>
@@ -162,5 +187,13 @@ watch(
                 </li>
             </ul>
         </div>
+
+        <!-- Mobile infinite-scroll sentinel: reveals the next batch when it enters the
+             viewport. Hidden from tablet up, where the row is horizontally scrollable. -->
+        <div
+            ref="sentinel"
+            class="h-px sm:hidden"
+            aria-hidden="true"
+        ></div>
     </div>
 </template>

--- a/app/src/components/content/RelatedContent.spec.ts
+++ b/app/src/components/content/RelatedContent.spec.ts
@@ -161,7 +161,7 @@ describe("RelatedContent", () => {
         });
     });
 
-    it("shows the summary and a tag chip on each related post", async () => {
+    it("shows the summary on each related post, without tag chips", async () => {
         await db.docs.bulkPut([
             {
                 ...mockEnglishContentDto,
@@ -186,8 +186,8 @@ describe("RelatedContent", () => {
 
         await waitForExpect(() => {
             expect(wrapper.html()).toContain("A short related summary");
-            // The post's tag rendered as a chip (topic title resolved from its id).
-            expect(wrapper.html()).toContain(mockTopicContentDto.title);
         });
+        // The redesigned cards carry no category/topic chips.
+        expect(wrapper.html()).not.toContain(mockTopicContentDto.title);
     });
 });

--- a/app/src/components/content/RelatedContent.spec.ts
+++ b/app/src/components/content/RelatedContent.spec.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import RelatedContent from "./RelatedContent.vue";
+import ReadMore from "./ReadMore.vue";
 import { mount } from "@vue/test-utils";
 import { mockEnglishContentDto, mockLanguageDtoEng, mockTopicContentDto } from "@/tests/mockdata";
 import waitForExpect from "wait-for-expect";
@@ -50,7 +51,8 @@ describe("RelatedContent", () => {
         });
 
         await waitForExpect(() => {
-            expect(wrapper.html()).not.toContain(mockTopicContentDto.title);
+            // The topic itself is included in Read more, but the current post isn't.
+            expect(wrapper.html()).toContain(mockTopicContentDto.title);
             expect(wrapper.html()).not.toContain(mockEnglishContentDto.title);
         });
     });
@@ -187,7 +189,40 @@ describe("RelatedContent", () => {
         await waitForExpect(() => {
             expect(wrapper.html()).toContain("A short related summary");
         });
-        // The redesigned cards carry no category/topic chips.
-        expect(wrapper.html()).not.toContain(mockTopicContentDto.title);
+        expect(wrapper.findComponent(ReadMore).html()).toContain(mockTopicContentDto.title);
+    });
+
+    it("displays all topics in the same Read more collection as related posts", async () => {
+        const topicB = {
+            ...mockTopicContentDto,
+            _id: "content-tag-topicB",
+            parentId: "tag-topicB",
+            slug: "content-tag-topicB",
+            title: "Topic B",
+        } as ContentDto;
+
+        await db.docs.put({
+            ...mockEnglishContentDto,
+            parentId: "post-post2",
+            _id: "content-post2-eng",
+            title: "Post 2",
+        } as ContentDto);
+
+        const wrapper = mount(RelatedContent, {
+            props: {
+                tags: [
+                    { ...mockTopicContentDto, parentTaggedDocs: ["post-post2"] },
+                    topicB,
+                ],
+                selectedContent: mockEnglishContentDto,
+            },
+        });
+
+        await waitForExpect(() => {
+            const readMore = wrapper.findComponent(ReadMore).html();
+            expect(readMore).toContain("Post 2");
+            expect(readMore).toContain(mockTopicContentDto.title);
+            expect(readMore).toContain("Topic B");
+        });
     });
 });

--- a/app/src/components/content/RelatedContent.spec.ts
+++ b/app/src/components/content/RelatedContent.spec.ts
@@ -160,4 +160,35 @@ describe("RelatedContent", () => {
             expect(wrapper.html()).not.toContain("Post 3");
         });
     });
+
+    it("shows the summary and a tag chip on each related post", async () => {
+        await db.docs.bulkPut([
+            {
+                ...mockEnglishContentDto,
+                parentId: "post-post2",
+                _id: "content-post2-eng",
+                title: "Post 2",
+                summary: "A short related summary",
+                parentTags: [mockTopicContentDto.parentId],
+            } as ContentDto,
+        ]);
+
+        const wrapper = mount(RelatedContent, {
+            props: {
+                tags: [{ ...mockTopicContentDto, parentTaggedDocs: ["post-post2"] }],
+                selectedContent: {
+                    ...mockEnglishContentDto,
+                    _id: "content-post3-eng",
+                    title: "Post 3",
+                },
+            },
+        });
+
+        await waitForExpect(() => {
+            // Summary shown in place of the publish date.
+            expect(wrapper.html()).toContain("A short related summary");
+            // The post's tag rendered as a chip (topic title resolved from its id).
+            expect(wrapper.html()).toContain(mockTopicContentDto.title);
+        });
+    });
 });

--- a/app/src/components/content/RelatedContent.spec.ts
+++ b/app/src/components/content/RelatedContent.spec.ts
@@ -185,7 +185,6 @@ describe("RelatedContent", () => {
         });
 
         await waitForExpect(() => {
-            // Summary shown in place of the publish date.
             expect(wrapper.html()).toContain("A short related summary");
             // The post's tag rendered as a chip (topic title resolved from its id).
             expect(wrapper.html()).toContain(mockTopicContentDto.title);

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import IgnorePagePadding from "@/components/IgnorePagePadding.vue";
-import { TagType, type ContentDto } from "luminary-shared";
-import { computed, toRef } from "vue";
-import { contentByTag } from "../contentByTag";
-import HorizontalContentTileCollection from "./HorizontalContentTileCollection.vue";
+import { DocType, TagType, type ContentDto } from "luminary-shared";
+import { computed } from "vue";
 import { useContentQuery } from "@/composables/useContentQuery";
 import { useI18n } from "vue-i18n";
+import ReadMore from "./ReadMore.vue";
 
 type Props = {
     tags: ContentDto[];
@@ -15,54 +13,72 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 
+const MAX_ITEMS = 8;
+
+// Topic pages already list their own content, so the "Read more" block is for non-topics.
 const isNotTopic = computed(() => props.selectedContent.parentTagType !== TagType.Topic);
-// `parentTaggedDocs` is optional and may itself contain null/undefined ids, and
-// `.flat()` keeps those holes. Drop them before they become `{ parentId: { $in:
-// [null] } }`, which crashes CouchDB's _find (function_clause / 500). `new Set`
-// dedupes the remainder.
+
+// Ids of posts tagged with any of the current article's topic tags. `parentTaggedDocs`
+// is optional and may contain null/undefined holes — drop them before they become
+// `{ parentId: { $in: [null] } }`, which crashes CouchDB's _find. `new Set` dedupes.
 const contentIds = computed(() => [
     ...new Set(props.tags.flatMap((tag) => tag.parentTaggedDocs ?? []).filter((id) => id != null)),
 ]);
 
-// parentId $in can't use a sorted Mango index, so the API supplement scans the older
-// tail. Cap at 50 so the limit-shortfall branch skips the API POST once local Dexie
-// already holds 50 matches (the common warm case); 50 also comfortably covers what the
-// horizontal related-content row displays.
 const contentDocs = useContentQuery(() => [{ parentId: { $in: contentIds.value } }], {
-    sort: [{ publishDate: "asc" }],
+    sort: [{ publishDate: "desc" }],
     limit: 50,
 });
 
-const filtered = computed(() =>
-    contentDocs.value.filter((item) => item._id !== props.selectedContent._id),
+// One flat, newest-first list (dedup is inherent — a single query, not one row per tag),
+// with the current article removed and capped.
+const relatedContent = computed(() =>
+    contentDocs.value.filter((item) => item._id !== props.selectedContent._id).slice(0, MAX_ITEMS),
 );
 
-const contentByTopic = contentByTag(filtered, toRef(props.tags));
+// Resolve each related post's tag ids to titles for the per-card chips: one query over
+// every tag any of the related posts carries.
+const relatedTagIds = computed(() => [
+    ...new Set(relatedContent.value.flatMap((c) => c.parentTags ?? []).filter((id) => id != null)),
+]);
+
+const tagDocs = useContentQuery(
+    () =>
+        relatedTagIds.value.length
+            ? [{ parentId: { $in: relatedTagIds.value } }, { parentType: DocType.Tag }]
+            : [{ parentId: { $in: [] } }],
+    { includeScheduled: false },
+);
+
+// Tag id -> title, restricted to the category/topic tags shown elsewhere on the article.
+const tagTitleById = computed(() => {
+    const map = new Map<string, string>();
+    for (const tag of tagDocs.value) {
+        if (tag.parentTagType === TagType.Category || tag.parentTagType === TagType.Topic) {
+            map.set(tag.parentId, tag.title);
+        }
+    }
+    return map;
+});
+
+const items = computed(() =>
+    relatedContent.value.map((content) => ({
+        content,
+        tags: (content.parentTags ?? [])
+            .map((id) => tagTitleById.value.get(id))
+            .filter((title): title is string => !!title),
+    })),
+);
 </script>
 
 <template>
-    <IgnorePagePadding>
-        <h1
-            v-if="isNotTopic && contentByTopic.tagged.value.length"
-            class="px-4 pb-3 text-xl text-zinc-800 dark:text-zinc-200"
-        >
-            {{ t("content.related_title") }}
-        </h1>
-        <div class="mb-2 flex max-w-full flex-wrap">
-            <div
-                class="max-w-full"
-                ref="scrollElement"
-            >
-                <HorizontalContentTileCollection
-                    v-for="topic in contentByTopic.tagged.value"
-                    :key="topic.tag._id"
-                    :contentDocs="topic.content"
-                    :title="topic.tag.title"
-                    :summary="topic.tag.summary"
-                    :useVerticalTileLayout="topic.tag.parentUseVerticalTileLayout"
-                    :showPublishDate="false"
-                />
-            </div>
-        </div>
-    </IgnorePagePadding>
+    <section
+        v-if="isNotTopic && items.length"
+        class="px-4 pb-2"
+    >
+        <h2 class="pb-3 text-xl text-zinc-800 dark:text-zinc-200">
+            {{ t("content.read_more") }}
+        </h2>
+        <ReadMore :items="items" />
+    </section>
 </template>

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -13,8 +13,6 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 
-const MAX_ITEMS = 8;
-
 // Topic pages already list their own content, so the "Read more" block is for non-topics.
 const isNotTopic = computed(() => props.selectedContent.parentTagType !== TagType.Topic);
 
@@ -31,9 +29,10 @@ const contentDocs = useContentQuery(() => [{ parentId: { $in: contentIds.value }
 });
 
 // One flat, newest-first list (dedup is inherent — a single query, not one row per tag),
-// with the current article removed and capped.
+// with the current article removed. The query's `limit` is the overall cap; per-breakpoint
+// display (mobile infinite scroll, desktop full scroll row) is ReadMore's job.
 const relatedContent = computed(() =>
-    contentDocs.value.filter((item) => item._id !== props.selectedContent._id).slice(0, MAX_ITEMS),
+    contentDocs.value.filter((item) => item._id !== props.selectedContent._id),
 );
 
 // Resolve each related post's tag ids to titles for the per-card chips: one query over

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -24,6 +24,7 @@ const contentIds = computed(() => [
 ]);
 
 const contentDocs = useContentQuery(() => [{ parentId: { $in: contentIds.value } }], {
+    includeScheduled: false,
     sort: [{ publishDate: "desc" }],
     limit: 50,
 });

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -74,7 +74,7 @@ const items = computed(() =>
 <template>
     <section
         v-if="isNotTopic && items.length"
-        class="px-4 pb-2"
+        class="mx-auto w-full max-w-5xl px-4 pb-2"
     >
         <h2 class="pb-3 text-xl text-zinc-800 dark:text-zinc-200">
             {{ t("content.read_more") }}

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -35,11 +35,19 @@ const contentDocs = useContentQuery(() => [{ parentId: { $in: contentIds.value }
 const relatedContent = computed(() =>
     contentDocs.value.filter((item) => item._id !== props.selectedContent._id),
 );
+
+// Topic pages and their related posts belong in one collection. Keep the related
+// posts first and deduplicate by document id in case the inputs ever overlap.
+const readMoreItems = computed(() =>
+    [...relatedContent.value, ...props.tags].filter(
+        (item, index, items) => items.findIndex(({ _id }) => _id === item._id) === index,
+    ),
+);
 </script>
 
 <template>
     <section
-        v-if="isNotTopic && relatedContent.length"
+        v-if="isNotTopic && readMoreItems.length"
         class="w-full pb-2"
     >
         <!-- Horizontal padding mirrors the list/grid inset in ReadMore so the heading
@@ -47,6 +55,6 @@ const relatedContent = computed(() =>
         <h2 class="px-4 pb-3 text-xl text-zinc-800 dark:text-zinc-200 sm:px-8">
             {{ t("content.read_more") }}
         </h2>
-        <ReadMore :items="relatedContent" />
+        <ReadMore :items="readMoreItems" />
     </section>
 </template>

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DocType, TagType, type ContentDto } from "luminary-shared";
+import { TagType, type ContentDto } from "luminary-shared";
 import { computed } from "vue";
 import { useContentQuery } from "@/composables/useContentQuery";
 import { useI18n } from "vue-i18n";
@@ -34,50 +34,18 @@ const contentDocs = useContentQuery(() => [{ parentId: { $in: contentIds.value }
 const relatedContent = computed(() =>
     contentDocs.value.filter((item) => item._id !== props.selectedContent._id),
 );
-
-// Resolve each related post's tag ids to titles for the per-card chips: one query over
-// every tag any of the related posts carries.
-const relatedTagIds = computed(() => [
-    ...new Set(relatedContent.value.flatMap((c) => c.parentTags ?? []).filter((id) => id != null)),
-]);
-
-const tagDocs = useContentQuery(
-    () =>
-        relatedTagIds.value.length
-            ? [{ parentId: { $in: relatedTagIds.value } }, { parentType: DocType.Tag }]
-            : [{ parentId: { $in: [] } }],
-    { includeScheduled: false },
-);
-
-// Tag id -> title, restricted to the category/topic tags shown elsewhere on the article.
-const tagTitleById = computed(() => {
-    const map = new Map<string, string>();
-    for (const tag of tagDocs.value) {
-        if (tag.parentTagType === TagType.Category || tag.parentTagType === TagType.Topic) {
-            map.set(tag.parentId, tag.title);
-        }
-    }
-    return map;
-});
-
-const items = computed(() =>
-    relatedContent.value.map((content) => ({
-        content,
-        tags: (content.parentTags ?? [])
-            .map((id) => tagTitleById.value.get(id))
-            .filter((title): title is string => !!title),
-    })),
-);
 </script>
 
 <template>
     <section
-        v-if="isNotTopic && items.length"
+        v-if="isNotTopic && relatedContent.length"
         class="w-full pb-2"
     >
-        <h2 class="px-4 pb-3 text-xl text-zinc-800 dark:text-zinc-200">
+        <!-- Horizontal padding mirrors the list/grid inset in ReadMore so the heading
+             lines up with the first card at every breakpoint. -->
+        <h2 class="px-4 pb-3 text-xl text-zinc-800 dark:text-zinc-200 sm:px-8">
             {{ t("content.read_more") }}
         </h2>
-        <ReadMore :items="items" />
+        <ReadMore :items="relatedContent" />
     </section>
 </template>

--- a/app/src/components/content/RelatedContent.vue
+++ b/app/src/components/content/RelatedContent.vue
@@ -74,9 +74,9 @@ const items = computed(() =>
 <template>
     <section
         v-if="isNotTopic && items.length"
-        class="mx-auto w-full max-w-5xl px-4 pb-2"
+        class="w-full pb-2"
     >
-        <h2 class="pb-3 text-xl text-zinc-800 dark:text-zinc-200">
+        <h2 class="px-4 pb-3 text-xl text-zinc-800 dark:text-zinc-200">
             {{ t("content.read_more") }}
         </h2>
         <ReadMore :items="items" />

--- a/app/src/components/images/LImage.vue
+++ b/app/src/components/images/LImage.vue
@@ -41,9 +41,9 @@ const rounding = {
     thumbnailFeatured: "rounded-xl",
     thumbnailCompact: "rounded-lg",
     post: "md:rounded-lg",
+    card: "rounded-lg",
     icon: "rounded-none",
 };
-
 </script>
 
 <template>

--- a/app/src/components/images/LImageProvider.vue
+++ b/app/src/components/images/LImageProvider.vue
@@ -49,9 +49,9 @@ export const sizesMap: Record<ImageSize, string> = {
     thumbnailFeatured: "(min-width: 768px) 224px, 165px",
     thumbnailCompact: "(min-width: 768px) 176px, 128px",
     post: "(min-width: 1024px) 800px, 100vw",
-    // Card in the related grid: ~one third of the 1024px-capped section on desktop, ~half the
-    // viewport on tablet. (Mobile uses the left-thumbnail slot instead, so 100vw never applies.)
-    card: "(min-width: 1024px) 340px, (min-width: 640px) 45vw, 100vw",
+    // Card in the related grid, which is 4 columns on desktop, 3 on tablet, 2 on small tablets.
+    // (Mobile uses the left-thumbnail slot instead, so the last fallback never applies.)
+    card: "(min-width: 1024px) 260px, (min-width: 768px) 33vw, 50vw",
     smallSquare: "48px",
     icon: "",
 };

--- a/app/src/components/images/LImageProvider.vue
+++ b/app/src/components/images/LImageProvider.vue
@@ -49,9 +49,9 @@ export const sizesMap: Record<ImageSize, string> = {
     thumbnailFeatured: "(min-width: 768px) 224px, 165px",
     thumbnailCompact: "(min-width: 768px) 176px, 128px",
     post: "(min-width: 1024px) 800px, 100vw",
-    // Fixed-width tile in the related horizontal scroll row (~192px). (Mobile uses the
-    // left-thumbnail slot instead.)
-    card: "200px",
+    // Fluid tile in the related-content grid: 2 columns from sm, 3 from md, 4 from lg,
+    // 5 from xl. (Mobile uses the left-thumbnail slot instead.)
+    card: "(min-width: 1280px) 20vw, (min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw",
     smallSquare: "48px",
     icon: "",
 };
@@ -67,7 +67,7 @@ export const sizesReducedMap: Record<ImageSize, string> = {
     thumbnailFeatured: "165px",
     thumbnailCompact: "128px",
     post: "50vw",
-    card: "150px",
+    card: "200px",
     smallSquare: "48px",
     icon: "",
 };

--- a/app/src/components/images/LImageProvider.vue
+++ b/app/src/components/images/LImageProvider.vue
@@ -49,9 +49,9 @@ export const sizesMap: Record<ImageSize, string> = {
     thumbnailFeatured: "(min-width: 768px) 224px, 165px",
     thumbnailCompact: "(min-width: 768px) 176px, 128px",
     post: "(min-width: 1024px) 800px, 100vw",
-    // Card in the related grid, which is 4 columns on desktop, 3 on tablet, 2 on small tablets.
-    // (Mobile uses the left-thumbnail slot instead, so the last fallback never applies.)
-    card: "(min-width: 1024px) 260px, (min-width: 768px) 33vw, 50vw",
+    // Fixed-width tile in the related horizontal scroll row (~192px). (Mobile uses the
+    // left-thumbnail slot instead.)
+    card: "200px",
     smallSquare: "48px",
     icon: "",
 };
@@ -67,7 +67,7 @@ export const sizesReducedMap: Record<ImageSize, string> = {
     thumbnailFeatured: "165px",
     thumbnailCompact: "128px",
     post: "50vw",
-    card: "45vw",
+    card: "150px",
     smallSquare: "48px",
     icon: "",
 };

--- a/app/src/components/images/LImageProvider.vue
+++ b/app/src/components/images/LImageProvider.vue
@@ -31,6 +31,8 @@ export const sizes = {
     thumbnailFeatured: "w-[165px] max-w-[165px] min-w-[165px] md:w-56 md:max-w-56 md:min-w-56",
     thumbnailCompact: "w-32 max-w-32 min-w-32 md:w-44 md:max-w-44 md:min-w-44",
     post: "w-full max-w-full",
+    // Fills the width of a card in a multi-column grid (e.g. the related-content grid).
+    card: "w-full max-w-full",
     smallSquare: "w-12 max-w-12 min-w-12 md:w-12 md:max-w-12 md:min-w-12",
     icon: "",
 };
@@ -47,6 +49,9 @@ export const sizesMap: Record<ImageSize, string> = {
     thumbnailFeatured: "(min-width: 768px) 224px, 165px",
     thumbnailCompact: "(min-width: 768px) 176px, 128px",
     post: "(min-width: 1024px) 800px, 100vw",
+    // Card in the related grid: ~one third of the 1024px-capped section on desktop, ~half the
+    // viewport on tablet. (Mobile uses the left-thumbnail slot instead, so 100vw never applies.)
+    card: "(min-width: 1024px) 340px, (min-width: 640px) 45vw, 100vw",
     smallSquare: "48px",
     icon: "",
 };
@@ -62,6 +67,7 @@ export const sizesReducedMap: Record<ImageSize, string> = {
     thumbnailFeatured: "165px",
     thumbnailCompact: "128px",
     post: "50vw",
+    card: "45vw",
     smallSquare: "48px",
     icon: "",
 };

--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -960,15 +960,17 @@ watch([isLoading, content, is404], async () => {
                 </article>
             </div>
 
-            <RelatedContent
-                v-if="content && tags.length"
-                :selectedContent="content"
-                :tags="
-                    tags.filter(
-                        (t: ContentDto) => t && t.parentTagType && t.parentTagType == TagType.Topic,
-                    )
-                "
-            />
+            <IgnorePagePadding v-if="content && tags.length">
+                <RelatedContent
+                    :selectedContent="content"
+                    :tags="
+                        tags.filter(
+                            (t: ContentDto) =>
+                                t && t.parentTagType && t.parentTagType == TagType.Topic,
+                        )
+                    "
+                />
+            </IgnorePagePadding>
             <IgnorePagePadding ignoreBottom>
                 <CopyrightBanner />
             </IgnorePagePadding>

--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -271,9 +271,10 @@ describe("SingleContent", () => {
             },
         });
         await waitForExpect(() => {
-            expect(wrapper.text()).toContain(mockTopicContentDto.title);
             expect(wrapper.text()).toContain("content 2");
         });
+        // The redesigned related-content cards carry no topic/category chips.
+        expect(wrapper.text()).not.toContain(mockTopicContentDto.title);
     });
 
     it("doesn't display tag when content not tagged", async () => {

--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -273,8 +273,8 @@ describe("SingleContent", () => {
         await waitForExpect(() => {
             expect(wrapper.text()).toContain("content 2");
         });
-        // The redesigned related-content cards carry no topic/category chips.
-        expect(wrapper.text()).not.toContain(mockTopicContentDto.title);
+        // The related-content cards show their topic/category chips (mobile row).
+        expect(wrapper.text()).toContain(mockTopicContentDto.title);
     });
 
     it("doesn't display tag when content not tagged", async () => {


### PR DESCRIPTION
The new direction for #1737 — replaces the per-topic horizontal tile rows with a single flat "Read more" list. (The old dedupe-across-rows PR was closed in favour of this.)

## Mobile (built to the mockup)
`ReadMore.vue` — image-left cards:
- **Image**: `aspectRatio="classic"` (4:3), the exact ratio the Explore page uses.
- **Summary in place of the date**: shows `content.summary` (clamped to 2 lines); falls back to the publish date when a post has no summary, so a row is never blank.
- **Tag chips**: per-post, resolved from the post's tag ids to titles, in the **same chip colour as the category tags under the bookmark icon** (`border-yellow-500/25 bg-yellow-500/10 … dark:bg-slate-700`) **without** the tag icon, scrolling horizontally on overflow (`overflow-x-auto scrollbar-hide`).

## Desktop — dynamic columns
As you asked: columns adapt to the screen, not fixed breakpoints. The list is an auto-fit grid — `grid-cols-[repeat(auto-fit,minmax(18rem,1fr))]` — so it fits as many ~18rem cards as the width allows: one column on a phone, two or three on a wide screen. Same card either way.

## Data
- One flat, **deduped** list (a single query instead of one row per tag — which is what made items repeat before), **newest-first**, capped at 8.
- Per-card tags come from one extra query resolving the related posts' tag ids to titles (category/topic only).
- `RelatedContent` keeps the same props, so `SingleContent` is unchanged.

## Tests
- `RelatedContent.spec.ts`: the 5 existing behaviour tests still pass, plus a new one asserting the summary and a tag chip render. Full app suite: 595 passed / 1 skipped. type-check + eslint clean.

## Notes for review
- **Not visually verified.** I can't run the app to pixel-check the layout/spacing against the mockup here — the logic, data, and responsive grid are in place, but the exact look (image size, gaps, alignment within the article column) wants a real-app pass.
- **Heading string**: added `content.read_more` ("Read more" / "Lire plus") to the eng + fra seeds. Since UI strings load from CouchDB Language docs, the deployed lang docs need a re-seed for the new heading to appear (until then it shows the raw key).
- **Ordering/cap** are my defaults (newest-first, 8) — easy to change if you'd prefer relevance-ranked or a different count.