### PR TITLE
fix(cms): dirty check on always-available-offline toggle

### DIFF
--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1068,7 +1068,6 @@ describe("EditContent.vue", () => {
             },
             { timeout: 10000 },
         );
-
     });
 
     describe("Image bucket validation", () => {
@@ -1276,7 +1275,9 @@ describe("EditContent.vue", () => {
         };
 
         it("is not dirty on load when the post has no bucket IDs and a single media bucket is auto-selected", async () => {
-            const wrapper = await loadWithoutUserEdits({}, [mockData.mockStorageDtoWithEncryptedCredentials]);
+            const wrapper = await loadWithoutUserEdits({}, [
+                mockData.mockStorageDtoWithEncryptedCredentials,
+            ]);
 
             // Revert action is only rendered while isDirty is true — its absence proves
             // the dirty state stayed clean across the bucket auto-select watcher.
@@ -1306,44 +1307,56 @@ describe("EditContent.vue", () => {
             });
         });
 
-        it(
-            "is not dirty on load when the post already has bucket IDs persisted",
-            async () => {
-                const wrapper = await loadWithoutUserEdits(
-                    {
-                        imageBucketId: mockData.mockStorageDto._id,
-                        mediaBucketId: mockData.mockStorageDtoWithEncryptedCredentials._id,
-                    },
-                    [mockData.mockStorageDto, mockData.mockStorageDtoWithEncryptedCredentials],
-                );
+        it("returns to clean when the always-offline toggle is flipped on and back off", async () => {
+            // Legacy docs predate `alwaysOffline`, so the field is absent. Toggling it on
+            // and back off writes `false` where the shadow has no key — the parent
+            // filterFn must normalize that away (like showComingSoon/useVerticalTileLayout)
+            // or the editor stays stuck reporting unsaved settings changes.
+            const wrapper = await loadWithoutUserEdits();
 
+            const parentCard = wrapper.findComponent(EditContentParent);
+            // Publish date (0), Coming soon (1), Always offline (2)
+            const alwaysOfflineToggle = parentCard.findAllComponents({ name: "LToggle" })[2];
+
+            alwaysOfflineToggle.vm.$emit("update:modelValue", true);
+            await waitForExpect(() => {
+                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(true);
+            });
+
+            alwaysOfflineToggle.vm.$emit("update:modelValue", false);
+            await waitForExpect(() => {
                 expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
-            },
-            15000,
-        );
+            });
+        });
 
-        it(
-            "becomes dirty after a genuine user edit on a legacy post with auto-selected buckets",
-            async () => {
-                const wrapper = await loadWithoutUserEdits({}, [
-                    mockData.mockStorageDto,
-                    mockData.mockStorageDtoWithEncryptedCredentials,
-                ]);
+        it("is not dirty on load when the post already has bucket IDs persisted", async () => {
+            const wrapper = await loadWithoutUserEdits(
+                {
+                    imageBucketId: mockData.mockStorageDto._id,
+                    mediaBucketId: mockData.mockStorageDtoWithEncryptedCredentials._id,
+                },
+                [mockData.mockStorageDto, mockData.mockStorageDtoWithEncryptedCredentials],
+            );
 
-                // Baseline must be clean before the edit — otherwise the next assertion
-                // could pass for the wrong reason.
-                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+        }, 15000);
 
-                await wrapper.find('input[name="title"]').setValue("Edited title");
+        it("becomes dirty after a genuine user edit on a legacy post with auto-selected buckets", async () => {
+            const wrapper = await loadWithoutUserEdits({}, [
+                mockData.mockStorageDto,
+                mockData.mockStorageDtoWithEncryptedCredentials,
+            ]);
 
-                await waitForExpect(() => {
-                    expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(
-                        true,
-                    );
-                });
-            },
-            15000,
-        );
+            // Baseline must be clean before the edit — otherwise the next assertion
+            // could pass for the wrong reason.
+            expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(false);
+
+            await wrapper.find('input[name="title"]').setValue("Edited title");
+
+            await waitForExpect(() => {
+                expect(wrapper.find('[data-test="revert-changes-button"]').exists()).toBe(true);
+            });
+        }, 15000);
 
         it("optional boolean toggles clear dirty state when toggled back off", async () => {
             const wrapper = await loadWithoutUserEdits({}, [

--- a/cms/src/components/content/EditContent.spec.ts
+++ b/cms/src/components/content/EditContent.spec.ts
@@ -1308,10 +1308,6 @@ describe("EditContent.vue", () => {
         });
 
         it("returns to clean when the always-offline toggle is flipped on and back off", async () => {
-            // Legacy docs predate `alwaysOffline`, so the field is absent. Toggling it on
-            // and back off writes `false` where the shadow has no key — the parent
-            // filterFn must normalize that away (like showComingSoon/useVerticalTileLayout)
-            // or the editor stays stuck reporting unsaved settings changes.
             const wrapper = await loadWithoutUserEdits();
 
             const parentCard = wrapper.findComponent(EditContentParent);

--- a/cms/src/components/content/composables/useEditContentSource.ts
+++ b/cms/src/components/content/composables/useEditContentSource.ts
@@ -143,6 +143,7 @@ export function useEditContentSource(options: UseEditContentSourceOptions): UseE
             const copy = { ...item };
             if (copy.showComingSoon === false) delete copy.showComingSoon;
             if (copy.useVerticalTileLayout === false) delete copy.useVerticalTileLayout;
+            if (copy.alwaysOffline === false) delete copy.alwaysOffline;
             return copy;
         },
     });


### PR DESCRIPTION
## Problem

Flipping the "Always available offline" toggle on and back off leaves the editor stuck showing "Unsaved changes to …'s settings" — unlike the Show publish date / Coming soon / Pinned / Vertical Tile toggles, which return to a clean state.

Cause: documents predating the `alwaysOffline` field simply don't carry the key, so toggling on-and-off writes `alwaysOffline: false` where the shadow copy has no key — a strict deep-compare counts that as an edit. The parent editable's `filterFn` in `useEditContentSource.ts` already normalizes exactly this for the other optional booleans (`showComingSoon === false` / `useVerticalTileLayout === false` → key deleted before the dirty compare), but `alwaysOffline` was never added when the toggle shipped (#1756).

## Fix

Add `alwaysOffline` to the same normalization — one line. Both sides of the compare are filtered, so a stored `false` and an absent key now read as equal, matching the other toggles' behavior.

## Tests

New regression test in `EditContent.spec.ts` ("dirty state" suite): loads a legacy post without the field, flips the Always-offline toggle on (revert button appears) and back off (revert button gone). Full `EditContent.spec.ts` passes (43/43); cms `type-check` clean.