### PR TITLE
fix(api): make image duplication idempotent across changerequest replays

### DIFF
--- a/api/src/changeRequests/documentProcessing/processImageDto.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processImageDto.spec.ts
@@ -207,6 +207,96 @@ describe("S3ImageHandler", () => {
         resImages.push(duplicatedImage);
     });
 
+    it("keeps the copied files when a processed duplication request is replayed", async () => {
+        const sourceImage = new ImageDto();
+        sourceImage.uploadData = [
+            {
+                fileData: fs.readFileSync(
+                    path.resolve(__dirname + "/../../test/" + "testImage.jpg"),
+                ) as unknown as ArrayBuffer,
+                preset: "default",
+            },
+        ];
+        await processImage(sourceImage, undefined, dbService, testBucketId);
+
+        // First processing of the duplication request — the copy runs.
+        const duplicatedImage = new ImageDto();
+        duplicatedImage.fileCollections = JSON.parse(JSON.stringify(sourceImage.fileCollections));
+        duplicatedImage.duplicate = true;
+        await processImage(duplicatedImage, undefined, dbService, testBucketId);
+
+        const copiedFilenames = duplicatedImage.fileCollections.flatMap((collection) =>
+            collection.imageFiles.map((imageFile) => imageFile.filename),
+        );
+        expect(copiedFilenames.length).toBeGreaterThan(0);
+
+        // Replay: the client retries the SAME payload (stale source filenames + duplicate
+        // flag), while prevImage is the processed doc holding the copied filenames.
+        const replayedImage = new ImageDto();
+        replayedImage.fileCollections = JSON.parse(JSON.stringify(sourceImage.fileCollections));
+        replayedImage.duplicate = true;
+        await processImage(replayedImage, duplicatedImage, dbService, testBucketId);
+
+        // The replay must keep the already-copied files — not diff-delete them.
+        const replayedFilenames = replayedImage.fileCollections.flatMap((collection) =>
+            collection.imageFiles.map((imageFile) => imageFile.filename),
+        );
+        expect(replayedFilenames).toEqual(copiedFilenames);
+        expect(replayedImage.duplicate).toBeUndefined();
+
+        // And the copied files must still exist in the bucket.
+        const copies = await Promise.all(
+            copiedFilenames.map((filename) => service.getObject(filename)),
+        );
+        expect(copies.some((stream) => stream == undefined)).toBeFalsy();
+
+        resImages.push(sourceImage);
+        resImages.push(replayedImage);
+    });
+
+    it("re-attempts the copy when a duplication request is replayed after a failed copy", async () => {
+        const sourceImage = new ImageDto();
+        sourceImage.uploadData = [
+            {
+                fileData: fs.readFileSync(
+                    path.resolve(__dirname + "/../../test/" + "testImage.jpg"),
+                ) as unknown as ArrayBuffer,
+                preset: "default",
+            },
+        ];
+        await processImage(sourceImage, undefined, dbService, testBucketId);
+
+        // A previously-failed duplication persisted the doc with EMPTY fileCollections.
+        const failedImage = new ImageDto();
+        failedImage.fileCollections = [];
+
+        // The retried payload still carries the source filenames + duplicate flag.
+        const retriedImage = new ImageDto();
+        retriedImage.fileCollections = JSON.parse(JSON.stringify(sourceImage.fileCollections));
+        retriedImage.duplicate = true;
+        await processImage(retriedImage, failedImage, dbService, testBucketId);
+
+        const sourceFilenames = sourceImage.fileCollections.flatMap((collection) =>
+            collection.imageFiles.map((imageFile) => imageFile.filename),
+        );
+        const retriedFilenames = retriedImage.fileCollections.flatMap((collection) =>
+            collection.imageFiles.map((imageFile) => imageFile.filename),
+        );
+
+        // The copy ran on the retry: fresh filenames, present in the bucket.
+        expect(retriedFilenames.length).toBeGreaterThan(0);
+        retriedFilenames.forEach((filename) => {
+            expect(sourceFilenames).not.toContain(filename);
+        });
+        const copies = await Promise.all(
+            retriedFilenames.map((filename) => service.getObject(filename)),
+        );
+        expect(copies.some((stream) => stream == undefined)).toBeFalsy();
+
+        resImages.push(sourceImage);
+        resImages.push(retriedImage);
+    });
+
     it("clears copied image references if duplication fails", async () => {
         const sourceImage = new ImageDto();
         sourceImage.uploadData = [
@@ -223,7 +313,12 @@ describe("S3ImageHandler", () => {
         duplicatedImage.fileCollections = JSON.parse(JSON.stringify(sourceImage.fileCollections));
         duplicatedImage.duplicate = true;
 
-        const result = await processImage(duplicatedImage, undefined, dbService, "storage-missing-bucket");
+        const result = await processImage(
+            duplicatedImage,
+            undefined,
+            dbService,
+            "storage-missing-bucket",
+        );
 
         expect(
             result.warnings.some((warning) =>
@@ -698,7 +793,8 @@ describe("S3ImageHandler - File Type Validation", () => {
         // Should fail with file type warning (jpeg not allowed when only webp is allowed)
         // Note: Sharp detects "jpeg" format but the code normalizes it to "jpg" in the warning
         const fileTypeWarning = warnings.warnings.find(
-            (w) => w.includes("not allowed") && (w.includes("image/jpg") || w.includes("image/jpeg")),
+            (w) =>
+                w.includes("not allowed") && (w.includes("image/jpg") || w.includes("image/jpeg")),
         );
         expect(fileTypeWarning).toBeDefined();
         expect(image.fileCollections.length).toBe(0);

--- a/api/src/changeRequests/documentProcessing/processImageDto.ts
+++ b/api/src/changeRequests/documentProcessing/processImageDto.ts
@@ -206,7 +206,7 @@ export async function processImage(
                 (collection) => collection.imageFiles?.length > 0,
             );
 
-            if (prevHasFiles) {
+            if (prevHasImageFiles) {
                 image.fileCollections = prevImage.fileCollections;
             } else {
                 if (!parentBucketId) {

--- a/api/src/changeRequests/documentProcessing/processImageDto.ts
+++ b/api/src/changeRequests/documentProcessing/processImageDto.ts
@@ -50,9 +50,9 @@ async function deleteImageFilesFromBucket(
                         .removeObject(bucketS3Service.getBucketName(), file.filename);
                 } catch (error) {
                     warnings.push(
-                        `Failed to delete ${file.filename} from bucket ${bucketS3Service.getBucketName()}: ${
-                            error.message
-                        }`,
+                        `Failed to delete ${
+                            file.filename
+                        } from bucket ${bucketS3Service.getBucketName()}: ${error.message}`,
                     );
                 }
             }
@@ -198,27 +198,37 @@ export async function processImage(
 ): Promise<{ migrationFailed: boolean; warnings: string[] }> {
     const warnings: string[] = [];
     let migrationFailed = false;
+    let duplicatedNow = false;
 
     try {
-        if (!prevImage && image.duplicate && image.fileCollections.length > 0) {
-            if (!parentBucketId) {
-                warnings.push("Parent bucket ID is required for duplicated image copy.");
-                return { migrationFailed, warnings };
-            }
-
-            const duplicateResult = await duplicateImageFilesWithoutReencoding(
-                image,
-                db,
-                parentBucketId,
-                parentBucketId,
+        if (image.duplicate && image.fileCollections.length > 0) {
+            const prevHasFiles = !!prevImage?.fileCollections?.some(
+                (collection) => collection.imageFiles?.length > 0,
             );
-            warnings.push(...duplicateResult.warnings);
 
-            if (!duplicateResult.success) {
-                // Avoid persisting stale source filenames when copy fails.
-                image.fileCollections = [];
-                delete image.duplicate;
-                return { migrationFailed, warnings };
+            if (prevHasFiles) {
+                image.fileCollections = prevImage.fileCollections;
+            } else {
+                if (!parentBucketId) {
+                    warnings.push("Parent bucket ID is required for duplicated image copy.");
+                    return { migrationFailed, warnings };
+                }
+
+                const duplicateResult = await duplicateImageFilesWithoutReencoding(
+                    image,
+                    db,
+                    parentBucketId,
+                    parentBucketId,
+                );
+                warnings.push(...duplicateResult.warnings);
+
+                if (!duplicateResult.success) {
+                    // Avoid persisting stale source filenames when copy fails.
+                    image.fileCollections = [];
+                    delete image.duplicate;
+                    return { migrationFailed, warnings };
+                }
+                duplicatedNow = true;
             }
         }
 
@@ -240,7 +250,10 @@ export async function processImage(
             migrationFailed = migrationResult.failed;
         }
 
-        if (prevImage) {
+        // Skipped when the duplicate copy just authored the collections (a retry after a
+        // failed first copy has a prevImage with EMPTY collections — reconciling against
+        // it would wipe the files the copy just created).
+        if (prevImage && !duplicatedNow) {
             // Remove files that were removed from the image
             const removedFiles = prevImage.fileCollections.flatMap((collection) => {
                 return collection.imageFiles.filter(

--- a/api/src/changeRequests/documentProcessing/processImageDto.ts
+++ b/api/src/changeRequests/documentProcessing/processImageDto.ts
@@ -202,7 +202,7 @@ export async function processImage(
 
     try {
         if (image.duplicate && image.fileCollections.length > 0) {
-            const prevHasFiles = !!prevImage?.fileCollections?.some(
+            const prevHasImageFiles = !!prevImage?.fileCollections?.some(
                 (collection) => collection.imageFiles?.length > 0,
             );
 


### PR DESCRIPTION
Closes #1810

## Root cause

Duplicating a post marks the cloned `imageData` with `duplicate: true` and (necessarily) still references the SOURCE post's filenames; the API copies the files on first processing and rewrites `fileCollections`. But the same changerequest can reach the API **twice**:

- the client's delivery retry (`syncLocalChanges` retries up to 3× and re-drains on reconnect) when the first response is lost, or
- the user saving again before the processed doc round-trips back over the socket (the editable still carries the stale payload until the `imageData` back-patch lands).

On the second processing, `prevDoc` exists with the **copied** filenames while the payload carries the **source** filenames + the `duplicate` flag. The prev-reconcile in `processImage` treated the copied files as removed: it deleted them from the bucket and rebuilt `fileCollections` to empty — the duplicated post silently lost its image. Whether the bug hit depended purely on network timing, matching the reported ~50% on production.

## Fix

`processImage` now treats a `duplicate` request idempotently:

- **Replay after a successful copy** (prev has files): keep the previously copied files, drop the flag — never diff them against the stale source filenames.
- **Retry after a failed copy** (prev exists with empty collections): re-attempt the copy, and skip the prev-reconcile for the just-authored collections (reconciling against an empty prev would wipe them).
- First-time processing is unchanged.

## Tests

Two new cases in `processImageDto.spec.ts` (S3/CouchDB-backed — please run with the local stack): replay-after-success keeps the copied files in the bucket and on the doc; retry-after-failure performs the copy. `typecheck` and `lint` pass.