### PR TITLE
Related content (mobile): even margins around the card text

### DIFF
--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -106,6 +106,15 @@ describe("ReadMore", () => {
         expect(summaryClampFor(3)).toBe("line-clamp-1");
     });
 
+    it("uses even top/bottom/right spacing around the mobile text content", () => {
+        const wrapper = mountList([makeItem()]);
+
+        const textArea = wrapper.get("p").element.parentElement!;
+        // p-2 gives an equal 8px on every side; pl-0 drops the left (the thumbnail gap sets it).
+        expect(textArea.classList).toContain("p-2");
+        expect(textArea.classList).toContain("pl-0");
+    });
+
     it("shows the content tags in a horizontally scrollable mobile row", async () => {
         await db.docs.bulkPut([
             mockLanguageDtoEng,
@@ -148,6 +157,8 @@ describe("ReadMore", () => {
             expect(tags.classes()).toContain("sm:hidden");
             // Categories are pinned to the bottom of the card.
             expect(tags.classes()).toContain("mt-auto");
+            // No extra bottom padding, so the space below the chips matches the top/right.
+            expect(tags.classes()).not.toContain("pb-1");
         });
     });
 

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -142,8 +142,10 @@ watch(visibleItems, () => nextTick(measureTitles));
                         </div>
                     </div>
 
+                    <!-- Even spacing on mobile: the same 8px above the title, below the tags,
+                         and to the right of the text (the thumbnail gap sets the left). -->
                     <div
-                        class="flex min-w-0 flex-1 flex-col gap-1 py-2 pr-2 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
+                        class="flex min-w-0 flex-1 flex-col gap-1 p-2 pl-0 sm:justify-center sm:px-2 sm:pb-1 sm:pt-0"
                     >
                         <!-- Mobile only: title beside the thumbnail (on the card it sits on
                              the image instead). Up to two lines; the summary adapts below. -->
@@ -169,7 +171,7 @@ watch(visibleItems, () => nextTick(measureTitles));
                              the title and summary when the row is taller than the text. -->
                         <div
                             v-if="tagsFor(item).length"
-                            class="mt-auto flex max-w-full gap-1 overflow-x-auto pb-1 scrollbar-hide sm:hidden"
+                            class="mt-auto flex max-w-full gap-1 overflow-x-auto scrollbar-hide sm:hidden"
                             data-test="content-tags"
                         >
                             <span


### PR DESCRIPTION
Evens the spacing around the mobile card's text content so the gap above the title, below the tags, and to the right of the text is the same 8px (the thumbnail gap sets the left):

- The text container uses `p-2 pl-0` (equal padding all round, minus the left which the thumbnail gap already provides).
- Drops the tag row's extra `pb-1`, which had made the space below the chips larger than the top and right.

Applies with the category fade — the right padding is the fade's margin, so it stays consistent. Part of the #1737 related-content redesign; scoped to one change for focused review.