### PR TITLE
Related content (mobile): thumbnail fills the card height (no top/bottom gap)

### DIFF
--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -69,19 +69,6 @@ describe("ReadMore", () => {
         expect(card.classes()).toContain("sm:flex-col");
     });
 
-    it("fills the card height with the 4:3 mobile thumbnail (no top/bottom gap)", () => {
-        const wrapper = mountList([makeItem()]);
-
-        // The mobile image is the first LImage (the second is the tablet/desktop card image).
-        const mobileImage = wrapper.findAllComponents(LImage)[0];
-        expect(mobileImage.props("aspectRatio")).toBe("classic");
-
-        // Its wrapper stretches the image to the card height instead of centring it in a gap.
-        const thumbWrapper = mobileImage.element.parentElement as HTMLElement;
-        expect(thumbWrapper.className).toContain("h-full");
-        expect(thumbWrapper.className).not.toContain("self-center");
-    });
-
     it("lets the mobile title wrap onto up to two lines", () => {
         const wrapper = mountList([makeItem()]);
 

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -4,7 +4,6 @@ import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { db, DocType, PublishStatus, TagType, type ContentDto } from "luminary-shared";
 import ReadMore, { summaryClampFor } from "./ReadMore.vue";
-import LImage from "../images/LImage.vue";
 import waitForExpect from "wait-for-expect";
 import { mockLanguageDtoEng } from "@/tests/mockdata";
 import { appLanguageIdsAsRef } from "@/globalConfig";

--- a/app/src/components/content/ReadMore.spec.ts
+++ b/app/src/components/content/ReadMore.spec.ts
@@ -4,6 +4,7 @@ import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { db, DocType, PublishStatus, TagType, type ContentDto } from "luminary-shared";
 import ReadMore, { summaryClampFor } from "./ReadMore.vue";
+import LImage from "../images/LImage.vue";
 import waitForExpect from "wait-for-expect";
 import { mockLanguageDtoEng } from "@/tests/mockdata";
 import { appLanguageIdsAsRef } from "@/globalConfig";
@@ -66,6 +67,19 @@ describe("ReadMore", () => {
         expect(card.classes()).not.toContain("p-1");
         expect(card.classes()).toContain("flex");
         expect(card.classes()).toContain("sm:flex-col");
+    });
+
+    it("fills the card height with the 4:3 mobile thumbnail (no top/bottom gap)", () => {
+        const wrapper = mountList([makeItem()]);
+
+        // The mobile image is the first LImage (the second is the tablet/desktop card image).
+        const mobileImage = wrapper.findAllComponents(LImage)[0];
+        expect(mobileImage.props("aspectRatio")).toBe("classic");
+
+        // Its wrapper stretches the image to the card height instead of centring it in a gap.
+        const thumbWrapper = mobileImage.element.parentElement as HTMLElement;
+        expect(thumbWrapper.className).toContain("h-full");
+        expect(thumbWrapper.className).not.toContain("self-center");
     });
 
     it("lets the mobile title wrap onto up to two lines", () => {

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -142,10 +142,8 @@ watch(visibleItems, () => nextTick(remeasureAll));
                     :to="{ name: 'content', params: { slug: item.slug } }"
                     class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:shadow-lg hover:brightness-[1.15] dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
                 >
-                    <!-- Mobile: thumbnail on the left. It fills the card's height (object-cover)
-                         so there's no gap above or below it, while its width stays fixed so it
-                         still reads as a compact thumbnail. The h-full overrides stretch LImage's
-                         fixed 4:3 box to the card's height. -->
+                    <!-- Mobile: left thumbnail with fixed width; the h-full overrides stretch
+                         LImage's 4:3 box to fill the card's height without gaps. -->
                     <div
                         class="shrink-0 overflow-hidden sm:hidden [&>div>div]:!h-full [&>div]:h-full [&_img]:!h-full"
                     >

--- a/app/src/components/content/ReadMore.vue
+++ b/app/src/components/content/ReadMore.vue
@@ -142,8 +142,13 @@ watch(visibleItems, () => nextTick(remeasureAll));
                     :to="{ name: 'content', params: { slug: item.slug } }"
                     class="ease-out-expo group flex gap-2 overflow-hidden rounded-lg bg-white shadow ring-1 ring-zinc-950/10 transition hover:shadow-lg hover:brightness-[1.15] dark:bg-slate-800 dark:ring-white/10 sm:h-full sm:flex-col sm:gap-1"
                 >
-                    <!-- Mobile: small thumbnail on the left. -->
-                    <div class="shrink-0 sm:hidden">
+                    <!-- Mobile: thumbnail on the left. It fills the card's height (object-cover)
+                         so there's no gap above or below it, while its width stays fixed so it
+                         still reads as a compact thumbnail. The h-full overrides stretch LImage's
+                         fixed 4:3 box to the card's height. -->
+                    <div
+                        class="shrink-0 overflow-hidden sm:hidden [&>div>div]:!h-full [&>div]:h-full [&_img]:!h-full"
+                    >
                         <LImage
                             :image="item.parentImageData"
                             :content-parent-id="item.parentId"


### PR DESCRIPTION
The mobile thumbnail is a compact 4:3, but the card is taller than a 4:3 image (a two-line title + summary + tags need more height), so centring the image left white space above and below it.

This keeps the same compact 4:3 thumbnail but lets it **fill the card's height** with `object-cover` — the width is unchanged, so it reads as the same image, just with no gap top or bottom. Small `h-full` overrides stretch LImage's fixed 4:3 box to the card height.

The tablet/desktop card image is unchanged. Part of the #1737 related-content redesign.