### PR TITLE
APP: Show reading progress on ContentTile as a bottom bar in the ContinueReadingPrompt style

### DIFF
--- a/app/src/components/content/ContentTile.spec.ts
+++ b/app/src/components/content/ContentTile.spec.ts
@@ -332,7 +332,7 @@ describe("ContentTile", () => {
         expect(wrapper.html()).toContain("bg-yellow-500");
     });
 
-    it("shows media and reading progress as independent bars on mixed content", () => {
+    it("shows a single bar with the highest progress on mixed content", () => {
         const content = {
             _id: "sample-mixed-id",
             title: "Mixed Content",
@@ -365,14 +365,14 @@ describe("ContentTile", () => {
             },
         });
 
-        // Media keeps the white bar in the black pill; reading gets its own yellow bar.
-        expect(wrapper.html()).toContain('style="width: 40%');
+        // One yellow bar showing the furthest progress (reading 60% > media 40%); the white pill is gone.
         expect(wrapper.html()).toContain('style="width: 60%');
-        expect(wrapper.html()).toContain("bg-white");
+        expect(wrapper.html()).not.toContain('style="width: 40%');
+        expect(wrapper.html()).not.toContain("bg-white");
         expect(wrapper.html()).toContain("bg-yellow-500");
     });
 
-    it("does not show the reading bar when only media progress exists", () => {
+    it("shows the yellow bar for media-only progress", () => {
         const content = {
             _id: "sample-mixed-id-2",
             title: "Mixed Content 2",
@@ -405,7 +405,8 @@ describe("ContentTile", () => {
         });
 
         expect(wrapper.html()).toContain('style="width: 70%');
-        expect(wrapper.html()).not.toContain("bg-yellow-500");
+        expect(wrapper.html()).toContain("bg-yellow-500");
+        expect(wrapper.html()).not.toContain("bg-white");
     });
 
     it("renders title on the image in overlay mode without text below", () => {

--- a/app/src/components/content/ContentTile.spec.ts
+++ b/app/src/components/content/ContentTile.spec.ts
@@ -328,9 +328,11 @@ describe("ContentTile", () => {
         });
 
         expect(wrapper.html()).toContain('style="width: 45%');
+        // Reading progress uses the ContinueReadingPrompt bar style (yellow fill).
+        expect(wrapper.html()).toContain("bg-yellow-500");
     });
 
-    it("shows reading progress when it is higher than video progress", () => {
+    it("shows media and reading progress as independent bars on mixed content", () => {
         const content = {
             _id: "sample-mixed-id",
             title: "Mixed Content",
@@ -363,10 +365,14 @@ describe("ContentTile", () => {
             },
         });
 
+        // Media keeps the white bar in the black pill; reading gets its own yellow bar.
+        expect(wrapper.html()).toContain('style="width: 40%');
         expect(wrapper.html()).toContain('style="width: 60%');
+        expect(wrapper.html()).toContain("bg-white");
+        expect(wrapper.html()).toContain("bg-yellow-500");
     });
 
-    it("shows video progress when it is higher than reading progress", () => {
+    it("does not show the reading bar when only media progress exists", () => {
         const content = {
             _id: "sample-mixed-id-2",
             title: "Mixed Content 2",
@@ -380,7 +386,6 @@ describe("ContentTile", () => {
         } as unknown as ContentDto;
 
         setMediaProgress("sample-mixed-media-id-2", content._id, 210, 300); // 70%
-        setReadingProgress(content._id, 30);
 
         const wrapper = mount(ContentTile, {
             props: {
@@ -400,6 +405,7 @@ describe("ContentTile", () => {
         });
 
         expect(wrapper.html()).toContain('style="width: 70%');
+        expect(wrapper.html()).not.toContain("bg-yellow-500");
     });
 
     it("renders title on the image in overlay mode without text below", () => {

--- a/app/src/components/content/ContentTile.vue
+++ b/app/src/components/content/ContentTile.vue
@@ -81,6 +81,9 @@ const mediaProgress = computed(() => {
 const readingProgress = computed(() =>
     props.showProgress ? getReadingProgress(props.content._id) : 0,
 );
+
+/** One bar per tile: whichever progress (playback or reading) is further along. */
+const displayProgress = computed(() => Math.max(mediaProgress.value, readingProgress.value));
 </script>
 
 <template>
@@ -218,31 +221,18 @@ const readingProgress = computed(() =>
                             </p>
                         </div>
 
+                        <!-- Progress (playback or reading): same bar design as ContinueReadingPrompt, on the image's bottom edge. -->
                         <div
-                            v-if="showProgress && mediaProgress > 0"
-                            class="absolute bottom-2 left-0 right-0 z-20 mx-1 rounded-md bg-black/50 px-1 py-1"
-                            :class="titlePosition === 'overlay' ? 'bottom-[4.5rem]' : ''"
-                        >
-                            <div class="relative h-1.5 w-full overflow-hidden rounded bg-zinc-600">
-                                <div
-                                    class="absolute left-0 top-0 h-full bg-white"
-                                    :style="{ width: `${mediaProgress}%` }"
-                                ></div>
-                            </div>
-                        </div>
-
-                        <!-- Reading progress: same bar design as ContinueReadingPrompt, on the image's bottom edge. -->
-                        <div
-                            v-if="showProgress && readingProgress > 0"
+                            v-if="showProgress && displayProgress > 0"
                             class="absolute inset-x-0 bottom-0 z-20 h-1 overflow-hidden rounded-b-lg bg-zinc-200 dark:bg-slate-600"
                             role="progressbar"
-                            :aria-valuenow="readingProgress"
+                            :aria-valuenow="displayProgress"
                             aria-valuemin="0"
                             aria-valuemax="100"
                         >
                             <div
                                 class="h-full bg-yellow-500"
-                                :style="{ width: `${readingProgress}%` }"
+                                :style="{ width: `${displayProgress}%` }"
                             ></div>
                         </div>
                     </template>

--- a/app/src/components/content/ContentTile.vue
+++ b/app/src/components/content/ContentTile.vue
@@ -60,29 +60,27 @@ const isComingSoon = computed(() => {
     );
 });
 
-const displayProgress = computed(() => {
+const mediaProgress = computed(() => {
     if (!props.showProgress) return 0;
 
-    let mediaProgressPercent = 0;
     const mediaIds = props.content.video
         ? [props.content.video]
         : (props.content.parentMedia?.fileCollections ?? []).map((f) => f.fileUrl);
 
     for (const mediaId of mediaIds) {
-        const mediaProgress = getMediaProgress(mediaId, props.content._id);
-        const mediaDuration = getMediaDuration(mediaId, props.content._id);
+        const progress = getMediaProgress(mediaId, props.content._id);
+        const duration = getMediaDuration(mediaId, props.content._id);
 
-        if (mediaProgress > 0 && mediaDuration > 0) {
-            mediaProgressPercent = Math.min(100, (mediaProgress / mediaDuration) * 100);
-            break;
+        if (progress > 0 && duration > 0) {
+            return Math.min(100, (progress / duration) * 100);
         }
     }
-
-    const readingProgressPercent = getReadingProgress(props.content._id);
-    return Math.max(mediaProgressPercent, readingProgressPercent);
+    return 0;
 });
 
-const hasProgress = computed(() => displayProgress.value > 0);
+const readingProgress = computed(() =>
+    props.showProgress ? getReadingProgress(props.content._id) : 0,
+);
 </script>
 
 <template>
@@ -221,16 +219,31 @@ const hasProgress = computed(() => displayProgress.value > 0);
                         </div>
 
                         <div
-                            v-if="showProgress && hasProgress"
+                            v-if="showProgress && mediaProgress > 0"
                             class="absolute bottom-2 left-0 right-0 z-20 mx-1 rounded-md bg-black/50 px-1 py-1"
                             :class="titlePosition === 'overlay' ? 'bottom-[4.5rem]' : ''"
                         >
                             <div class="relative h-1.5 w-full overflow-hidden rounded bg-zinc-600">
                                 <div
                                     class="absolute left-0 top-0 h-full bg-white"
-                                    :style="{ width: `${displayProgress}%` }"
+                                    :style="{ width: `${mediaProgress}%` }"
                                 ></div>
                             </div>
+                        </div>
+
+                        <!-- Reading progress: same bar design as ContinueReadingPrompt, on the image's bottom edge. -->
+                        <div
+                            v-if="showProgress && readingProgress > 0"
+                            class="absolute inset-x-0 bottom-0 z-20 h-1 overflow-hidden rounded-b-lg bg-zinc-200 dark:bg-slate-600"
+                            role="progressbar"
+                            :aria-valuenow="readingProgress"
+                            aria-valuemin="0"
+                            aria-valuemax="100"
+                        >
+                            <div
+                                class="h-full bg-yellow-500"
+                                :style="{ width: `${readingProgress}%` }"
+                            ></div>
                         </div>
                     </template>
                 </LImage>


### PR DESCRIPTION
Closes #1847

## What

`ContentTile` now shows progress as a single thin yellow bar (`bg-yellow-500` fill on a `bg-zinc-200` / `dark:bg-slate-600` track) anchored to the bottom edge of the tile image — the same bar design as the `ContinueReadingPrompt` ("Continue where you left off") pill. The old white-bar-in-black-pill overlay used for media progress is removed; video/audio playback progress renders in the same yellow bar.

## How

- Split the progress computation into `mediaProgress` and `readingProgress`, with `displayProgress` showing whichever is further along.
- One bar per tile, carrying `role="progressbar"` + `aria-valuenow/min/max`, matching the prompt.
- Gated by the existing `showProgress` prop; tiles that don't opt in are unaffected.

## Tests

- Video-only tile shows the yellow bar at its playback percentage.
- Reading-only tile shows the yellow bar at its reading percentage.
- Mixed content shows a single bar at the higher of the two values, and no white pill.
- Verified visually in the running app: the Continue tile shows one yellow bar on the image's bottom edge with both progress kinds present.