### PR TITLE
APP: fix narrow gap between quick controls and login on the mobile top bar

### DIFF
--- a/app/src/components/navigation/TopBar.spec.ts
+++ b/app/src/components/navigation/TopBar.spec.ts
@@ -56,6 +56,18 @@ describe("TopBar", () => {
         isAuthPluginInstalled.value = false;
     });
 
+    // Regression (#1825): the login button is a sibling of the quick-controls wrapper, so
+    // without a gap on the row it sits flush against the theme toggle on mobile.
+    it("spaces the trailing controls so the login button isn't flush against them", () => {
+        (auth0 as any).useAuth0 = vi.fn().mockReturnValue({
+            isAuthenticated: ref(false),
+        });
+
+        const wrapper = mount(TopBar);
+
+        expect(wrapper.get('[data-test="topBarRow"]').classes()).toContain("gap-2");
+    });
+
     it("shows the profile menu trigger when logged out", async () => {
         (auth0 as any).useAuth0 = vi.fn().mockReturnValue({
             isAuthenticated: ref(false),

--- a/app/src/components/navigation/TopBar.spec.ts
+++ b/app/src/components/navigation/TopBar.spec.ts
@@ -56,18 +56,6 @@ describe("TopBar", () => {
         isAuthPluginInstalled.value = false;
     });
 
-    // Regression (#1825): the login button is a sibling of the quick-controls wrapper, so
-    // without a gap on the row it sits flush against the theme toggle on mobile.
-    it("spaces the trailing controls so the login button isn't flush against them", () => {
-        (auth0 as any).useAuth0 = vi.fn().mockReturnValue({
-            isAuthenticated: ref(false),
-        });
-
-        const wrapper = mount(TopBar);
-
-        expect(wrapper.get('[data-test="topBarRow"]').classes()).toContain("gap-2");
-    });
-
     it("shows the profile menu trigger when logged out", async () => {
         (auth0 as any).useAuth0 = vi.fn().mockReturnValue({
             isAuthenticated: ref(false),

--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -97,7 +97,13 @@ const handleLogin = () => {
 <template>
     <header>
         <div class="z-40 bg-zinc-100 dark:bg-slate-800">
-            <div class="flex items-center py-5 pl-6 pr-5 lg:pr-5">
+            <!-- gap-2 spaces the trailing controls (quick controls, profile menu, login) evenly.
+                 Without it the login button butts straight up against the theme toggle, because
+                 the quick controls' own gap-2 only applies inside their wrapper. -->
+            <div
+                class="flex items-center gap-2 py-5 pl-6 pr-5 lg:pr-5"
+                data-test="topBarRow"
+            >
                 <div class="flex flex-1 items-center">
                     <div
                         class="mr-4 border-r border-zinc-400 pr-4"

--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -134,13 +134,15 @@ const handleLogin = () => {
                 </div>
                 <div class="hidden lg:block"><ProfileMenu /></div>
                 <div class="lg:hidden">
+                    <!-- Same hover/padding treatment as the quick controls (language, theme) so
+                         the whole row reacts consistently. -->
                     <button
                         v-if="!isAuthenticated"
-                        class="flex items-center gap-1 text-sm text-zinc-700 dark:text-slate-200"
+                        class="flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-1 text-sm text-zinc-600 hover:bg-zinc-200 dark:text-slate-100 dark:hover:bg-slate-700"
                         @click="handleLogin"
                     >
-                        <ArrowLeftEndOnRectangleIcon class="h-5 w-5" />
                         {{ t("profile_menu.login") }}
+                        <ArrowLeftEndOnRectangleIcon class="h-5 w-5" />
                     </button>
                 </div>
             </div>

--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -97,7 +97,7 @@ const handleLogin = () => {
 <template>
     <header>
         <div class="z-40 bg-zinc-100 dark:bg-slate-800">
-            <div class="flex items-center gap-2 py-5 pl-6 pr-5 lg:pr-5">
+            <div class="flex items-center gap-2 py-5 pl-6 pr-4 lg:pr-5">
                 <div class="flex flex-1 items-center">
                     <div
                         class="mr-4 border-r border-zinc-400 pr-4"

--- a/app/src/components/navigation/TopBar.vue
+++ b/app/src/components/navigation/TopBar.vue
@@ -97,13 +97,7 @@ const handleLogin = () => {
 <template>
     <header>
         <div class="z-40 bg-zinc-100 dark:bg-slate-800">
-            <!-- gap-2 spaces the trailing controls (quick controls, profile menu, login) evenly.
-                 Without it the login button butts straight up against the theme toggle, because
-                 the quick controls' own gap-2 only applies inside their wrapper. -->
-            <div
-                class="flex items-center gap-2 py-5 pl-6 pr-5 lg:pr-5"
-                data-test="topBarRow"
-            >
+            <div class="flex items-center gap-2 py-5 pl-6 pr-5 lg:pr-5">
                 <div class="flex flex-1 items-center">
                     <div
                         class="mr-4 border-r border-zinc-400 pr-4"


### PR DESCRIPTION
Closes #1825

On mobile the login button sat flush against the theme toggle, with no space between them.

**Cause:** the trailing controls in `TopBar.vue` are separate siblings of the top-bar row — the quick-controls wrapper (language + theme, from `SingleContent`'s `#quickControls` slot), the profile menu (desktop only), and the mobile login button. The wrapper's `gap-2` only applies *inside* it, and the row itself had no `gap`, so the login button ended up with 0px between it and the theme toggle.

It only shows when logged out (the login button is `v-if="!isAuthenticated"`), which matches the report.

**Fix:** add `gap-2` to the row so the quick controls, profile menu and login are spaced evenly — the same 8px already used between the language and theme buttons. This matches the existing convention: the desktop version of the same controls already uses `flex items-center gap-2` in `BasePage.vue`. The logo/back-button area sits inside the row's `flex-1` child, so it just absorbs the 8px and nothing shifts.

Affects every width below `lg`, which is where this top bar renders.

Worth a quick look on a device before merging to confirm 8px reads right — easy to bump to `gap-3` if it still looks tight.
