### PR TITLE
fix(app): align homepage search bar x padding with page content

### DIFF
--- a/app/src/components/HomePage/HomePageSearch.vue
+++ b/app/src/components/HomePage/HomePageSearch.vue
@@ -28,7 +28,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <section class="bg-yellow-500/10 px-2 pt-2 dark:bg-yellow-500/5">
+    <section class="bg-yellow-500/10 px-4 pt-2 dark:bg-yellow-500/5">
         <div class="mx-auto max-w-xl">
             <button
                 type="button"


### PR DESCRIPTION
Fixes #1853

## Problem

On mobile (< 768px), the homepage search bar sat 8px closer to the screen edge than the rest of the page content.

## Cause

All other homepage sections (pinned categories, newest, continue listening/progress) render through `HorizontalContentTileCollection`, which uses `px-4` (16px) for the section title row and tile row. `HomePageSearch.vue` wrapped the search button in a section with `px-2` (8px). Both sit inside `IgnorePagePadding`, which cancels the page's own padding, so each section's own padding determines the visible inset — leaving the search bar misaligned by 8px.

## Fix

Changed `px-2` to `px-4` on the section wrapper in `HomePageSearch.vue`. The inner `mx-auto max-w-xl` wrapper means this only affects narrow screens where the padding is the constraint; the search bar only renders below 768px anyway.

## Verification

- Verified in the browser at 375px viewport: search button content edge now at 16px, matching the tile rows exactly.
- `HomePage.spec.ts` passes.