### PR TITLE
fix(app): increase basepage x padding on tablet-sized screens

### DIFF
--- a/app/src/components/BasePage.vue
+++ b/app/src/components/BasePage.vue
@@ -62,7 +62,7 @@ onUnmounted(() => {
             </Teleport>
 
             <main
-                class="flex-1 overflow-y-scroll px-2 py-2 scrollbar-hide focus:outline-none dark:bg-slate-900"
+                class="flex-1 overflow-y-scroll px-2 py-2 scrollbar-hide focus:outline-none dark:bg-slate-900 md:max-lg:px-4"
                 ref="main"
             >
                 <!-- Desktop pinned chrome: back (left) + quick controls (right) stay fixed while scrolling.

--- a/app/src/components/IgnorePagePadding.vue
+++ b/app/src/components/IgnorePagePadding.vue
@@ -16,7 +16,7 @@ withDefaults(
 <template>
     <div
         :class="[
-            mobileOnly ? 'md:mx-0' : '',
+            mobileOnly ? 'md:mx-0' : 'md:max-lg:-mx-4',
             '-mx-2',
             ignoreTop ? (mobileOnly ? '-mt-2 md:mt-0' : '-mt-2') : '',
             ignoreBottom ? (mobileOnly ? '-mb-2 md:mb-0' : '-mb-2') : '',


### PR DESCRIPTION
Fixes #1835

## Problem

BasePage's `<main>` uses `px-2` (8px) horizontal padding at every viewport width. On tablet-sized screens (768–1023px) that reads as too little breathing room for page content.

## Change

- `BasePage.vue`: `<main>` padding is now `px-2 md:max-lg:px-4` — 16px on tablets, unchanged (8px) on mobile and desktop. Desktop is deliberately left alone since its chrome (sticky quick controls, centered article column) is aligned around the existing `px-2`.
- `IgnorePagePadding.vue`: the full-bleed wrapper mirrors the new value with `md:max-lg:-mx-4` so edge-to-edge sections (tile collections, related content, copyright banner) still reach the screen edge on tablets. The `mobileOnly` variant is untouched — it already resets at `md:` and now simply respects the larger tablet padding.

16px was chosen because it matches `HorizontalContentTileCollection`'s internal `px-4`, so on tablets regular page content aligns exactly with the tile rows of full-bleed sections.

## Verification

Measured in the browser via bounding rects at four widths:
- 375px (mobile): 8px padding, full-bleed sections at screen edge — unchanged
- 768px & 800px (tablet): 16px padding, full-bleed sections still edge-to-edge, tile content aligned at 16px; content page hero respects the padding
- 1280px (desktop): 8px padding — unchanged

`BasePage.spec.ts` and `HomePage.spec.ts` pass.