### PR TITLE
feat(ssg): prefer SSG_API_URL for Node-side build fetches (#1889)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ stats.html
 # Throwaway SSG proof-of-concept (kept locally for reference, not part of the repo)
 vite-ssg_poc/
 .worktree-ports.env
+.dev-api.sh
+.dev-app.sh
+.dev-cms.sh

--- a/app/src/ssg/README.md
+++ b/app/src/ssg/README.md
@@ -62,6 +62,13 @@ The normal SPA build (`npm run build` → `dist/`, with its service worker) is
 **unchanged** and unaffected by anything here. Web config is `app/vite.config.web.ts`;
 the normal SPA is `app/vite.config.ts`.
 
+**Build-time API URL:** the build's own Node-side fetches (route/language/redirect/delete-cmd
+enumeration, the per-page `queryTransport` reads) resolve `SSG_API_URL`, falling back to
+`VITE_API_URL` when unset. This lets a deployer point the build at a colocated internal API
+without touching what gets compiled into the client bundle — `VITE_API_URL` is still the only
+origin embedded in the shipped JS (via `src/globalConfig.ts`), so it must stay publicly
+reachable. Unset `SSG_API_URL` and nothing changes.
+
 ---
 
 ## File map
@@ -317,7 +324,7 @@ full `build:web` to completion across all ~1934 routes against a production-size
 
 **Still the user's to run (browser-level):** `preview:web` in Incognito (a stale normal SPA SW
 will otherwise hijack localhost) — confirm no flash, no hydration warnings, language
-switch, 404, and nav links. Note `VITE_API_URL` must point at a running API.
+switch, 404, and nav links. Note `VITE_API_URL` (or `SSG_API_URL`) must point at a running API.
 
 ---
 

--- a/app/vite.config.web.ts
+++ b/app/vite.config.web.ts
@@ -164,6 +164,10 @@ function assertRouteLanguage(route: string, keys: Set<string> | undefined): void
 const OUT_DIR = "dist-web";
 const WEB_ORIGIN = (env.VITE_WEB_ORIGIN || "").replace(/\/$/, "");
 const APP_NAME = env.VITE_APP_NAME || "Luminary";
+// Node-side build/SSR fetches only — prefers a colocated internal API when set, falling
+// back to the public URL. The client bundle keeps using VITE_API_URL (compiled into the
+// shipped JS), so this never reaches real visitors' browsers.
+const SSG_API_URL = process.env.SSG_API_URL || env.VITE_API_URL;
 type SsgLanguage = KeysetDocument & { languageCode?: string; default?: number };
 type SsgRedirect = KeysetDocument & {
     slug?: string;
@@ -657,10 +661,10 @@ const config: UserConfig & { ssgOptions: ViteSSGOptions } = {
         // the build is CPU-bound (a JSDOM per page), so N cores gives roughly N× here.
         concurrency: Number(process.env.SSG_CONCURRENCY || 1),
         includedRoutes: async (_paths: string[], routes: readonly RouteRecordRaw[]) => {
-            const apiUrl = env.VITE_API_URL;
+            const apiUrl = SSG_API_URL;
             if (!apiUrl) {
                 // Fail fast: a partial build that silently drops pages is worse than no build.
-                throw new Error("[ssg] VITE_API_URL is required for route enumeration");
+                throw new Error("[ssg] VITE_API_URL (or SSG_API_URL) is required for route enumeration");
             }
 
             // Always populate the route→language map + default language (used per
@@ -768,9 +772,9 @@ const config: UserConfig & { ssgOptions: ViteSSGOptions } = {
                 writeManifest();
                 writeRouteIndex();
                 writeDocFacets();
-                writeDeleteQueue(await fetchDeleteCmds(env.VITE_API_URL));
+                writeDeleteQueue(await fetchDeleteCmds(SSG_API_URL));
                 if (!IS_SCOPED) {
-                    await writeRedirectFiles(env.VITE_API_URL);
+                    await writeRedirectFiles(SSG_API_URL);
                 }
                 // Sitemap/robots/llms reflect the full route set on both full and scoped builds.
                 writeSeoArtifacts();

--- a/dev-api.sh
+++ b/dev-api.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/api"
-npm run start:dev

--- a/dev-api.sh
+++ b/dev-api.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/278-cms-add-toggle-to-link-dates-on-content-documents-belonging-to-the-same-parent/api"
+cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/api"
 npm run start:dev

--- a/dev-app.sh
+++ b/dev-app.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/app"
-npm run dev -- --port 4284

--- a/dev-app.sh
+++ b/dev-app.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/278-cms-add-toggle-to-link-dates-on-content-documents-belonging-to-the-same-parent/app"
-npm run dev -- --port 4264
+cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/app"
+npm run dev -- --port 4284

--- a/dev-cms.sh
+++ b/dev-cms.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/cms"
-npm run dev -- --port 4285

--- a/dev-cms.sh
+++ b/dev-cms.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "/Users/dirk/orca/workspaces/luminary/278-cms-add-toggle-to-link-dates-on-content-documents-belonging-to-the-same-parent/cms"
-npm run dev -- --port 4265
+cd "/Users/dirk/orca/workspaces/luminary/1889-ssg-decouple-build-time-content-fetch-url-from-the-client-embedded-vite_api_url/cms"
+npm run dev -- --port 4285


### PR DESCRIPTION
Add an optional SSG_API_URL env var that vite.config.web.ts prefers for its Node-side build/SSR fetches (route/language/redirect/delete-cmd enumeration, the per-page queryTransport reads), falling back to VITE_API_URL when unset.

This decouples the build-time content-fetch origin from the URL compiled into the client bundle, so a deployer can point the initial full SSG build at a colocated internal API (as the ISR watcher already does) without affecting what real visitors' browsers call after hydration.

VITE_API_URL — and src/globalConfig.ts's embedded apiUrl — stay exactly as they are today. Unset SSG_API_URL and nothing changes.