### PR TITLE
fix(app): resolve reading time from the article's own language, not the translation dropdown list

### DIFF
--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -395,16 +395,23 @@ if (!isSSG) {
     );
 }
 
+// All known Language docs by id — `cmsLanguages` (global, prerender-seeded) plus
+// `localLanguages` (client supplement for a translation whose Language doc isn't in the
+// public set). Used both for the dropdown (below) and for looking up the current article's
+// own language doc directly, independent of which translations happen to be published.
+const languagesById = computed(
+    () => new Map([...cmsLanguages.value, ...localLanguages.value].map((l) => [l._id, l])),
+);
+
 // Only translations whose Language doc is actually loaded get a dropdown entry — never
 // fabricate a languageCode from the language id. `cmsLanguages` (prerender) and the
 // `localLanguages` fetch (client) cover every referenced language, so an unloaded one is a
 // brief pre-load gap, not a permanent drop.
-const languages = computed<LanguageDto[]>(() => {
-    const byId = new Map([...cmsLanguages.value, ...localLanguages.value].map((l) => [l._id, l]));
-    return availableTranslations.value
-        .map((t) => byId.get(t.language))
-        .filter((l): l is LanguageDto => !!l);
-});
+const languages = computed<LanguageDto[]>(() =>
+    availableTranslations.value
+        .map((t) => languagesById.value.get(t.language))
+        .filter((l): l is LanguageDto => !!l),
+);
 
 // Tags drive the category chips and RelatedContent. In the prerender the seam fetches them chained after `content` (via `ssrChain`, so the selector reads a resolved parent) and primes a per-slug cache for no-flash hydration.
 const tags = useContentQuery(
@@ -555,9 +562,14 @@ const readingTrackerEnabled = computed(() => !!content.value?._id && !!content.v
 
 const contentId = computed(() => content.value?._id);
 
-const contentLanguage = computed(() =>
-    languages.value.find((l) => l._id === content.value?.language),
-);
+// Looked up from the full language map, not the translation-dropdown-only `languages`
+// (which is empty unless 2+ translations are published) — otherwise a single-language
+// article would always miss its own Language doc and silently fall back to the default
+// reading speed instead of the one configured for it.
+const contentLanguage = computed(() => {
+    const languageId = content.value?.language;
+    return languageId ? languagesById.value.get(languageId) : undefined;
+});
 
 const averageReadingSpeed = computed(() =>
     resolveReadingSpeedWpm(contentLanguage.value?.averageReadingSpeed),

--- a/app/src/pages/SingleContent/SingleContent.vue
+++ b/app/src/pages/SingleContent/SingleContent.vue
@@ -495,7 +495,10 @@ const toggleBookmark = () => {
             (b) => b.id != content.value?.parentId,
         );
         if (content.value) {
-            recordAffinity(content.value.parentTags, affinityConfig.value.eventWeight.bookmarkRemoved);
+            recordAffinity(
+                content.value.parentTags,
+                affinityConfig.value.eventWeight.bookmarkRemoved,
+            );
         }
     } else {
         // Add to bookmarks
@@ -562,10 +565,7 @@ const readingTrackerEnabled = computed(() => !!content.value?._id && !!content.v
 
 const contentId = computed(() => content.value?._id);
 
-// Looked up from the full language map, not the translation-dropdown-only `languages`
-// (which is empty unless 2+ translations are published) — otherwise a single-language
-// article would always miss its own Language doc and silently fall back to the default
-// reading speed instead of the one configured for it.
+// Looked up from the full language map
 const contentLanguage = computed(() => {
     const languageId = content.value?.language;
     return languageId ? languagesById.value.get(languageId) : undefined;
@@ -945,7 +945,10 @@ watch([isLoading, content, is404], async () => {
                         v-if="content.text"
                         :content-id="content._id"
                         @highlighted="
-                            recordAffinity(content?.parentTags, affinityConfig.eventWeight.highlight)
+                            recordAffinity(
+                                content?.parentTags,
+                                affinityConfig.eventWeight.highlight,
+                            )
                         "
                         @highlight-removed="
                             recordAffinity(

--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -62,7 +62,7 @@ const affinityProfileMock = vi.hoisted(() => ({
     value: { affinity: {}, lastDecayUtc: undefined },
 }));
 type ReadingTrackerOptions = Parameters<
-    typeof import("@/composables/useReadingProgressTracker")["useReadingProgressTracker"]
+    (typeof import("@/composables/useReadingProgressTracker"))["useReadingProgressTracker"]
 >[0];
 const readingTrackerOptions = vi.hoisted(() => ({
     current: undefined as ReadingTrackerOptions | undefined,
@@ -924,7 +924,7 @@ describe("SingleContent", () => {
         });
     });
 
-    it("uses the article's own language reading speed even with no other published translation", async () => {
+    it("uses the article's own language reading speed", async () => {
         // Regression test: an article with only one published translation must still pick up
         // its language's configured averageReadingSpeed via the global cmsLanguages list —
         // not silently fall back to the default because the translation-dropdown-only

--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -924,6 +924,48 @@ describe("SingleContent", () => {
         });
     });
 
+    it("uses the article's own language reading speed even with no other published translation", async () => {
+        // Regression test: an article with only one published translation must still pick up
+        // its language's configured averageReadingSpeed via the global cmsLanguages list —
+        // not silently fall back to the default because the translation-dropdown-only
+        // `availableTranslations`/`languages` list is empty in this (most common) case.
+        const wordCount = 400;
+        const readingSpeed = 100;
+        const defaultSpeedReadingTime = computeEstimatedReadingMinutes(wordCount, 200);
+        const expectedReadingTime = computeEstimatedReadingMinutes(wordCount, readingSpeed);
+        expect(expectedReadingTime).not.toBe(defaultSpeedReadingTime);
+
+        isConnected.value = false;
+
+        // No sibling translation published for this content's parent.
+        await db.docs.delete(mockFrenchContentDto._id);
+        await db.docs.put({
+            ...mockEnglishContentDto,
+            wordCount,
+        } as ContentDto);
+
+        cmsLanguages.value = [{ ...mockLanguageDtoEng, averageReadingSpeed: readingSpeed }];
+
+        await flushPromises();
+
+        wrapper = mount(SingleContent, {
+            props: {
+                slug: mockEnglishContentDto.slug,
+            },
+        });
+
+        await flushPromises();
+
+        await waitForExpect(() => {
+            expect(wrapper!.text()).toContain(mockEnglishContentDto.title);
+        });
+
+        await waitForExpect(() => {
+            expect(wrapper!.text()).toContain(`${expectedReadingTime} min`);
+        });
+        expect(wrapper!.text()).not.toContain(`${defaultSpeedReadingTime} min`);
+    });
+
     it("preserves saved reading progress on mount", async () => {
         setReadingProgress(mockEnglishContentDto._id, 60);
 


### PR DESCRIPTION
Logic: the reading-time badge is Math.ceil(wordCount / averageReadingSpeed), where averageReadingSpeed should come from the article's own Language doc (per-language averageReadingSpeed, set in the CMS), falling back to a hardcoded 200 wpm only if that Language doc can't be resolved.

How the lookup worked before: contentLanguage was derived from languages, which is built from availableTranslations — a list that's only populated when an article has 2+ published translations (it exists to drive the translation-switcher dropdown). For any single-translation article, languages was empty, so contentLanguage was always undefined and the badge silently used the 200 wpm default instead of the language's actual configured speed.

Worth noting: English's configured averageReadingSpeed on dev is currently 90 wpm, well below that 200 default — that gap alone is likely a big part of why some content's reading time looks so large.

<img width="1236" height="495" alt="image" src="https://github.com/user-attachments/assets/3c61a5e1-e078-4567-9c01-e01b60283ab4" />
