### PR TITLE
Consume the encoder's player packages as a submodule

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# The build context is the repository root, and every Dockerfile here installs
+# its own dependencies. Shipping the working tree's node_modules would send
+# well over a gigabyte to the daemon and then be overwritten by `npm ci` anyway.
+**/node_modules
+**/dist
+**/.git
+
+# Test fixtures and desktop build output from the encoder submodule: large,
+# and nothing in an image needs them.
+media-convert/test-media
+media-convert/app-electron/bin
+media-convert/app-electron/release
+media-convert/api/work
+
+# NOT .env: the deploy workflow writes app/.env immediately before `docker build`,
+# and the PWA plugin reads its icon paths from it. Excluding it here would fail
+# the staging build with an undefined icon path.
+**/*.log

--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # The encoder's player packages are consumed from media-convert/,
+          # which is a submodule rather than a published package.
+          submodules: true
 
       - name: Create .env file
         run: |

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # The encoder's player packages are consumed from media-convert/,
+          # which is a submodule rather than a published package.
+          submodules: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "media-convert"]
+	path = media-convert
+	url = https://github.com/bccsa/luminary-media-convert.git
+	branch = 185-rename-hls-core

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "luminary-media-convert"]
 	path = media-convert
 	url = https://github.com/bccsa/luminary-media-convert.git
-	branch = 185-rename-hls-core
+	branch = luminary-1897-encrypted-hls

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "media-convert"]
+[submodule "luminary-media-convert"]
 	path = media-convert
 	url = https://github.com/bccsa/luminary-media-convert.git
 	branch = 185-rename-hls-core

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,9 +7,9 @@ RUN npm ci
 RUN npm run build
 
 # Build the encoder's player libraries. They ship only dist/, and app depends on
-# player-web by path (file:../media-convert/player-web), so this has to happen
-# before app installs. The submodule's own workspace links resolve player-core
-# and hls-core underneath it.
+# player-web-legacy by path (file:../media-convert/player-web-legacy), so this
+# has to happen before app installs. The submodule's own workspace links resolve
+# player-core and hls-core underneath it.
 WORKDIR /media-convert
 COPY ./media-convert ./
 RUN npm ci

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,6 +6,15 @@ COPY ./shared ./
 RUN npm ci
 RUN npm run build
 
+# Build the encoder's player libraries. They ship only dist/, and app depends on
+# player-web by path (file:../media-convert/player-web), so this has to happen
+# before app installs. The submodule's own workspace links resolve player-core
+# and hls-core underneath it.
+WORKDIR /media-convert
+COPY ./media-convert ./
+RUN npm ci
+RUN npm run build:libs
+
 # Build the app
 WORKDIR /app
 COPY ./app/package*.json ./

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,6 +7,7 @@
             "name": "luminary-app",
             "dependencies": {
                 "@headlessui/vue": "^1.7.19",
+                "@luminary-media-converter/player-web": "file:../media-convert/player-web",
                 "@sentry/vue": "^7.110.1",
                 "@vueuse/core": "^10.9.0",
                 "dexie": "^4.0.11",
@@ -68,6 +69,29 @@
                 "vue-matomo": "^4.2.0",
                 "vue-tsc": "^1.8.27",
                 "wait-for-expect": "^3.0.2"
+            }
+        },
+        "../media-convert/player-web": {
+            "name": "@luminary-media-converter/player-web",
+            "version": "0.0.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@luminary-media-converter/player-core": "file:../player-core",
+                "hls.js": "^1.6.0"
+            },
+            "devDependencies": {
+                "@vitejs/plugin-vue": "^5.2.0",
+                "@vue/test-utils": "^2.4.0",
+                "jsdom": "^26.0.0",
+                "typescript": "~5.7.0",
+                "vite": "^6.0.0",
+                "vite-plugin-css-injected-by-js": "^3.5.0",
+                "vitest": "^3.0.0",
+                "vue": "^3.5.0",
+                "vue-tsc": "^2.2.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
             }
         },
         "../shared": {
@@ -2613,6 +2637,10 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@luminary-media-converter/player-web": {
+            "resolved": "../media-convert/player-web",
+            "link": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,7 +7,7 @@
             "name": "luminary-app",
             "dependencies": {
                 "@headlessui/vue": "^1.7.19",
-                "@luminary-media-converter/player-web": "file:../media-convert/player-web",
+                "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
                 "@sentry/vue": "^7.110.1",
                 "@vueuse/core": "^10.9.0",
                 "dexie": "^4.0.11",
@@ -71,13 +71,16 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
-        "../media-convert/player-web": {
-            "name": "@luminary-media-converter/player-web",
+        "../media-convert/player-web-legacy": {
+            "name": "@luminary-media-converter/player-web-legacy",
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@luminary-media-converter/player-core": "file:../player-core",
-                "hls.js": "^1.6.0"
+                "iso-639-2": "^3.0.2",
+                "video.js": "8.23.4",
+                "videojs-mobile-ui": "1.1.1",
+                "videojs-youtube": "3.0.1"
             },
             "devDependencies": {
                 "@vitejs/plugin-vue": "^5.2.0",
@@ -2638,8 +2641,8 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@luminary-media-converter/player-web": {
-            "resolved": "../media-convert/player-web",
+        "node_modules/@luminary-media-converter/player-web-legacy": {
+            "resolved": "../media-convert/player-web-legacy",
             "link": true
         },
         "node_modules/@nodelib/fs.scandir": {

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.19",
-        "@luminary-media-converter/player-web": "file:../media-convert/player-web",
+        "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
         "@sentry/vue": "^7.110.1",
         "@vueuse/core": "^10.9.0",
         "dexie": "^4.0.11",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.19",
+        "@luminary-media-converter/player-web": "file:../media-convert/player-web",
         "@sentry/vue": "^7.110.1",
         "@vueuse/core": "^10.9.0",
         "dexie": "^4.0.11",


### PR DESCRIPTION
Wires `bccsa/luminary-media-convert` into this repository as a submodule, so the player packages can be consumed without publishing them. Nothing imports the player yet — this is the build plumbing, so that swapping the player (#1903) is a code change rather than a build problem.

## Why a submodule

npm cannot install a *subdirectory* of a git repository, so a plain git dependency was never an option. A submodule plus a path dependency is the same shape this repo already uses for `luminary-shared`, which is `file:../shared`.

## What it does

- `media-convert/` submodule, and `app` depends on `@luminary-media-converter/player-web` by path.
- CI checks out with `submodules: true` and builds the libraries before `app` installs — beside the step that already does this for `shared`.
- `app/Dockerfile` gained the matching stage.

**Only `player-web` is needed.** It re-exports the whole stack: `LuminaryPlayer`, `PlayerController`, `HlsJsAdapter`, the LMCENC helpers (`decryptLmcenc`, `fetchMaybeEncrypted`, `createMemoryKeyLoader`), playlist handling (`parseMasterText`, `applyQualityCap`, `buildAudioOnlyMaster`), VTT parsing and the angle constants — 71 exports in total. A second dependency is only needed if something here parses or builds playlists server-side, which nothing does today.

## Verified rather than assumed

Importing `player-web` from `app` resolves 71 exports including `LuminaryPlayer`, with `player-core` and `hls-core` resolving through the submodule's own workspace links. The Docker image builds: submodule copied, libraries built, `app` compiled against them. 923 app tests pass, type-check clean.

Worth knowing about the arrangement: `player-core` and `hls-core` are **not** in `app/node_modules`. They resolve through the submodule, which is why the step that runs `npm ci` *inside* `media-convert` is load-bearing — a checkout alone leaves them unresolvable.

## Two things found by running the real build

There was **no `.dockerignore` at all**, so the build context carried the working tree's `node_modules` — over a gigabyte before this change, 632 MB more after. Added one.

The first version of that file excluded `**/.env`, **which would have broken staging**: the deploy workflow writes `app/.env` immediately before `docker build`, and the PWA plugin reads its icon paths from it. The build failed in front of me, which is the only reason it was caught.

## Before merging

The submodule is pinned to the head of bccsa/luminary-media-convert#187, which carries the renames (`hls` → `hls-core`) and the fixes that make these packages installable from outside that repository. **It needs re-pinning to the epic branch once #187 merges** — a one-line submodule update.
