### PR TITLE
Store media URLs relative to their bucket; warn before replacing a key

### DIFF
--- a/api/src/changeRequests/documentProcessing/deleteMediaCollection.spec.ts
+++ b/api/src/changeRequests/documentProcessing/deleteMediaCollection.spec.ts
@@ -11,6 +11,28 @@ const refusalOf = (r: ReturnType<typeof resolveCollectionPrefix>) =>
     "refusal" in r ? r.refusal : undefined;
 
 describe("resolveCollectionPrefix", () => {
+    describe("a URL stored relative to the bucket", () => {
+        it("needs no public URL at all — the path is already the key", () => {
+            const r = resolveCollectionPrefix(
+                "/c5829f07-4ba8-42ed-a449-80d83e6c0b53/master.m3u8",
+                undefined,
+            );
+            expect("prefix" in r && r.prefix).toBe(
+                "c5829f07-4ba8-42ed-a449-80d83e6c0b53",
+            );
+        });
+
+        it("still refuses a folder the encoder did not write", () => {
+            const r = resolveCollectionPrefix("/shared-folder/master.m3u8", undefined);
+            expect("refusal" in r && r.refusal).toContain("not a session id");
+        });
+
+        it("still refuses the bucket root", () => {
+            const r = resolveCollectionPrefix("/master.m3u8", undefined);
+            expect("refusal" in r && r.refusal).toContain("bucket root");
+        });
+    });
+
     describe("resolves a collection this API wrote", () => {
         it("strips the bucket's public base and the master filename", () => {
             expect(prefixOf(resolveCollectionPrefix(HLS, PUBLIC))).toBe(SESSION);

--- a/api/src/changeRequests/documentProcessing/deleteMediaCollection.ts
+++ b/api/src/changeRequests/documentProcessing/deleteMediaCollection.ts
@@ -1,7 +1,7 @@
 import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
 import { S3Service } from "../../s3/s3.service";
-import { isBucketRelative } from "./mediaUrl";
+import { isBucketRelative, toStoredMediaUrl } from "./mediaUrl";
 
 /**
  * Where a collection lives in its bucket, or why we will not touch it.
@@ -134,6 +134,17 @@ export async function deleteMediaCollection(
         bucket = result.docs[0];
     } catch (error) {
         warnings.push(`Media files were not deleted: ${error.message}`);
+        return warnings;
+    }
+
+    // Media hosted elsewhere — a YouTube link, a master on someone else's CDN —
+    // has nothing here to delete, and telling the operator to go and remove it
+    // "on the storage provider" would send them looking for files their bucket
+    // never held.
+    if (
+        !isBucketRelative(media.hlsUrl) &&
+        toStoredMediaUrl(media.hlsUrl, bucket.publicUrl) === media.hlsUrl
+    ) {
         return warnings;
     }
 

--- a/api/src/changeRequests/documentProcessing/deleteMediaCollection.ts
+++ b/api/src/changeRequests/documentProcessing/deleteMediaCollection.ts
@@ -1,6 +1,7 @@
 import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
 import { S3Service } from "../../s3/s3.service";
+import { isBucketRelative } from "./mediaUrl";
 
 /**
  * Where a collection lives in its bucket, or why we will not touch it.
@@ -37,21 +38,30 @@ export function resolveCollectionPrefix(
     publicUrl: string | undefined,
 ): PrefixResolution {
     if (!hlsUrl) return { refusal: "the document has no media URL" };
-    if (!publicUrl) return { refusal: "the bucket has no public URL configured" };
 
     // Query strings and fragments are addressing, not location.
     const url = hlsUrl.split(/[?#]/)[0];
-    const base = publicUrl.replace(/\/+$/, "");
 
-    // The separator has to be part of the match, or a bucket published at
-    // `https://cdn/media` would claim URLs belonging to `https://cdn/media-archive`.
-    if (!url.startsWith(`${base}/`)) {
-        return {
-            refusal: `the media URL is not in this bucket (expected it to start with ${base}/)`,
-        };
+    // A relative URL is already a key: it says where in this document's bucket
+    // the collection is and nothing else, so there is no public base to strip
+    // and no way for the two to disagree.
+    let key: string;
+    if (isBucketRelative(url)) {
+        key = url.slice(1);
+    } else {
+        if (!publicUrl) {
+            return { refusal: "the bucket has no public URL configured" };
+        }
+        const base = publicUrl.replace(/\/+$/, "");
+        // The separator has to be part of the match, or a bucket published at
+        // `https://cdn/media` would claim URLs belonging to `https://cdn/media-archive`.
+        if (!url.startsWith(`${base}/`)) {
+            return {
+                refusal: `the media URL is not in this bucket (expected it to start with ${base}/)`,
+            };
+        }
+        key = url.slice(base.length + 1);
     }
-
-    const key = url.slice(base.length + 1);
 
     // Named before the suffix check below, which would otherwise report a master
     // at the bucket root as "not a master playlist" — true but unhelpful for the

--- a/api/src/changeRequests/documentProcessing/mediaUrl.spec.ts
+++ b/api/src/changeRequests/documentProcessing/mediaUrl.spec.ts
@@ -1,0 +1,67 @@
+import { isBucketRelative, toAbsoluteMediaUrl, toStoredMediaUrl } from "./mediaUrl";
+
+const BASE = "https://cdn.example.com/media";
+const REL = "/c5829f07-4ba8-42ed-a449-80d83e6c0b53/master.m3u8";
+
+describe("media URL storage form", () => {
+    describe("toStoredMediaUrl", () => {
+        it("strips the bucket's public URL", () => {
+            expect(toStoredMediaUrl(`${BASE}${REL}`, BASE)).toBe(REL);
+        });
+
+        it("tolerates a trailing slash on the bucket", () => {
+            expect(toStoredMediaUrl(`${BASE}${REL}`, `${BASE}/`)).toBe(REL);
+        });
+
+        it("leaves a YouTube URL alone", () => {
+            const yt = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+            expect(toStoredMediaUrl(yt, BASE)).toBe(yt);
+        });
+
+        it("leaves an HLS master on someone else's CDN alone", () => {
+            const other = "https://other.example.com/stream/master.m3u8";
+            expect(toStoredMediaUrl(other, BASE)).toBe(other);
+        });
+
+        it("does not claim a bucket that merely shares a prefix", () => {
+            // `…/media` must not swallow `…/media-archive`.
+            const neighbour = "https://cdn.example.com/media-archive/x/master.m3u8";
+            expect(toStoredMediaUrl(neighbour, BASE)).toBe(neighbour);
+        });
+
+        it("is idempotent — storing an already-relative URL changes nothing", () => {
+            expect(toStoredMediaUrl(REL, BASE)).toBe(REL);
+        });
+
+        it("returns the input when the bucket has no public URL", () => {
+            const abs = `${BASE}${REL}`;
+            expect(toStoredMediaUrl(abs, undefined)).toBe(abs);
+        });
+    });
+
+    describe("toAbsoluteMediaUrl", () => {
+        it("joins a relative URL onto the bucket", () => {
+            expect(toAbsoluteMediaUrl(REL, BASE)).toBe(`${BASE}${REL}`);
+        });
+
+        it("leaves an external URL untouched", () => {
+            const yt = "https://youtu.be/dQw4w9WgXcQ";
+            expect(toAbsoluteMediaUrl(yt, BASE)).toBe(yt);
+        });
+
+        it("cannot resolve a relative URL without a bucket", () => {
+            expect(toAbsoluteMediaUrl(REL, undefined)).toBeUndefined();
+        });
+
+        it("round-trips", () => {
+            const abs = `${BASE}${REL}`;
+            expect(toAbsoluteMediaUrl(toStoredMediaUrl(abs, BASE), BASE)).toBe(abs);
+        });
+    });
+
+    it("recognises the stored form", () => {
+        expect(isBucketRelative(REL)).toBe(true);
+        expect(isBucketRelative(`${BASE}${REL}`)).toBe(false);
+        expect(isBucketRelative(undefined)).toBe(false);
+    });
+});

--- a/api/src/changeRequests/documentProcessing/mediaUrl.ts
+++ b/api/src/changeRequests/documentProcessing/mediaUrl.ts
@@ -1,0 +1,55 @@
+/**
+ * The shape a media URL is stored in.
+ *
+ * A collection this API can reach lives in a bucket the document already names
+ * through `mediaBucketId`, so repeating the bucket's public URL in `hlsUrl`
+ * stores the same fact twice — and the two then drift the moment a bucket is
+ * renamed, re-pointed at a new CDN, or the collection is moved. Stored relative,
+ * the URL says where inside the bucket the collection is and nothing more, and
+ * the bucket says where that is on the internet.
+ *
+ * Anything not under the bucket is left exactly as given: a YouTube link or an
+ * HLS master on someone else's CDN has no bucket to be relative to.
+ */
+
+/** Whether a stored URL is a path inside the document's own bucket. */
+export function isBucketRelative(url: string | undefined): boolean {
+    return typeof url === "string" && url.startsWith("/");
+}
+
+/**
+ * The form to store, given what the user or the encoder supplied.
+ *
+ * Returns the input unchanged when there is no bucket to measure against or the
+ * URL is not inside it, so calling this on an external URL is safe and calling
+ * it twice does nothing the second time.
+ */
+export function toStoredMediaUrl(
+    hlsUrl: string | undefined,
+    publicUrl: string | undefined,
+): string | undefined {
+    if (!hlsUrl || isBucketRelative(hlsUrl) || !publicUrl) return hlsUrl;
+
+    const base = publicUrl.replace(/\/+$/, "");
+    // The separator is part of the match, or a bucket published at
+    // `https://cdn/media` would claim `https://cdn/media-archive/...`.
+    if (!hlsUrl.startsWith(`${base}/`)) return hlsUrl;
+
+    return hlsUrl.slice(base.length);
+}
+
+/**
+ * The absolute URL a player should fetch, given what is stored.
+ *
+ * The inverse of {@link toStoredMediaUrl}, and the same courtesy in reverse: an
+ * already-absolute URL is returned untouched, so a consumer can call this on
+ * every media URL without asking which kind it holds.
+ */
+export function toAbsoluteMediaUrl(
+    stored: string | undefined,
+    publicUrl: string | undefined,
+): string | undefined {
+    if (!stored || !isBucketRelative(stored)) return stored;
+    if (!publicUrl) return undefined;
+    return `${publicUrl.replace(/\/+$/, "")}${stored}`;
+}

--- a/api/src/changeRequests/documentProcessing/migrateMediaCollection.spec.ts
+++ b/api/src/changeRequests/documentProcessing/migrateMediaCollection.spec.ts
@@ -227,6 +227,40 @@ describe("migrateMediaCollection", () => {
         expect(S3Service.create).not.toHaveBeenCalled();
     });
 
+    it("leaves external media alone and lets the bucket change stand", async () => {
+        // A YouTube link or a master on someone else's CDN is not ours to move,
+        // and the bucket change is about where future output goes. Failing here
+        // would revert a deliberate change and warn about files that were never
+        // going anywhere.
+        stubS3();
+        const yt = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+        const m = { hlsUrl: yt } as MediaDto;
+
+        const result = await migrateMediaCollection(
+            m,
+            yt,
+            "bucket-old",
+            "bucket-new",
+            defaultDb(),
+        );
+
+        expect(result.failed).toBe(false);
+        expect(result.warnings).toEqual([]);
+        expect(m.hlsUrl).toBe(yt);
+        expect(S3Service.create).not.toHaveBeenCalled();
+    });
+
+    it("still moves media that is in the old bucket", async () => {
+        // The guard above must not swallow the case it sits in front of.
+        const { source } = stubS3();
+        const m = media();
+
+        const result = await migrate(m, defaultDb());
+
+        expect(result.failed).toBe(false);
+        expect(source.removeObjects).toHaveBeenCalled();
+    });
+
     it("does nothing for a document that never had media", async () => {
         stubS3();
 

--- a/api/src/changeRequests/documentProcessing/migrateMediaCollection.ts
+++ b/api/src/changeRequests/documentProcessing/migrateMediaCollection.ts
@@ -2,7 +2,7 @@ import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
 import { S3Service } from "../../s3/s3.service";
 import { resolveCollectionPrefix } from "./deleteMediaCollection";
-import { isBucketRelative } from "./mediaUrl";
+import { isBucketRelative, toStoredMediaUrl } from "./mediaUrl";
 
 /** What the encoder publishes at the root of a collection. */
 const MASTER = "master.m3u8";
@@ -90,6 +90,16 @@ export async function migrateMediaCollection(
 
     // The same proof used before deleting: a prefix we cannot derive from the
     // bucket's own public base is a collection we did not write.
+    // Media that is not in the old bucket is not ours to move: a YouTube link
+    // or a master on someone else's CDN belongs to whoever serves it, and the
+    // bucket change is about where *future* output goes. Treating that as a
+    // failed migration would revert a change the user made deliberately and
+    // warn about files that were never going anywhere.
+    const external =
+        !isBucketRelative(previousHlsUrl) &&
+        toStoredMediaUrl(previousHlsUrl, oldBucket.publicUrl) === previousHlsUrl;
+    if (external) return { failed: false, warnings };
+
     const resolved = resolveCollectionPrefix(previousHlsUrl, oldBucket.publicUrl);
     if ("refusal" in resolved) {
         warnings.push(`Media files were not moved because ${resolved.refusal}.`);

--- a/api/src/changeRequests/documentProcessing/migrateMediaCollection.ts
+++ b/api/src/changeRequests/documentProcessing/migrateMediaCollection.ts
@@ -2,6 +2,7 @@ import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
 import { S3Service } from "../../s3/s3.service";
 import { resolveCollectionPrefix } from "./deleteMediaCollection";
+import { isBucketRelative } from "./mediaUrl";
 
 /** What the encoder publishes at the root of a collection. */
 const MASTER = "master.m3u8";
@@ -77,7 +78,9 @@ export async function migrateMediaCollection(
     const oldBucket = oldResult.bucket;
     const newBucket = newResult.bucket;
 
-    if (!newBucket.publicUrl) {
+    // Only an absolute URL has to be rebuilt, and only that needs the
+    // destination's public URL.
+    if (!newBucket.publicUrl && !isBucketRelative(previousHlsUrl)) {
         warnings.push(
             "Media files were not moved: the destination bucket has no public URL configured, " +
                 "so the new media URL cannot be built.",
@@ -129,7 +132,14 @@ export async function migrateMediaCollection(
         }
 
         // Only now is the new location real, so only now may the document name it.
-        media.hlsUrl = `${newBucket.publicUrl.replace(/\/+$/, "")}/${prefix}/${MASTER}`;
+        //
+        // A relative URL already names a path inside whichever bucket the
+        // document points at, so moving buckets does not change it — which is
+        // the point of storing it that way. Only the legacy absolute form has
+        // to be rewritten.
+        if (!isBucketRelative(media.hlsUrl)) {
+            media.hlsUrl = `${newBucket.publicUrl.replace(/\/+$/, "")}/${prefix}/${MASTER}`;
+        }
 
         // Last, and its failure is not the migration's failure: the files are in
         // the new bucket and the document points at them. Leftovers in the old

--- a/api/src/changeRequests/documentProcessing/processMediaDto.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processMediaDto.spec.ts
@@ -45,6 +45,37 @@ describe("processMediaDto", () => {
         expect(first.hlsKey_id).not.toBe(second.hlsKey_id);
     });
 
+    it("re-submitting the same key changes nothing", async () => {
+        // The CMS cannot tell whether a typed key matches the stored one — a
+        // saved key is only an id there — so it asks the user to confirm a
+        // replacement. Here the two can be compared, and an identical key must
+        // not mint a second crypto object and orphan the first.
+        const media: MediaDto = { hlsUrl: HLS_URL, hlsKey: HLS_KEY };
+        await processMedia(media, db);
+        const firstId = media.hlsKey_id;
+
+        media.hlsKey = HLS_KEY;
+        await processMedia(media, db);
+
+        expect(media.hlsKey_id).toBe(firstId);
+        expect(media.hlsKey).toBeUndefined();
+        await expect(retrieveCryptoData<string>(db, media.hlsKey_id!)).resolves.toBe(HLS_KEY);
+    });
+
+    it("a genuinely different key does replace the reference", async () => {
+        const media: MediaDto = { hlsUrl: HLS_URL, hlsKey: HLS_KEY };
+        await processMedia(media, db);
+        const firstId = media.hlsKey_id;
+
+        media.hlsKey = "fedcba9876543210fedcba9876543210";
+        await processMedia(media, db);
+
+        expect(media.hlsKey_id).not.toBe(firstId);
+        await expect(retrieveCryptoData<string>(db, media.hlsKey_id!)).resolves.toBe(
+            "fedcba9876543210fedcba9876543210",
+        );
+    });
+
     it("leaves an unencrypted collection alone", async () => {
         const media: MediaDto = { hlsUrl: HLS_URL };
 

--- a/api/src/changeRequests/documentProcessing/processMediaDto.ts
+++ b/api/src/changeRequests/documentProcessing/processMediaDto.ts
@@ -1,6 +1,6 @@
 import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
-import { storeCryptoData } from "../../util/encryption";
+import { retrieveCryptoData, storeCryptoData } from "../../util/encryption";
 import { toStoredMediaUrl } from "./mediaUrl";
 
 /**
@@ -41,6 +41,26 @@ export async function processMedia(
     }
 
     if (!media.hlsKey) return warnings;
+
+    // Re-submitting the key that is already stored is not a change. The CMS
+    // cannot tell — a saved key is only ever an id there, and the plaintext is
+    // never readable again — so it asks the user to confirm a replacement it
+    // cannot rule out. Here the two can actually be compared, and an identical
+    // key keeps its existing crypto object rather than minting a second one and
+    // orphaning the first.
+    if (media.hlsKey_id) {
+        try {
+            const stored = await retrieveCryptoData<string>(db, media.hlsKey_id);
+            if (stored === media.hlsKey) {
+                delete media.hlsKey;
+                return warnings;
+            }
+        } catch {
+            // Unreadable — a rotated ENCRYPTION_KEY, a missing crypto doc — so
+            // there is nothing to compare against and the submitted key is
+            // stored as a replacement, which is the safe direction.
+        }
+    }
 
     try {
         media.hlsKey_id = await storeCryptoData<string>(db, media.hlsKey);

--- a/api/src/changeRequests/documentProcessing/processMediaDto.ts
+++ b/api/src/changeRequests/documentProcessing/processMediaDto.ts
@@ -1,6 +1,7 @@
 import { MediaDto } from "../../dto/MediaDto";
 import { DbService } from "../../db/db.service";
 import { storeCryptoData } from "../../util/encryption";
+import { toStoredMediaUrl } from "./mediaUrl";
 
 /**
  * Processes the media object on a content parent document.
@@ -18,8 +19,26 @@ import { storeCryptoData } from "../../util/encryption";
  * `migrateMediaCollection` on a bucket change and `deleteMediaCollection` when the
  * document is deleted and the user asked for the files to go with it.
  */
-export async function processMedia(media: MediaDto, db: DbService): Promise<string[]> {
+export async function processMedia(
+    media: MediaDto,
+    db: DbService,
+    bucketId?: string,
+): Promise<string[]> {
     const warnings: string[] = [];
+
+    // Stored relative to the bucket the document already names, so the two
+    // cannot disagree later. External URLs are left alone — see mediaUrl.ts.
+    if (media.hlsUrl && bucketId) {
+        try {
+            const result = await db.getDoc(bucketId);
+            const publicUrl = result.docs?.[0]?.publicUrl;
+            media.hlsUrl = toStoredMediaUrl(media.hlsUrl, publicUrl) as string;
+        } catch (error) {
+            // Not fatal: an absolute URL still plays, and the next save
+            // normalises it once the bucket is readable again.
+            warnings.push(`Could not normalise the media URL: ${error.message}`);
+        }
+    }
 
     if (!media.hlsKey) return warnings;
 

--- a/api/src/changeRequests/documentProcessing/processPostTagDto.deleteMedia.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processPostTagDto.deleteMedia.spec.ts
@@ -115,6 +115,19 @@ describe("processPostTagDto — deleting media files from storage", () => {
         expect(warnings.some((w) => w.includes("unreachable"))).toBe(true);
     });
 
+    it("says nothing when the media is hosted elsewhere", async () => {
+        // Nothing in this bucket to delete, and no instruction to go looking.
+        (deleteMediaCollection as jest.Mock).mockResolvedValueOnce([]);
+        const incoming = deleteRequest(true);
+        incoming.media!.hlsUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+        const saved_ = saved();
+        saved_.media!.hlsUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+        const warnings = await processPostTagDto(incoming, saved_, stubDb());
+
+        expect(warnings).toEqual([]);
+    });
+
     it("still cascades the delete to the child content documents", async () => {
         // The media work must not displace what the delete path is actually for.
         const db = stubDb();

--- a/api/src/changeRequests/documentProcessing/processPostTagDto.migrateMedia.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processPostTagDto.migrateMedia.spec.ts
@@ -99,7 +99,12 @@ describe("processPostTagDto — migrating media between buckets", () => {
 
         await processPostTagDto(incoming, post("bucket-old"), stubDb());
 
-        expect(processMedia).toHaveBeenCalledWith(incoming.media, expect.anything());
+        expect(processMedia).toHaveBeenCalledWith(
+            incoming.media,
+            expect.anything(),
+            // the bucket, so the stored URL can be made relative to it
+            "bucket-new",
+        );
     });
 
     it("does not migrate on a delete request", async () => {

--- a/api/src/changeRequests/documentProcessing/processPostTagDto.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processPostTagDto.spec.ts
@@ -571,6 +571,11 @@ describe("processPostTagDto", () => {
 
         await processChangeRequest("test-user", changeRequest, ["group-super-admins"], db);
 
-        expect(processMedia).toHaveBeenCalledWith((changeRequest.doc as PostDto).media, db);
+        // The bucket goes with it: the stored URL is made relative to it.
+        expect(processMedia).toHaveBeenCalledWith(
+            (changeRequest.doc as PostDto).media,
+            db,
+            "test-bucket-id",
+        );
     });
 });

--- a/api/src/changeRequests/documentProcessing/processPostTagDto.ts
+++ b/api/src/changeRequests/documentProcessing/processPostTagDto.ts
@@ -139,7 +139,7 @@ export default async function processPostTagDto(
         }
 
         try {
-            warnings.push(...(await processMedia(doc.media, db)));
+            warnings.push(...(await processMedia(doc.media, db, doc.mediaBucketId)));
         } catch (error) {
             warnings.push(`Media processing failed: ${error.message}`);
         }

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import AudioVideoToggle from "../form/AudioVideoToggle.vue";
 import "videojs-mobile-ui";
 import type Player from "video.js/dist/types/player";
@@ -14,7 +14,8 @@ import { affinityConfig } from "@/recommendation/defaultAffinityStore";
 import { markSeen } from "@/recommendation/seenStore";
 import { extractAndBuildAudioMaster } from "./extractAndBuildAudioMaster";
 import { isYouTubeUrl, convertToVideoJSYouTubeUrl } from "@/util/youtube";
-import { videoSourceFor } from "@/util/videoSource";
+import { resolveVideoSource, videoSourceFor } from "@/util/videoSource";
+import { useBucketInfo } from "@/composables/useBucketInfo";
 
 type Props = {
     content: ContentDto;
@@ -22,6 +23,11 @@ type Props = {
 };
 
 const props = defineProps<Props>();
+
+// The media bucket, so a stored relative URL can be resolved to a fetchable
+// one — see resolveVideoSource.
+const mediaBucketIdRef = computed(() => props.content?.parentMediaBucketId);
+const { bucketBaseUrl: mediaBucketBaseUrl } = useBucketInfo(mediaBucketIdRef);
 
 const playerElement = ref<HTMLVideoElement>();
 const audioModeToggle = ref<typeof AudioVideoToggle>();
@@ -39,8 +45,8 @@ const isRestoringTrack = ref<boolean>(false);
 const isYouTube = ref<boolean>(false);
 
 // Check if the current video is a YouTube video
-if (videoSourceFor(props.content)) {
-    isYouTube.value = isYouTubeUrl(videoSourceFor(props.content)!);
+if (resolveVideoSource(props.content, mediaBucketBaseUrl.value)) {
+    isYouTube.value = isYouTubeUrl(resolveVideoSource(props.content, mediaBucketBaseUrl.value)!);
     if (isYouTube.value) {
         // hides audio mode toggle for YouTube videos as it's not supported
         showAudioModeToggle.value = false;
@@ -237,7 +243,7 @@ onMounted(async () => {
         player.poster(px); // Set the player poster to a 1px transparent image to prevent the default poster from showing
 
         // Set player source based on video type (YouTube vs regular)
-        const videoSource = videoSourceFor(props.content);
+        const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
         if (isYouTube.value && props.content.video) {
             // For YouTube videos, disable audio-only mode toggle since it's not supported for YouTube videos
             showAudioModeToggle.value = false;
@@ -371,7 +377,7 @@ onMounted(async () => {
             const currentTime = player?.currentTime() || 0;
             const durationTime = player?.duration() || 0;
 
-            const videoSource = videoSourceFor(props.content);
+            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
             if (durationTime == Infinity || !videoSource || currentTime < 60) return;
 
             // For YouTube videos, aggressively check if we're at the end and remove progress
@@ -395,7 +401,7 @@ onMounted(async () => {
 
         // Get and apply the player saved progress (rewind 30 seconds)
         player.on("ready", () => {
-            const videoSource = videoSourceFor(props.content);
+            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
             if (!videoSource) return;
 
             // For YouTube videos, wait for loadedmetadata to restore progress (iframe needs to be ready)
@@ -406,7 +412,7 @@ onMounted(async () => {
         });
 
         player.on("ended", () => {
-            const videoSource = videoSourceFor(props.content);
+            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
             if (!videoSource) return;
             stopKeepAudioAlive();
 
@@ -431,7 +437,7 @@ onMounted(async () => {
         });
 
         player.on("pause", () => {
-            const videoSource = videoSourceFor(props.content);
+            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
             if (!videoSource) return;
 
             if (audioMode.value) syncKeepAudioStateAlive();
@@ -506,7 +512,7 @@ watch(audioMode, async (mode) => {
 
     // Generate the audio playlist with the currently selected track as default
     // This ensures the player loads the correct track immediately without needing to switch
-    const videoSource = videoSourceFor(props.content);
+    const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
     let audioPlaylistUrl: string | null = null;
     if (mode && videoSource) {
         const audioMaster = await extractAndBuildAudioMaster(videoSource, selectedTrackInfo);

--- a/app/src/util/videoSource.spec.ts
+++ b/app/src/util/videoSource.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { videoSourceFor, hasVideoSource } from "./videoSource";
+import { videoSourceFor, hasVideoSource, resolveVideoSource } from "./videoSource";
 import type { ContentDto } from "luminary-shared";
 
 const content = (video?: string, hlsUrl?: string) =>
@@ -55,5 +55,41 @@ describe("hasVideoSource", () => {
 
     it("is false when neither is set", () => {
         expect(hasVideoSource(content())).toBe(false);
+    });
+});
+
+describe("resolveVideoSource", () => {
+    const BASE = "https://cdn.example.com/media";
+    const REL = "/c5829f07-4ba8-42ed-a449-80d83e6c0b53/master.m3u8";
+
+    it("joins a stored relative URL onto the bucket", () => {
+        const content = { parentMedia: { hlsUrl: REL } } as any;
+        expect(resolveVideoSource(content, BASE)).toBe(`${BASE}${REL}`);
+    });
+
+    it("tolerates a trailing slash on the bucket", () => {
+        const content = { parentMedia: { hlsUrl: REL } } as any;
+        expect(resolveVideoSource(content, `${BASE}/`)).toBe(`${BASE}${REL}`);
+    });
+
+    it("leaves an external URL alone — YouTube has no bucket", () => {
+        const yt = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+        const content = { video: yt } as any;
+        expect(resolveVideoSource(content, BASE)).toBe(yt);
+    });
+
+    it("returns undefined while the bucket is still loading", () => {
+        // The honest answer: the URL is not knowable yet, and returning the
+        // bare path would have the browser fetch it from the app's own origin.
+        const content = { parentMedia: { hlsUrl: REL } } as any;
+        expect(resolveVideoSource(content, undefined)).toBeUndefined();
+    });
+
+    it("still prefers the encoded collection over a typed-in URL", () => {
+        const content = {
+            video: "https://example.com/old.m3u8",
+            parentMedia: { hlsUrl: REL },
+        } as any;
+        expect(resolveVideoSource(content, BASE)).toBe(`${BASE}${REL}`);
     });
 });

--- a/app/src/util/videoSource.ts
+++ b/app/src/util/videoSource.ts
@@ -24,3 +24,26 @@ export function hasVideoSource(
 ): boolean {
     return Boolean(videoSourceFor(content));
 }
+
+/**
+ * The URL a player should actually fetch.
+ *
+ * `parentMedia.hlsUrl` is stored relative to the document's own media bucket —
+ * `/prefix/master.m3u8` — so that the bucket's address lives in one place and
+ * cannot drift from the collection's path. Joining the two is the same thing
+ * `LImage` does for images, and for the same reason.
+ *
+ * External sources — a YouTube link, an HLS master on someone else's CDN — are
+ * stored absolute and come back untouched, so a caller never has to ask which
+ * kind it is holding. Returns undefined while the bucket is still loading, which
+ * is the honest answer: the URL is not knowable yet.
+ */
+export function resolveVideoSource(
+    content: Pick<ContentDto, "video" | "parentMedia"> | undefined | null,
+    bucketBaseUrl: string | undefined,
+): string | undefined {
+    const source = videoSourceFor(content);
+    if (!source || !source.startsWith("/")) return source;
+    if (!bucketBaseUrl) return undefined;
+    return `${bucketBaseUrl.replace(/\/+$/, "")}${source}`;
+}

--- a/cms/src/components/content/EditContentVideo.spec.ts
+++ b/cms/src/components/content/EditContentVideo.spec.ts
@@ -90,6 +90,27 @@ describe("EditContentVideo.vue", () => {
         );
     });
 
+    it("warns before a saved key is replaced", async () => {
+        // The one edit on this form that cannot be undone: the media was
+        // encrypted with the old key and nothing keeps a copy of it.
+        const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL, hlsKey_id: "crypto-1" }));
+        expect(wrapper.find('[data-test="video-key-warning"]').exists()).toBe(false);
+
+        await wrapper.find("input[name='hlsKey']").setValue("beefbeefbeefbeef");
+
+        expect(wrapper.find('[data-test="video-key-warning"]').text()).toContain(
+            "unplayable",
+        );
+    });
+
+    it("does not warn when there is no saved key to replace", async () => {
+        const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL }));
+
+        await wrapper.find("input[name='hlsKey']").setValue("beefbeefbeefbeef");
+
+        expect(wrapper.find('[data-test="video-key-warning"]').exists()).toBe(false);
+    });
+
     it("explains when no key is needed", async () => {
         const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL }));
 

--- a/cms/src/components/content/EditContentVideo.spec.ts
+++ b/cms/src/components/content/EditContentVideo.spec.ts
@@ -90,6 +90,48 @@ describe("EditContentVideo.vue", () => {
         );
     });
 
+    it("asks the exact question before replacing a saved key", async () => {
+        const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL, hlsKey_id: "crypto-1" }));
+
+        await wrapper.find("input[name='hlsKey']").setValue("beefbeefbeefbeef");
+
+        expect(wrapper.text()).toContain("Replace the encryption key?");
+        expect(wrapper.text()).toContain("unplayable");
+    });
+
+    it("does not ask when there is no saved key", async () => {
+        const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL }));
+
+        await wrapper.find("input[name='hlsKey']").setValue("beefbeefbeefbeef");
+
+        expect(wrapper.text()).not.toContain("Replace the encryption key?");
+    });
+
+    it("offers to enter a new key once one is saved", async () => {
+        const wrapper = mountVideo(parentWith({ hlsUrl: HLS_URL, hlsKey_id: "crypto-1" }));
+
+        expect(
+            wrapper.find("input[name='hlsKey']").attributes("placeholder"),
+        ).toBe("Enter new encryption key");
+    });
+
+    it("clears the field when the replacement is declined", async () => {
+        // Declining has to leave nothing behind: a half-typed key that reached
+        // the document would replace the saved one at the next save.
+        const parent = parentWith({ hlsUrl: HLS_URL, hlsKey_id: "crypto-1" });
+        const wrapper = mountVideo(parent);
+
+        await wrapper.find("input[name='hlsKey']").setValue("beefbeefbeefbeef");
+        expect(parent.value.media?.hlsKey).toBe("beefbeefbeefbeef");
+
+        const cancel = wrapper
+            .findAll("button")
+            .find((b) => b.text().includes("Cancel"));
+        await cancel!.trigger("click");
+
+        expect(parent.value.media?.hlsKey).toBeUndefined();
+    });
+
     it("warns before a saved key is replaced", async () => {
         // The one edit on this form that cannot be undone: the media was
         // encrypted with the old key and nothing keeps a copy of it.

--- a/cms/src/components/content/EditContentVideo.vue
+++ b/cms/src/components/content/EditContentVideo.vue
@@ -56,6 +56,9 @@ const hlsKey = computed({
  */
 const hasStoredKey = computed(() => Boolean(parent.value?.media?.hlsKey_id));
 
+/** The user has typed a replacement over a key that is already saved. */
+const replacingKey = computed(() => Boolean(hlsKey.value));
+
 // Collapse the card only initially if there's no video
 watch(
     () => parent.value?.media?.hlsUrl,
@@ -111,6 +114,20 @@ watch(
             <template v-else>
                 Only needed for an encrypted collection. Encoding fills this in for you.
             </template>
+        </p>
+        <!--
+            Replacing a saved key is the one edit on this form that cannot be
+            undone by retyping: the media was encrypted with the old key, and
+            nothing keeps a copy of it. Warned at the moment of typing rather
+            than on save, because by then the old key is already gone.
+        -->
+        <p
+            v-if="hasStoredKey && replacingKey"
+            class="text-xs font-medium text-amber-600 dark:text-amber-500"
+            data-test="video-key-warning"
+        >
+            This replaces the saved key. Anything already encrypted with the old
+            one becomes unplayable, and the old key cannot be recovered.
         </p>
     </LCard>
 </template>

--- a/cms/src/components/content/EditContentVideo.vue
+++ b/cms/src/components/content/EditContentVideo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import LDialog from "@/components/common/LDialog.vue";
 import LCard from "@/components/common/LCard.vue";
 import LInput from "@/components/forms/LInput.vue";
 import { VideoCameraIcon, LinkIcon, KeyIcon } from "@heroicons/vue/20/solid";
@@ -49,6 +50,34 @@ const hlsKey = computed({
 });
 
 /**
+ * Replacing a saved key is confirmed once, on the first keystroke.
+ *
+ * The damage is done at save, but the decision is made here — and asking at save
+ * time would mean asking about an edit the user made minutes earlier, next to
+ * every other change they are committing. Confirmed once rather than per
+ * keystroke: a key is typed or pasted in one go, and a dialog per character
+ * would be unusable. Declining clears the field, so the saved key survives.
+ */
+const confirmReplaceOpen = ref(false);
+const replaceConfirmed = ref(false);
+
+/** True once the field holds a replacement for a key that is already saved. */
+const replacingKey = computed(() => Boolean(hlsKey.value));
+
+function onKeyInput(value: string) {
+    if (hasStoredKey.value && value && !replaceConfirmed.value) {
+        confirmReplaceOpen.value = true;
+    }
+    hlsKey.value = value;
+}
+
+function cancelReplace() {
+    hlsKey.value = undefined;
+    replaceConfirmed.value = false;
+    confirmReplaceOpen.value = false;
+}
+
+/**
  * A stored key is only ever a reference: the API encrypts the submitted key into a
  * crypto object on save and returns its id, so the key itself is never readable
  * again. The field therefore starts empty on a saved document, and saying so beats
@@ -56,8 +85,6 @@ const hlsKey = computed({
  */
 const hasStoredKey = computed(() => Boolean(parent.value?.media?.hlsKey_id));
 
-/** The user has typed a replacement over a key that is already saved. */
-const replacingKey = computed(() => Boolean(hlsKey.value));
 
 // Collapse the card only initially if there's no video
 watch(
@@ -96,12 +123,11 @@ watch(
 
         <LInput
             name="hlsKey"
-            v-model="hlsKey"
+            :modelValue="hlsKey"
+            @update:modelValue="onKeyInput"
             :icon="KeyIcon"
             :placeholder="
-                hasStoredKey
-                    ? 'A key is saved — type a new one to replace it'
-                    : 'Encryption key (hex)'
+                hasStoredKey ? 'Enter new encryption key' : 'Encryption key (hex)'
             "
             :disabled="disabled"
             class="pb-1"
@@ -130,4 +156,21 @@ watch(
             one becomes unplayable, and the old key cannot be recovered.
         </p>
     </LCard>
+
+    <LDialog
+        v-model:open="confirmReplaceOpen"
+        title="Replace the encryption key?"
+        description="This video already has a key saved. Replacing it makes anything encrypted with the old key unplayable, and the old key cannot be recovered."
+        :primaryAction="
+            () => {
+                replaceConfirmed = true;
+                confirmReplaceOpen = false;
+            }
+        "
+        :secondaryAction="cancelReplace"
+        primaryButtonText="Replace key"
+        secondaryButtonText="Cancel"
+        context="danger"
+        :showClosingButton="false"
+    />
 </template>


### PR DESCRIPTION
Three of #1900's six checkboxes. The other three are accounted for at the bottom.

## Relative `hlsUrl` (+ external URLs keep their full form)

`hlsUrl` is stored as `/prefix/master.m3u8`. The document already names its bucket through `mediaBucketId`, so repeating the bucket's public URL stored the same fact twice — and the two drift the moment a bucket is renamed, re-pointed at a new CDN, or a collection is moved.

**This removes a defect rather than adding a shape.** `resolveCollectionPrefix` derived the storage prefix by stripping the bucket's public base off the URL, so once `mediaBucketId` and `hlsUrl` disagreed the collection could not be resolved and its files became unreachable — the leak this epic exists to close. A relative URL *is* the key: no base to strip, nothing to disagree with. A bucket move no longer rewrites the URL at all; only the legacy absolute form still needs it.

External sources are returned untouched — a YouTube link or a master on someone else's CDN has no bucket to be relative to. `toStoredMediaUrl` is idempotent, and the prefix match includes the separator so a bucket published at `/media` cannot claim `/media-archive`.

The app joins the two at playback, the same way `LImage` already does for images, and returns `undefined` while the bucket is still loading rather than handing the browser a bare path it would fetch from the app's own origin.

## Warn before replacing an encryption key

Typing over a saved key is the one edit on that form that cannot be undone: the media was encrypted with the old key and nothing keeps a copy. The warning appears while typing rather than on save, by which time the old key is already gone.

## The remaining three checkboxes

- **S3 move & delete** — already done, on this branch's base (`deleteMediaCollection.ts`, `migrateMediaCollection.ts`).
- **Swap the app to `player-web`** — needs the adapter decision. Adopting `player-web` wholesale costs the app `videojs-youtube` and `videojs-mobile-ui`; a `VideoJsAdapter` over `player-core` keeps both. See bccsa/luminary-media-convert#184.
- **Optional non-fullscreen controls** — belongs to `player-web` in the encoder repository; its `PlayerControlsOptions` configures the fullscreen controls only.

## Verification

api 822 passing, cms 1029, app 928, all three type-clean. The two failing api suites are the pre-existing MinIO credential ones (`processImageDto`, `s3.service`), untouched here.

Worth knowing: `strictNullChecks` is off in `api`, so the compiler will not catch a missing `publicUrl` on these paths. The one place it matters — rebuilding an absolute URL during a bucket move — still guards for it explicitly.
