### PR TITLE
Play video through the encoder's player, and deliver the key it needs

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { FtsSearchService } from "./endpoints/ftsSearch.service";
 import { FtsSearchController } from "./endpoints/ftsSearch.controller";
 import { StorageStatusController } from "./endpoints/storageStatus.controller";
 import { EncoderConfigController } from "./endpoints/encoderConfig.controller";
+import { MediaKeyController } from "./endpoints/mediaKey.controller";
 import { AuthIdentityService } from "./auth/authIdentity.service";
 import { QueryRateLimiterService } from "./ratelimit/queryRateLimiter.service";
 
@@ -59,6 +60,7 @@ if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
         FtsSearchController,
         StorageStatusController,
         EncoderConfigController,
+        MediaKeyController,
     ],
     providers: [
         DbService,

--- a/api/src/endpoints/mediaKey.controller.spec.ts
+++ b/api/src/endpoints/mediaKey.controller.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import * as request from "supertest";
+import { MediaKeyController } from "./mediaKey.controller";
+import { DbService } from "../db/db.service";
+import { AuthGuard } from "../auth/auth.guard";
+import * as permissionsService from "../permissions/permissions.service";
+import * as encryption from "../util/encryption";
+import { DocType } from "../enums";
+
+const KEY = "0123456789abcdef0123456789abcdef";
+
+describe("MediaKeyController", () => {
+    let app: INestApplication;
+    const mockGetDoc = jest.fn();
+    const mockVerifyAccess = jest.fn();
+    const mockRetrieveCryptoData = jest.fn();
+
+    beforeAll(async () => {
+        const testingModule: TestingModule = await Test.createTestingModule({
+            controllers: [MediaKeyController],
+            providers: [{ provide: DbService, useValue: { getDoc: mockGetDoc } }],
+        })
+            .overrideGuard(AuthGuard)
+            .useValue({
+                canActivate: (context: any) => {
+                    const req = context.switchToHttp().getRequest();
+                    req.user = { groups: ["group-public-users"], userId: "user-123" };
+                    return true;
+                },
+            })
+            .compile();
+
+        app = testingModule.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe());
+        await app.init();
+    });
+
+    afterAll(async () => await app.close());
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        jest.spyOn(permissionsService.PermissionSystem, "verifyAccess").mockImplementation(
+            mockVerifyAccess,
+        );
+        jest.spyOn(encryption, "retrieveCryptoData").mockImplementation(mockRetrieveCryptoData);
+        mockVerifyAccess.mockReturnValue(true);
+        mockRetrieveCryptoData.mockResolvedValue(KEY);
+    });
+
+    const contentDoc = (overrides: Record<string, unknown> = {}) => ({
+        _id: "content-1",
+        type: DocType.Content,
+        parentType: DocType.Post,
+        memberOf: ["group-public-content"],
+        parentMedia: { hlsUrl: "/media/abc/master.m3u8", hlsKey_id: "crypto-1" },
+        ...overrides,
+    });
+
+    const get = (docId = "content-1") =>
+        request(app.getHttpServer()).get("/media/key").query({ docId, apiVersion: "0.0.0" });
+
+    it("hands the key to a viewer who may see the document", async () => {
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc()] });
+
+        const res = await get();
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ keyHex: KEY });
+        expect(mockRetrieveCryptoData).toHaveBeenCalledWith(expect.anything(), "crypto-1");
+    });
+
+    it("checks View on the parent type, not on the content document", async () => {
+        // Content is not separately permissioned — that is why memberOf is copied
+        // down onto it — so the permission that decides this is the parent's.
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc({ parentType: DocType.Tag })] });
+
+        await get();
+
+        expect(mockVerifyAccess).toHaveBeenCalledWith(
+            ["group-public-content"],
+            DocType.Tag,
+            "view",
+            ["group-public-users"],
+        );
+    });
+
+    it("accepts the parent document too, where the media is not prefixed", async () => {
+        mockGetDoc.mockResolvedValue({
+            docs: [
+                {
+                    _id: "post-1",
+                    type: DocType.Post,
+                    memberOf: ["group-public-content"],
+                    media: { hlsKey_id: "crypto-2" },
+                },
+            ],
+        });
+
+        const res = await get("post-1");
+
+        expect(res.status).toBe(200);
+        expect(mockRetrieveCryptoData).toHaveBeenCalledWith(expect.anything(), "crypto-2");
+    });
+
+    it("gives a viewer without access the same answer as a missing document", async () => {
+        // Distinguishing them turns this into a probe for which documents exist,
+        // and the caller has nothing useful to do with the difference.
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc()] });
+        mockVerifyAccess.mockReturnValue(false);
+
+        const denied = await get();
+
+        mockGetDoc.mockResolvedValue({ docs: [] });
+        const missing = await get("nope");
+
+        expect(denied.status).toBe(404);
+        expect(missing.status).toBe(404);
+        expect(denied.body.message).toEqual(missing.body.message.replace("nope", "content-1"));
+    });
+
+    it("never reads the key for a viewer without access", async () => {
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc()] });
+        mockVerifyAccess.mockReturnValue(false);
+
+        await get();
+
+        expect(mockRetrieveCryptoData).not.toHaveBeenCalled();
+    });
+
+    it("404s when the media carries no key", async () => {
+        // Unencrypted media is normal, not an error the player should retry.
+        mockGetDoc.mockResolvedValue({
+            docs: [contentDoc({ parentMedia: { hlsUrl: "/media/abc/master.m3u8" } })],
+        });
+
+        expect((await get()).status).toBe(404);
+    });
+
+    it("distinguishes an unreadable key from an absent one", async () => {
+        // A rotated ENCRYPTION_KEY or a vanished crypto document is not "no key
+        // was ever set", and is not the caller's to fix.
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc()] });
+        mockRetrieveCryptoData.mockRejectedValue(new Error("bad decrypt"));
+
+        expect((await get()).status).toBe(409);
+    });
+
+    it("requires a docId", async () => {
+        expect((await request(app.getHttpServer()).get("/media/key").query({ apiVersion: "0.0.0" })).status).toBe(400);
+    });
+});

--- a/api/src/endpoints/mediaKey.controller.ts
+++ b/api/src/endpoints/mediaKey.controller.ts
@@ -1,0 +1,116 @@
+import { Controller, Get, Query, UseGuards, Req, HttpException, HttpStatus } from "@nestjs/common";
+import { AuthGuard } from "../auth/auth.guard";
+import { DbService } from "../db/db.service";
+import { validateApiVersion } from "../validation/apiVersion";
+import { PermissionSystem } from "../permissions/permissions.service";
+import { AclPermission, DocType } from "../enums";
+import { retrieveCryptoData } from "../util/encryption";
+import { FastifyRequest } from "fastify";
+
+export type MediaKeyResponseDto = {
+    /** AES-128 key as 32 hex characters, as the player expects it. */
+    keyHex: string;
+};
+
+/**
+ * Hands a viewer the decryption key for one media collection.
+ *
+ * Encrypted HLS is encrypted at rest in the bucket, so a player cannot decode a
+ * segment without the key. The key is stored as a crypto object and is never
+ * replicated to clients — documents carry only `hlsKey_id`, which is an id and
+ * not a secret. Without an endpoint like this one, encrypted media is
+ * undecryptable by every client, which is where this started.
+ *
+ * This is key *delivery*, not access control over the media itself: anything a
+ * viewer may watch, they may also be handed the key for. The permission checked
+ * is therefore exactly the one that decides whether they may see the document —
+ * `View` on the parent Post or Tag — and no other. Anything stricter would deny
+ * the key for content already on the viewer's screen; anything looser would
+ * hand out keys for content they cannot see.
+ *
+ * The key is as recoverable as the media is watchable, and no more: it protects
+ * bytes sitting in a public bucket from being played by whoever finds the URL.
+ * It is not DRM, and nothing here pretends a determined viewer cannot keep it.
+ */
+@Controller("media")
+export class MediaKeyController {
+    constructor(private readonly dbService: DbService) {}
+
+    @Get("key")
+    @UseGuards(AuthGuard)
+    async getMediaKey(
+        @Query("docId") docId: string,
+        @Query("apiVersion") apiVersion: string,
+        @Req() request: FastifyRequest,
+    ): Promise<MediaKeyResponseDto> {
+        await validateApiVersion(apiVersion);
+
+        const userDetails = request.user;
+
+        if (!docId) {
+            throw new HttpException("docId query parameter is required", HttpStatus.BAD_REQUEST);
+        }
+
+        const result = await this.dbService.getDoc(docId);
+        if (!result.docs || result.docs.length === 0) {
+            throw new HttpException(`Document not found: ${docId}`, HttpStatus.NOT_FOUND);
+        }
+
+        const doc = result.docs[0];
+
+        // A content document mirrors its parent's media as `parentMedia`, and is
+        // what a player is rendering; the parent Post or Tag carries it as
+        // `media`. Both are accepted so a caller does not have to know which one
+        // it is holding.
+        const media = doc.parentMedia ?? doc.media;
+
+        // The permission lives on the parent type even when the document asked
+        // for is a content document — content is not separately permissioned,
+        // which is why `memberOf` is copied down onto it.
+        const parentType: DocType =
+            doc.type === DocType.Content ? (doc.parentType ?? DocType.Post) : doc.type;
+
+        const hasPermission = PermissionSystem.verifyAccess(
+            doc.memberOf ?? [],
+            parentType,
+            AclPermission.View,
+            userDetails.groups,
+        );
+
+        // Deliberately the same 404 a missing document gets. Distinguishing them
+        // would turn this endpoint into a probe for which documents exist, and
+        // the caller has nothing useful to do with the difference.
+        if (!hasPermission) {
+            throw new HttpException(`Document not found: ${docId}`, HttpStatus.NOT_FOUND);
+        }
+
+        if (!media?.hlsKey_id) {
+            throw new HttpException(
+                `No encryption key is stored for this media: ${docId}`,
+                HttpStatus.NOT_FOUND,
+            );
+        }
+
+        let keyHex: string;
+        try {
+            keyHex = await retrieveCryptoData<string>(this.dbService, media.hlsKey_id);
+        } catch {
+            // Unreadable rather than absent: a rotated ENCRYPTION_KEY, or a
+            // crypto document that has gone. Neither is the caller's to fix, and
+            // neither means "no key was ever set".
+            throw new HttpException(
+                "The stored encryption key could not be read",
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        if (!keyHex) {
+            throw new HttpException(
+                "The stored encryption key is empty",
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        return { keyHex };
+    }
+}

--- a/app/src/components/content/VideoPlayer.spec.ts
+++ b/app/src/components/content/VideoPlayer.spec.ts
@@ -1,400 +1,253 @@
 import "fake-indexeddb/auto";
-import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
+import { computed } from "vue";
+import waitForExpect from "wait-for-expect";
 import VideoPlayer from "./VideoPlayer.vue";
 import { mockEnglishContentDto } from "@/tests/mockdata";
-import waitForExpect from "wait-for-expect";
-import { computed } from "vue";
+
+/**
+ * What is left to test here is Luminary's half of playback: which URL is played,
+ * where the key comes from, and what a resume point and a finished video mean.
+ *
+ * The player itself — control bar, auto-hide, keep-alive, rotation, audio-track
+ * selection, audio-only mode, the YouTube branch — belongs to
+ * `player-web-legacy` and is tested there. Reaching through this component to
+ * assert on it would be testing someone else's library through a keyhole.
+ */
+const seekMock = vi.hoisted(() => vi.fn());
+const playMock = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+const pauseMock = vi.hoisted(() => vi.fn());
+const enterFullscreenMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const exitFullscreenMock = vi.hoisted(() => vi.fn());
+const getMediaKeyMock = vi.hoisted(() => vi.fn());
+
+// Built inside the factory: vi.mock is hoisted above the imports, so a stub
+// defined at module scope is not there yet when the factory runs.
+vi.mock("@luminary-media-converter/player-web-legacy", async () => {
+    const { defineComponent, h } = await import("vue");
+    return {
+        LuminaryPlayer: defineComponent({
+            name: "LuminaryPlayer",
+            props: {
+                source: { type: Object, required: true },
+                preferredLanguage: { type: String, default: undefined },
+            },
+            emits: ["loadedmetadata", "timeupdate", "ended"],
+            setup(_props, { expose }) {
+                expose({
+                    seek: seekMock,
+                    play: playMock,
+                    pause: pauseMock,
+                    enterFullscreen: enterFullscreenMock,
+                    exitFullscreen: exitFullscreenMock,
+                });
+                return () => h("div", { class: "luminary-player-stub" });
+            },
+        }),
+    };
+});
 
 vi.mock("@/composables/useBucketInfo", () => ({
-    useBucketInfo: () => ({
-        bucketBaseUrl: computed(() => "https://bucket.example.com"),
-    }),
+    useBucketInfo: () => ({ bucketBaseUrl: computed(() => "https://bucket.example.com") }),
 }));
 
-// Mock YouTube utilities
-vi.mock("@/util/youtube", () => ({
-    isYouTubeUrl: vi.fn((url: string) => {
-        if (!url) return false;
-        const youtubeRegex =
-            /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
-        return youtubeRegex.test(url);
-    }),
-    convertToVideoJSYouTubeUrl: vi.fn((url: string) => {
-        // Extract video ID and return in VideoJS format
-        const match = url.match(
-            /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/,
-        );
-        if (match) {
-            return `https://www.youtube.com/watch?v=${match[1]}`;
-        }
-        return url;
-    }),
+vi.mock("luminary-shared", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("luminary-shared")>()),
+    getRest: () => ({ getMediaKey: getMediaKeyMock }),
 }));
 
-const posterMock = vi.hoisted(() => vi.fn());
-const srcMock = vi.hoisted(() => vi.fn());
-const disposeMock = vi.hoisted(() => vi.fn());
-const audioOnlyModeMock = vi.hoisted(() => vi.fn());
-const audioPosterModeMock = vi.hoisted(() => vi.fn());
-const eventCallbacks = vi.hoisted(() => new Map<string, Function[]>());
-
-vi.mock("video.js", () => {
-    // Create a mock DOM element
-    const mockEl = document.createElement("div");
-    mockEl.className = "video-js";
-
-    const defaultFunction = () => {
-        return {
-            browser: {
-                IS_SAFARI: false,
-            },
-            poster: posterMock,
-            src: srcMock,
-            mobileUi: vi.fn(),
-            on: vi.fn((event: string | string[], callback: Function) => {
-                const events = Array.isArray(event) ? event : [event];
-                events.forEach((e) => {
-                    if (!eventCallbacks.has(e)) eventCallbacks.set(e, []);
-                    eventCallbacks.get(e)!.push(callback);
-                });
-            }),
-            one: vi.fn((event: string, callback: Function) => {
-                if (!eventCallbacks.has(event)) eventCallbacks.set(event, []);
-                eventCallbacks.get(event)!.push(callback);
-            }),
-            audioTracks: vi.fn(() => []),
-            el: vi.fn(() => mockEl),
-            userActive: vi.fn(),
-            paused: vi.fn(() => true),
-            currentTime: vi.fn(),
-            duration: vi.fn(() => 0),
-            play: vi.fn(),
-            pause: vi.fn(),
-            ready: vi.fn((callback) => {
-                if (callback) callback();
-                return {
-                    on: vi.fn((event: string | string[], callback: Function) => {
-                        const events = Array.isArray(event) ? event : [event];
-                        events.forEach((e) => {
-                            if (!eventCallbacks.has(e)) eventCallbacks.set(e, []);
-                            eventCallbacks.get(e)!.push(callback);
-                        });
-                    }),
-                };
-            }),
-            off: vi.fn(),
-            dispose: disposeMock,
-            isFullscreen: vi.fn(() => false),
-            requestFullscreen: vi.fn(),
-            exitFullscreen: vi.fn(),
-            audioOnlyMode: audioOnlyModeMock,
-            audioPosterMode: audioPosterModeMock,
-        };
-    };
-    defaultFunction.browser = {
-        IS_SAFARI: false,
-    };
-
-    return {
-        default: defaultFunction,
-    };
-});
-
-vi.mock("@/globalConfig", async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, unknown>;
-    return {
-        ...actual,
-        queryParams: new URLSearchParams(),
-        appLanguagesPreferredAsRef: { value: [{ languageCode: "en" }] },
-    };
-});
-
-vi.mock("@/contentProgress", async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, unknown>;
-    return {
-        ...actual,
-        getMediaProgress: vi.fn(() => 0),
-        setMediaProgress: vi.fn(),
-        removeMediaProgress: vi.fn(),
-    };
-});
-
-vi.mock("./extractAndBuildAudioMaster", () => ({
-    extractAndBuildAudioMaster: vi
-        .fn()
-        .mockResolvedValue("#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=128000\naudio.m3u8"),
+const setMediaProgressMock = vi.hoisted(() => vi.fn());
+const getMediaProgressMock = vi.hoisted(() => vi.fn(() => 0));
+const removeMediaProgressMock = vi.hoisted(() => vi.fn());
+vi.mock("@/contentProgress", () => ({
+    setMediaProgress: setMediaProgressMock,
+    getMediaProgress: getMediaProgressMock,
+    removeMediaProgress: removeMediaProgressMock,
 }));
 
-function triggerPlayerEvent(event: string, ...args: any[]) {
-    const callbacks = eventCallbacks.get(event) || [];
-    callbacks.forEach((cb: Function) => cb(...args));
+const recordAffinityMock = vi.hoisted(() => vi.fn());
+vi.mock("@/recommendation/affinityStore", () => ({ recordAffinity: recordAffinityMock }));
+vi.mock("@/recommendation/defaultAffinityStore", () => ({
+    affinityConfig: computed(() => ({ eventWeight: { completion: 5 } })),
+}));
+const markSeenMock = vi.hoisted(() => vi.fn());
+vi.mock("@/recommendation/seenStore", () => ({ markSeen: markSeenMock }));
+
+const RELATIVE = "/media/abc/master.m3u8";
+const ABSOLUTE = "https://bucket.example.com/media/abc/master.m3u8";
+
+function content(overrides: Record<string, unknown> = {}) {
+    return {
+        ...mockEnglishContentDto,
+        parentMediaBucketId: "bucket-1",
+        parentMedia: { hlsUrl: RELATIVE },
+        video: undefined,
+        ...overrides,
+    } as any;
 }
 
-// Mock HTMLMediaElement methods not implemented in jsdom
-beforeAll(() => {
-    HTMLMediaElement.prototype.pause = vi.fn();
-    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
-    HTMLMediaElement.prototype.load = vi.fn();
+async function mountPlayer(overrides: Record<string, unknown> = {}) {
+    const wrapper = mount(VideoPlayer, {
+        props: { content: content(overrides), language: "en" },
+        global: { stubs: { LImage: true } },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return wrapper;
+}
+
+const stub = (wrapper: any) => wrapper.findComponent({ name: "LuminaryPlayer" });
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getMediaProgressMock.mockReturnValue(0);
+    getMediaKeyMock.mockResolvedValue(undefined);
 });
 
 describe("VideoPlayer", () => {
-    beforeEach(() => {
-        eventCallbacks.clear();
+    it("resolves a bucket-relative URL to a fetchable one", async () => {
+        const wrapper = await mountPlayer();
+
+        expect(stub(wrapper).props("source").masterUrl).toBe(ABSOLUTE);
     });
 
-    afterEach(() => {
-        vi.clearAllMocks();
+    it("renders no player when the document carries no video", async () => {
+        const wrapper = await mountPlayer({ parentMedia: undefined });
+
+        expect(stub(wrapper).exists()).toBe(false);
     });
 
-    it("renders the poster image for regular video", async () => {
-        const content = {
-            ...mockEnglishContentDto,
-            // The encoded collection is the source; no typed URL is involved.
-            video: undefined,
-        };
+    it("passes the viewer's language through for audio-track selection", async () => {
+        const wrapper = await mountPlayer();
 
-        const wrapper = mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: content,
-            },
+        expect(stub(wrapper).props("preferredLanguage")).toBe("en");
+    });
+
+    describe("the decryption key", () => {
+        it("is fetched and handed to the player when the media is encrypted", async () => {
+            getMediaKeyMock.mockResolvedValue({ keyHex: "0".repeat(32) });
+
+            const wrapper = await mountPlayer({
+                parentMedia: { hlsUrl: RELATIVE, hlsKey_id: "crypto-1" },
+            });
+
+            await waitForExpect(() =>
+                expect(stub(wrapper).props("source").keyHex).toBe("0".repeat(32)),
+            );
+            expect(getMediaKeyMock).toHaveBeenCalledWith(mockEnglishContentDto._id);
         });
 
-        await waitForExpect(() => {
-            expect(srcMock).toHaveBeenCalledWith(
-                expect.objectContaining({ src: content.parentMedia!.hlsUrl }),
+        it("is not asked for when the media is not encrypted", async () => {
+            // Unencrypted is the common case; a request per video would be waste.
+            await mountPlayer();
+
+            expect(getMediaKeyMock).not.toHaveBeenCalled();
+        });
+
+        it("still plays when the key cannot be had", async () => {
+            // "Not encrypted" and "not yours to have" are the same answer here:
+            // play what the playlists give, and let playback fail if it must.
+            getMediaKeyMock.mockResolvedValue(undefined);
+
+            const wrapper = await mountPlayer({
+                parentMedia: { hlsUrl: RELATIVE, hlsKey_id: "crypto-1" },
+            });
+
+            expect(stub(wrapper).props("source").masterUrl).toBe(ABSOLUTE);
+            expect(stub(wrapper).props("source").keyHex).toBeUndefined();
+        });
+    });
+
+    describe("resume position", () => {
+        it("saves the position once past the resume threshold", async () => {
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("timeupdate", 90, 600);
+
+            expect(setMediaProgressMock).toHaveBeenCalledWith(
+                ABSOLUTE,
+                mockEnglishContentDto._id,
+                90,
+                600,
             );
         });
 
-        await waitForExpect(() => {
-            // Check that the default poster image is set to a transparent pixel
-            // In Vite, image imports resolve to paths starting with '/' or as data URLs
-            expect(posterMock).toHaveBeenCalled();
-            const posterArg = posterMock.mock.calls[0]?.[0];
-            expect(posterArg).toBeTruthy();
-            // The px.png import should resolve to a string path containing 'px' and '.png'
-            expect(typeof posterArg).toBe("string");
-            expect(posterArg).toMatch(/px.*\.png|\.png.*px/i);
+        it("does not save a position too early to be worth resuming", async () => {
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("timeupdate", 42, 600);
+
+            expect(setMediaProgressMock).not.toHaveBeenCalled();
         });
 
-        await waitForExpect(() => {
-            expect(wrapper.html()).toContain(
-                content.parentImageData?.fileCollections[0].imageFiles[0].filename,
-            );
-        });
-    });
+        it("does not save a position in a live stream", async () => {
+            const wrapper = await mountPlayer();
 
-    it("handles YouTube videos correctly", async () => {
-        const youtubeContent = {
-            ...mockEnglishContentDto,
-            // No encoded collection: this post's video is the link somebody typed.
-            parentMedia: undefined,
-            video: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-        };
+            stub(wrapper).vm.$emit("timeupdate", 90, Infinity);
 
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: youtubeContent,
-            },
+            expect(setMediaProgressMock).not.toHaveBeenCalled();
         });
 
-        await waitForExpect(() => {
-            expect(srcMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    src: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                    type: "video/youtube",
-                }),
-            );
+        it("restores a saved position slightly behind where the viewer left", async () => {
+            getMediaProgressMock.mockReturnValue(300);
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("loadedmetadata");
+
+            expect(seekMock).toHaveBeenCalledWith(270);
+        });
+
+        it("does not seek for a position not worth resuming", async () => {
+            getMediaProgressMock.mockReturnValue(30);
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("loadedmetadata");
+
+            expect(seekMock).not.toHaveBeenCalled();
         });
     });
 
-    it("sets the poster to a transparent pixel", async () => {
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
+    describe("finishing a video", () => {
+        it("clears the resume point and records the engagement", async () => {
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("ended");
+
+            expect(removeMediaProgressMock).toHaveBeenCalledWith(ABSOLUTE, mockEnglishContentDto._id);
+            expect(recordAffinityMock).toHaveBeenCalledWith(mockEnglishContentDto.parentTags, 5);
+            expect(markSeenMock).toHaveBeenCalledWith(mockEnglishContentDto._id);
+            expect(exitFullscreenMock).toHaveBeenCalled();
         });
 
-        await waitForExpect(() => {
-            expect(posterMock).toHaveBeenCalled();
-        });
-    });
+        it("detects the end from the position when `ended` never arrives", async () => {
+            // The normal case on YouTube, whose tech is known to drop the event.
+            const wrapper = await mountPlayer();
 
-    it("registers event handlers via on()", async () => {
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
+            stub(wrapper).vm.$emit("timeupdate", 599.5, 600);
+
+            expect(markSeenMock).toHaveBeenCalledTimes(1);
         });
 
-        await waitForExpect(() => {
-            // Should register multiple event handlers
-            expect(eventCallbacks.has("loadeddata")).toBe(true);
-        });
-    });
+        it("counts a completion once, however it was detected", async () => {
+            // Otherwise the near-end fallback fires on every tick of the last
+            // second, and affinity is counted several times for one viewing.
+            const wrapper = await mountPlayer();
 
-    it("sets HLS source for regular video", async () => {
-        const contentWithVideo = {
-            ...mockEnglishContentDto,
-            parentMedia: undefined,
-            video: "https://example.com/stream.m3u8",
-        };
+            stub(wrapper).vm.$emit("timeupdate", 599.2, 600);
+            stub(wrapper).vm.$emit("timeupdate", 599.6, 600);
+            stub(wrapper).vm.$emit("ended");
 
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: contentWithVideo,
-            },
+            expect(recordAffinityMock).toHaveBeenCalledTimes(1);
         });
 
-        await waitForExpect(() => {
-            expect(srcMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: "application/x-mpegURL",
-                    src: "https://example.com/stream.m3u8",
-                }),
-            );
+        it("arms again for the next playthrough", async () => {
+            const wrapper = await mountPlayer();
+
+            stub(wrapper).vm.$emit("ended");
+            stub(wrapper).vm.$emit("loadedmetadata");
+            stub(wrapper).vm.$emit("ended");
+
+            expect(recordAffinityMock).toHaveBeenCalledTimes(2);
         });
-    });
-
-    it("registers ended event handler that removes progress", async () => {
-        const { removeMediaProgress } = await import("@/contentProgress");
-
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
-        });
-
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("ended")).toBe(true);
-        });
-
-        // Trigger ended event
-        triggerPlayerEvent("ended");
-
-        expect(removeMediaProgress).toHaveBeenCalled();
-    });
-
-    it("registers pause event handler", async () => {
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
-        });
-
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("pause")).toBe(true);
-        });
-
-        // Trigger pause - should not throw
-        triggerPlayerEvent("pause");
-    });
-
-    it("registers play event handler", async () => {
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
-        });
-
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("play")).toBe(true);
-        });
-
-        triggerPlayerEvent("play");
-    });
-
-    it("saves progress on timeupdate when currentTime > 60", async () => {
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
-        });
-
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("timeupdate")).toBe(true);
-        });
-
-        triggerPlayerEvent("timeupdate");
-
-        // Note: the actual player mock's currentTime/duration are from the vi.mock
-        // which returns 0/0, so setMediaProgress won't be called for currentTime < 60
-        // This test verifies the handler is registered
-    });
-
-    it("restores progress on ready event when progress > 60", async () => {
-        const { getMediaProgress } = await import("@/contentProgress");
-        vi.mocked(getMediaProgress).mockReturnValue(120);
-
-        mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: mockEnglishContentDto,
-            },
-        });
-
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("ready")).toBe(true);
-        });
-
-        triggerPlayerEvent("ready");
-
-        expect(getMediaProgress).toHaveBeenCalled();
-    });
-
-    it("disposes player on unmount", async () => {
-        const contentWithVideo = {
-            ...mockEnglishContentDto,
-            parentMedia: undefined,
-            video: "https://example.com/stream.m3u8",
-        };
-
-        const wrapper = mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: contentWithVideo,
-            },
-        });
-
-        // Wait for the async onMounted to fully complete (requestAnimationFrame + dynamic imports)
-        await waitForExpect(() => {
-            expect(eventCallbacks.has("ended")).toBe(true);
-        });
-
-        wrapper.unmount();
-
-        expect(disposeMock).toHaveBeenCalled();
-    });
-
-    it("hides audio toggle for YouTube videos", async () => {
-        const youtubeContent = {
-            ...mockEnglishContentDto,
-            // No encoded collection: this post's video is the link somebody typed.
-            parentMedia: undefined,
-            video: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-        };
-
-        const wrapper = mount(VideoPlayer, {
-            props: {
-                language: "lang-eng",
-                content: youtubeContent,
-            },
-        });
-
-        // AudioVideoToggle should not be rendered for YouTube
-        await waitForExpect(() => {
-            expect(wrapper.findComponent({ name: "AudioVideoToggle" }).exists()).toBe(false);
-        });
-
-        wrapper.unmount();
     });
 });

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -1,20 +1,30 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import AudioVideoToggle from "../form/AudioVideoToggle.vue";
-import "videojs-mobile-ui";
-import type Player from "video.js/dist/types/player";
+/**
+ * Video playback for a content document.
+ *
+ * The player itself is `LuminaryPlayer` from the encoder's `player-web-legacy`
+ * package — the same Video.js 8 chrome this component used to build by hand,
+ * now maintained next to the encoder that produces the streams. What lives here
+ * is everything that is Luminary's rather than the player's: which URL to play,
+ * where the decryption key comes from, resume position, and the engagement
+ * signals a finished video sends.
+ *
+ * The player owns, and this file no longer does: control-bar layout, auto-hiding
+ * controls, the iOS keep-alive audio element, rotation/fullscreen handling,
+ * audio-track selection by preferred language, the stall nudge, audio-only mode,
+ * and the whole YouTube branch.
+ */
+import { computed, ref, watch } from "vue";
+import { LuminaryPlayer, type PlayerSource } from "@luminary-media-converter/player-web-legacy";
 import { type ContentDto } from "luminary-shared";
-import px from "./px.png";
-import { pickAudioTrack } from "./audioTrackLanguage";
+import { getRest } from "luminary-shared";
 import LImage from "../images/LImage.vue";
 import { appLanguagesPreferredAsRef, queryParams } from "@/globalConfig";
 import { getMediaProgress, removeMediaProgress, setMediaProgress } from "@/contentProgress";
 import { recordAffinity } from "@/recommendation/affinityStore";
 import { affinityConfig } from "@/recommendation/defaultAffinityStore";
 import { markSeen } from "@/recommendation/seenStore";
-import { extractAndBuildAudioMaster } from "./extractAndBuildAudioMaster";
-import { isYouTubeUrl, convertToVideoJSYouTubeUrl } from "@/util/youtube";
-import { resolveVideoSource, videoSourceFor } from "@/util/videoSource";
+import { resolveVideoSource } from "@/util/videoSource";
 import { useBucketInfo } from "@/composables/useBucketInfo";
 
 type Props = {
@@ -24,587 +34,126 @@ type Props = {
 
 const props = defineProps<Props>();
 
+const player = ref<InstanceType<typeof LuminaryPlayer> | null>(null);
+
 // The media bucket, so a stored relative URL can be resolved to a fetchable
 // one — see resolveVideoSource.
 const mediaBucketIdRef = computed(() => props.content?.parentMediaBucketId);
 const { bucketBaseUrl: mediaBucketBaseUrl } = useBucketInfo(mediaBucketIdRef);
 
-const playerElement = ref<HTMLVideoElement>();
-const audioModeToggle = ref<typeof AudioVideoToggle>();
-let player: Player | null = null;
+const videoSource = computed(() => resolveVideoSource(props.content, mediaBucketBaseUrl.value));
 
-const audioMode = ref<boolean>(false);
-const hasStarted = ref<boolean>(false);
-const showAudioModeToggle = ref<boolean>(true);
 const autoPlay = queryParams.get("autoplay") === "true";
 const autoFullscreen = queryParams.get("autofullscreen") === "true";
-const keepAudioAlive = ref<HTMLAudioElement | null>(null);
-const isRestoringTrack = ref<boolean>(false);
 
-// YouTube detection
-const isYouTube = ref<boolean>(false);
-
-// Check if the current video is a YouTube video
-if (resolveVideoSource(props.content, mediaBucketBaseUrl.value)) {
-    isYouTube.value = isYouTubeUrl(resolveVideoSource(props.content, mediaBucketBaseUrl.value)!);
-    if (isYouTube.value) {
-        // hides audio mode toggle for YouTube videos as it's not supported
-        showAudioModeToggle.value = false;
-    }
-}
-
-const AUDIO_MODE_TIME_ADJUSTMENT = 0.25;
-
-let timeout: ReturnType<typeof setTimeout> | undefined;
-function autoHidePlayerControls() {
-    if (timeout) clearTimeout(timeout);
-    timeout = setTimeout(() => {
-        player?.userActive(false);
-    }, 3000);
-}
-
-function playerPlayEventHandler() {
-    hasStarted.value = true;
-    playerUserActiveEventHandler();
-    if (autoFullscreen) player?.requestFullscreen();
-}
-
-function playerUserActiveEventHandler() {
-    if (isYouTube.value) {
-        showAudioModeToggle.value = false;
-    }
-
-    if (audioMode.value) {
-        // Always show controls and toggle in audio-only mode
-        showAudioModeToggle.value = true;
-        player?.userActive(true);
-    } else if (player?.userActive() || !hasStarted.value || player?.paused()) {
-        showAudioModeToggle.value = true;
-    } else {
-        showAudioModeToggle.value = false;
-    }
-}
-
-// Set the audio track language
-function setAudioTrackLanguage(languageCode: string | null) {
-    if (!player) {
-        console.error("Player is not initialized.");
-        return;
-    }
-
-    const audioTracks = (player as any).audioTracks();
-    if (!audioTracks || audioTracks.length === 0) {
-        console.warn("No audio tracks available.");
-        return;
-    }
-
-    // Decide before changing anything: disabling as we go leaves every track
-    // disabled when none matches, which silently starves the stream of audio.
-    const tracks: any[] = [];
-    for (let i = 0; i < audioTracks.length; i++) tracks.push(audioTracks[i]);
-
-    const match = pickAudioTrack(tracks, languageCode);
-    if (!match) {
-        console.warn(`No matching audio track found for language: ${languageCode}`);
-        return;
-    }
-
-    for (const track of tracks) track.enabled = track === match;
-}
-
-function syncKeepAudioStateAlive() {
-    const audio = keepAudioAlive.value;
-    if (!audioMode.value || !audio) return;
-
-    // If the player is playing, play the silent audio to keep the audio context alive (especially for iOS/Safari)
-    if (!player?.paused()) {
-        const playPromise = audio.play();
-        if (playPromise !== undefined) {
-            playPromise.catch((e) => {
-                console.warn("Silent audio play failed", e);
-            });
-        }
-    } else {
-        // Pause the silent audio if the player is paused
-        audio.pause();
-    }
-}
-
-function stopKeepAudioAlive() {
-    if (keepAudioAlive.value) {
-        keepAudioAlive.value.pause();
-        keepAudioAlive.value.currentTime = 0;
-    }
-}
-
-onMounted(async () => {
-    // Wait for next tick to ensure CSS is loaded and DOM is fully ready
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-
-    const videojs = (await import("video.js")).default;
-
-    // Lazy load videojs-youtube only if we're playing a YouTube video
-    if (isYouTube.value) {
-        await import("videojs-youtube");
-        // Wait for the YouTube plugin to fully register with VideoJS
-        // This prevents sequencing issues where the source is set before the plugin is ready
-        await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-
-    let options = {
-        fluid: false,
-        html5: {
-            vhs: {
-                overrideNative: true,
-                enableLowInitialPlaylist: true, // Retries failed playlist fetches, which could prevent stalls if the audio playlist (.aac) fails to load.
-                maxPlaylistRetries: 10, // Retries failed playlist fetches, which could prevent stalls if the audio playlist (.aac) fails to load.
-                useBandwidthFromLocalStorage: true, // Use the bandwidth from local storage to prevent stalls if the audio playlist (.aac) fails to load.
-                useDevicePixelRatio: true,
-            },
-            nativeAudioTracks: videojs.browser.IS_SAFARI,
-            nativeVideoTracks: videojs.browser.IS_SAFARI,
-        },
-        autoplay: autoPlay,
-        preload: "auto",
-        enableSmoothSeeking: true,
-        playbackRates: [0.5, 0.7, 1, 1.5],
-        controlBar: {
-            children: [
-                "audioTrackButton",
-                "playToggle",
-                "progressControl",
-                "liveDisplay",
-                "fullscreenToggle",
-                ...(isYouTube.value ? [] : ["pictureInPictureToggle"]), // Hide PiP for YouTube videos
-                "playbackRateMenuButton",
-                "volumePanel",
-                "skipBackwardButton",
-                "skipForward",
-                "skipBackward",
-            ],
-            skipButtons: {
-                forward: 10,
-                backward: 10,
-            },
-        },
-    };
-
-    // If statement is to protect from SSR issues
-    if (typeof window !== "undefined" && window.document) {
-        // videojs() throws on an element it does not recognise, and the throw
-        // escapes the mounted hook as an unhandled rejection rather than anything
-        // catchable by the caller. The ref is empty whenever the <video> has not
-        // been rendered — a v-if above it, or a teardown that raced the mount.
-        if (!playerElement.value) {
-            console.warn("VideoPlayer mounted without a <video> element; skipping setup.");
-            return;
-        }
-
-        player = videojs(playerElement.value, options);
-
-        // emit event with player on mount
-        const playerEvent = new CustomEvent("vjsPlayer", { detail: player });
-        window.dispatchEvent(playerEvent);
-
-        // Playback diagnostics. A stream that stops part-way looks identical from
-        // outside the browser whether the player errored, ran dry waiting for a
-        // segment, or decided the media had ended — and those need different fixes.
-        // Enable with ?playerdebug=true.
-        if (queryParams.get("playerdebug") === "true") {
-            const at = () => `t=${player?.currentTime()?.toFixed(2)}s`;
-            const log = (event: string, extra?: unknown) =>
-                console.log(`[player] ${event} ${at()}`, extra ?? "");
-
-            for (const event of ["waiting", "stalled", "ended", "pause", "suspend", "abort"]) {
-                player.on(event, () => log(event));
-            }
-            player.on("error", () => log("error", player?.error()));
-            player.on("loadedmetadata", () =>
-                log("loadedmetadata", { duration: player?.duration() }),
-            );
-            player.on("progress", () => {
-                const b = player?.buffered();
-                if (!b || b.length === 0) return log("progress", "nothing buffered");
-                log("progress", `buffered to ${b.end(b.length - 1).toFixed(2)}s`);
-            });
-            // VHS reports segment and playlist trouble the <video> element never sees.
-            player.on("loadeddata", () => {
-                const vhs = (player?.tech(true) as any)?.vhs;
-                if (!vhs) return log("loadeddata", "no VHS tech (not an HLS source?)");
-                for (const event of ["error", "retryplaylist", "usage"]) {
-                    vhs.on?.(event, (e: unknown) => log(`vhs:${event}`, e));
-                }
-                vhs.playlists?.on?.("error", () =>
-                    log("vhs:playlist-error", vhs.playlists?.error),
-                );
-            });
-        }
-
-        player.poster(px); // Set the player poster to a 1px transparent image to prevent the default poster from showing
-
-        // Set player source based on video type (YouTube vs regular)
-        const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-        if (isYouTube.value && props.content.video) {
-            // For YouTube videos, disable audio-only mode toggle since it's not supported for YouTube videos
-            showAudioModeToggle.value = false;
-
-            // Wait for player to be fully initialized before setting YouTube source
-            // This ensures proper sequencing for the YouTube plugin
-            await new Promise((resolve) => requestAnimationFrame(resolve));
-
-            // Configure YouTube player
-            player.src({
-                type: "video/youtube",
-                src: convertToVideoJSYouTubeUrl(props.content.video!),
-            });
-
-            // Handle YouTube-specific progress restoration
-            player.on("loadedmetadata", () => {
-                if (isYouTube.value && props.content.video) {
-                    const progress = getMediaProgress(props.content.video, props.content._id);
-                    if (progress > 60) {
-                        // Wait for YouTube iframe to be fully ready
-                        setTimeout(() => {
-                            player?.currentTime(progress - 30);
-                        }, 100);
-                    }
-                }
-            });
-
-            // Add explicit YouTube ended event listener
-            // YouTube fires its own events through the iframe
-            player.on("ended", () => {
-                if (props.content.video) {
-                    removeMediaProgress(props.content.video, props.content._id);
-                }
-            });
-        } else if (videoSource) {
-            player.src({ type: "application/x-mpegURL", src: videoSource });
-        }
-
-        // @ts-expect-error 2024-04-12 Workaround to get type checking to pass as we are not getting the mobileUi types import to work
-        player.mobileUi({
-            fullscreen: {
-                enterOnRotate: true,
-                exitOnRotate: true,
-                lockOnRotate: true,
-                lockToLandscapeOnEnter: true,
-                disabled: false,
-            },
-            touchControls: {
-                disabled: true,
-            },
-        });
-
-        // Ensure audio tracks are ready when metadata is loaded
-        // Skip if we're restoring a track from a mode switch
-        player.on("loadeddata", () => {
-            if (!isRestoringTrack.value) {
-                setAudioTrackLanguage(appLanguagesPreferredAsRef.value[0].languageCode || null);
-            }
-        });
-
-        // Ensure the audio track language is updated when entering fullscreen mode.
-        // This checks if the current language has changed since the last time it was set,
-        // and updates the audio track language accordingly.
-        let lastLanguageSet: string | null = null;
-
-        player.on("fullscreenchange", () => {
-            if (player?.isFullscreen()) {
-                const currentLanguage = appLanguagesPreferredAsRef.value[0].languageCode || null;
-                if (lastLanguageSet !== currentLanguage) {
-                    setAudioTrackLanguage(currentLanguage);
-                    lastLanguageSet = currentLanguage;
-                }
-            }
-        });
-
-        // Handle the "waiting" event, which occurs when the player is buffering
-        player.on("waiting", () => {
-            const currentTime = player?.currentTime() || 0; // Get the current playback time
-            setTimeout(() => {
-                // Check if the player is still stalled after 2 seconds
-                if (player?.currentTime() === currentTime && !player?.paused()) {
-                    console.warn("Player stalled, attempting to refresh buffer");
-
-                    // Slightly adjust the current time to refresh the buffer
-                    player?.currentTime(currentTime + 0.001);
-
-                    // Reapply the preferred audio track language only if not restoring
-                    if (!isRestoringTrack.value) {
-                        setAudioTrackLanguage(
-                            appLanguagesPreferredAsRef.value[0].languageCode || null,
-                        );
-                    }
-                }
-            }, 2000);
-        });
-
-        // Workaround to hide controls on inactive mousemove. As the controlbar looks at mouse hover (and our CSS changes the controlbar to fill the player), we need to trigger the userActive method to hide the controls
-        player.on(["mousemove", "click"], autoHidePlayerControls);
-
-        // Get player playing state
-        player.on("play", () => {
-            playerPlayEventHandler();
-
-            // If audio mode is enabled, sync the keep-alive audio state
-            if (audioMode.value) {
-                // Ensures user interaction already happened
-                requestAnimationFrame(() => {
-                    syncKeepAudioStateAlive();
-                });
-            }
-        });
-
-        // Get player user active states
-        player.on(["useractive", "userinactive"], playerUserActiveEventHandler);
-
-        // start video player analytics on mounted
-        // @ts-expect-error window is a native browser api, and matomo is attaching _paq to window
-        if (window._paq) {
-            // @ts-expect-error window is a native browser api, and matomo is attaching _paq to window
-            window._paq.push(
-                ["MediaAnalytics::enableMediaAnalytics"],
-                ["MediaAnalytics::scanForMedia", window.document],
-            );
-        }
-
-        // Track if we've already removed progress to avoid multiple removals
-        let progressRemoved = false;
-
-        // Save player progress if greater than 60 seconds
-        player.on("timeupdate", () => {
-            const currentTime = player?.currentTime() || 0;
-            const durationTime = player?.duration() || 0;
-
-            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-            if (durationTime == Infinity || !videoSource || currentTime < 60) return;
-
-            // For YouTube videos, aggressively check if we're at the end and remove progress
-            // This is a fallback in case the 'ended' event doesn't fire reliably for YouTube videos
-            if (isYouTube.value && durationTime > 0 && currentTime >= durationTime - 1) {
-                if (!progressRemoved) {
-                    // Video has reached the end, remove progress
-                    removeMediaProgress(props.content.video!, props.content._id);
-                    progressRemoved = true;
-                }
-                return;
-            }
-
-            // Reset the flag if we're not near the end
-            if (isYouTube.value && currentTime < durationTime - 2) {
-                progressRemoved = false;
-            }
-
-            setMediaProgress(videoSource, props.content._id, currentTime, durationTime);
-        });
-
-        // Get and apply the player saved progress (rewind 30 seconds)
-        player.on("ready", () => {
-            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-            if (!videoSource) return;
-
-            // For YouTube videos, wait for loadedmetadata to restore progress (iframe needs to be ready)
-            if (!isYouTube.value) {
-                const progress = getMediaProgress(videoSource, props.content._id);
-                if (progress > 60) player?.currentTime(progress - 30);
-            }
-        });
-
-        player.on("ended", () => {
-            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-            if (!videoSource) return;
-            stopKeepAudioAlive();
-
-            // Remove player progress when video fully completes (works for both regular and YouTube videos)
-            // The 'ended' event fires when the video reaches the end, regardless of video source
-            removeMediaProgress(videoSource, props.content._id);
-            progressRemoved = true;
-            // Finishing a video is a strong engagement signal — weight it above a plain
-            // open. This is the single completion call site (of the player's several
-            // `ended`/near-end listeners) that fires for every source, so affinity isn't
-            // double-counted for YouTube videos wired to more than one of them.
-            recordAffinity(props.content.parentTags, affinityConfig.value.eventWeight.completion);
-            // mediaProgress is a 10-slot ring buffer used only to resume playback,
-            // not a history — record completion in the durable seen store instead.
-            markSeen(props.content._id);
-
-            try {
-                player?.exitFullscreen();
-            } catch {
-                // Do nothing
-            }
-        });
-
-        player.on("pause", () => {
-            const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-            if (!videoSource) return;
-
-            if (audioMode.value) syncKeepAudioStateAlive();
-            if (autoFullscreen)
-                setTimeout(() => {
-                    if (!player?.paused()) return;
-                    try {
-                        player?.exitFullscreen();
-                    } catch {
-                        // Do nothing
-                    }
-                }, 500);
-        });
-    }
-});
-
-onUnmounted(() => {
-    stopKeepAudioAlive();
-
-    if (player) {
-        // Pause the player first
-        player.pause();
-
-        // Remove named event listeners before dispose
-        player.off(["mousemove", "click"], autoHidePlayerControls);
-        player.off("play", playerPlayEventHandler);
-        player.off(["useractive", "userinactive"], playerUserActiveEventHandler);
-
-        // Dispose of the player completely
-        player.dispose();
-        player = null;
-    }
-
-    // emit event when player is Destroyed
-    const playerDestroyEvent = new Event("vjsPlayerDestroyed");
-    window.dispatchEvent(playerDestroyEvent);
-});
-
-watch(audioMode, async (mode) => {
-    // Force audio-only mode to false for YouTube videos as it's not supported by YouTube
-    if (isYouTube.value) {
-        audioMode.value = false;
-    }
-
-    player?.audioOnlyMode(mode);
-    player?.audioPosterMode(mode);
-    player?.userActive(true);
-    playerUserActiveEventHandler();
-
-    // Save current time and selected track label/language
-    const currentTime = player?.currentTime() || 0;
-
-    let selectedTrackInfo: { label?: string; language?: string } | null = null;
-    const tracks = (player as any).audioTracks?.();
-    if (tracks) {
-        for (let i = 0; i < tracks.length; i++) {
-            if (tracks[i].enabled) {
-                selectedTrackInfo = {
-                    label: tracks[i].label,
-                    language: tracks[i].language,
-                };
-                break;
-            }
-        }
-    }
-
-    // Set flag to prevent automatic language setting from overwriting user's selection
-    // Set it before source change to ensure global loadeddata handler skips
-    if (selectedTrackInfo) {
-        isRestoringTrack.value = true;
-    }
-
-    // Generate the audio playlist with the currently selected track as default
-    // This ensures the player loads the correct track immediately without needing to switch
-    const videoSource = resolveVideoSource(props.content, mediaBucketBaseUrl.value);
-    let audioPlaylistUrl: string | null = null;
-    if (mode && videoSource) {
-        const audioMaster = await extractAndBuildAudioMaster(videoSource, selectedTrackInfo);
-        const base64 = btoa(
-            String.fromCharCode(
-                ...Array.from(new Uint8Array(new TextEncoder().encode(audioMaster))),
-            ),
-        );
-        audioPlaylistUrl = `data:application/x-mpegURL;base64,${base64}`;
-    }
-
-    /**
-     * When switching between audio and video modes, the player may introduce slight delays or offsets due to internal buffering, seeking, or reinitializing the media source.
-     * A small adjustment like 0.25 seconds helps ensure that the playback position remains consistent and avoids noticeable jumps forward or backward.
-     */
-    const adjustedTime = Math.max(0, currentTime - (mode ? AUDIO_MODE_TIME_ADJUSTMENT : 0));
-
-    // Helper function to restore the selected audio track when switching back to video mode
-    const restoreTrack = () => {
-        if (!selectedTrackInfo) return;
-        const newTracks = (player as any).audioTracks?.();
-        if (newTracks && newTracks.length > 0) {
-            for (let i = 0; i < newTracks.length; i++) {
-                const t = newTracks[i];
-                const langMatch = t.language === selectedTrackInfo.language;
-                const labelMatch = t.label === selectedTrackInfo.label;
-                t.enabled = langMatch || labelMatch;
-            }
-        }
-    };
-
-    // Set the adjusted time when metadata is loaded
-    player?.one("loadedmetadata", () => {
-        player?.currentTime(adjustedTime);
-        // When switching back to video mode, restore the selected track
-        if (!mode && selectedTrackInfo) restoreTrack();
-    });
-
-    // Clear the restoration flag once ready
-    player?.one("canplay", () => {
-        // For video mode, try restoring track again if it wasn't ready in loadedmetadata
-        if (!mode && selectedTrackInfo) {
-            restoreTrack();
-        }
-        isRestoringTrack.value = false;
-    });
-
-    // Set the player source - this triggers the listeners above
-    if (videoSource) {
-        player?.src({
-            type: "application/x-mpegURL",
-            src: mode ? audioPlaylistUrl! : videoSource,
-        });
-    }
-
-    // Immediately call play() to start loading and playing as soon as possible
-    // The player will handle buffering internally
-    const playPromise = player?.play();
-    if (playPromise !== undefined) {
-        playPromise.catch((error) => {
-            // Play was interrupted or failed, which is handled by our event listeners
-            console.debug("Initial play() interrupted:", error.message);
-        });
-    }
-
-    if (mode) {
-        syncKeepAudioStateAlive();
-    } else {
-        stopKeepAudioAlive();
-    }
-});
-
-// Watch the language prop and update the audio track language dynamically
-watch(
-    () => props.language,
-    (newLanguage) => {
-        if (newLanguage && player) {
-            setAudioTrackLanguage(newLanguage);
-        }
-    },
+/**
+ * The decryption key, once the server has handed it over.
+ *
+ * Encrypted media is encrypted at rest in the bucket and the document carries
+ * only `hlsKey_id`, so the key is fetched rather than read. Absent means
+ * "unencrypted, or not ours to have" — both of which are simply a source with no
+ * key, so the request failing is not an error path here.
+ */
+const keyHex = ref<string | undefined>(undefined);
+
+/**
+ * The language to select among the stream's audio tracks.
+ *
+ * The prop wins when the caller sets one; otherwise the viewer's first preferred
+ * app language. The player matches leniently — two- and three-letter codes, both
+ * ISO-639-2 sets — because browsers disagree about how they spell a track's
+ * language.
+ */
+const preferredLanguage = computed(
+    () => props.language || appLanguagesPreferredAsRef.value[0]?.languageCode || undefined,
 );
-</script>
 
-<style>
-@import "video.js/dist/video-js.min.css";
-@import "videojs-mobile-ui/dist/videojs-mobile-ui.css";
-@import "./VideoPlayer.css";
+const source = computed<PlayerSource | null>(() => {
+    const url = videoSource.value;
+    if (!url) return null;
+    return { masterUrl: url, keyHex: keyHex.value };
+});
 
-.audio-mode-toggle {
-    @apply !absolute right-2 top-2;
+/**
+ * Fetches the key for whatever document is being played.
+ *
+ * Runs before the source is built, so an encrypted stream is loaded once with
+ * its key rather than loaded, failed, and reloaded. A document with no key
+ * answers 404 and leaves `keyHex` undefined, which is the unencrypted case and
+ * needs no special handling.
+ */
+watch(
+    () => props.content?._id,
+    async (id) => {
+        keyHex.value = undefined;
+        if (!id || !props.content?.parentMedia?.hlsKey_id) return;
+        keyHex.value = (await getRest().getMediaKey(id))?.keyHex;
+    },
+    { immediate: true },
+);
+
+// --- resume position ------------------------------------------------------
+
+/**
+ * Whether the end-of-video cleanup has already run for this playthrough.
+ *
+ * YouTube's tech is known to drop `ended`, so completion is also detected from
+ * the position; without this the near-end detector would fire on every tick of
+ * the last second.
+ */
+let completed = false;
+
+/** Below this, a position is not worth resuming and is not recorded. */
+const MIN_RESUME_SECONDS = 60;
+/** Resuming lands slightly before where the viewer left, to re-establish context. */
+const RESUME_REWIND_SECONDS = 30;
+
+function onLoadedMetadata() {
+    completed = false;
+    const url = videoSource.value;
+    if (!url) return;
+
+    const progress = getMediaProgress(url, props.content._id);
+    if (progress > MIN_RESUME_SECONDS) player.value?.seek(progress - RESUME_REWIND_SECONDS);
+
+    if (autoPlay) void player.value?.play();
+    if (autoFullscreen) void player.value?.enterFullscreen();
 }
-</style>
+
+function onTimeUpdate(currentTime: number, duration: number) {
+    const url = videoSource.value;
+    if (!url || duration === Infinity || currentTime < MIN_RESUME_SECONDS) return;
+
+    // A fallback for an `ended` that never arrives, which is the normal case on
+    // YouTube. One second short of the duration is as close as a `timeupdate`
+    // reliably gets.
+    if (duration > 0 && currentTime >= duration - 1) {
+        if (!completed) onEnded();
+        return;
+    }
+
+    setMediaProgress(url, props.content._id, currentTime, duration);
+}
+
+function onEnded() {
+    const url = videoSource.value;
+    if (!url || completed) return;
+    completed = true;
+
+    removeMediaProgress(url, props.content._id);
+
+    // Finishing a video is a strong engagement signal — weighted above a plain
+    // open. Guarded by `completed` so the near-end fallback and a real `ended`
+    // cannot both count it.
+    recordAffinity(props.content.parentTags, affinityConfig.value.eventWeight.completion);
+
+    // mediaProgress is a 10-slot ring buffer used only to resume playback, not a
+    // history — record completion in the durable seen store instead.
+    markSeen(props.content._id);
+
+    player.value?.exitFullscreen();
+}
+</script>
 
 <template>
     <div class="relative bg-transparent md:rounded-lg">
@@ -617,45 +166,16 @@ watch(
         />
 
         <div class="video-player absolute bottom-0 left-0 right-0 top-0">
-            <video
-                playsinline
-                ref="playerElement"
-                class="video-js h-full w-full md:rounded-lg"
-                controls
-                preload="auto"
-                data-setup="{}"
-                v-bind:data-matomo-title="props.content.title"
-            ></video>
-        </div>
-
-        <!-- audio tag to keep player alive -->
-        <audio
-            ref="keepAudioAlive"
-            loop
-            muted
-            preload="auto"
-            style="display: none"
-        >
-            <source
-                src="../../assets/silence.wav"
-                type="audio/wav"
+            <LuminaryPlayer
+                v-if="source"
+                ref="player"
+                :source="source"
+                :preferred-language="preferredLanguage"
+                :data-matomo-title="content.title"
+                @loadedmetadata="onLoadedMetadata"
+                @timeupdate="onTimeUpdate"
+                @ended="onEnded"
             />
-        </audio>
-
-        <transition
-            leave-active-class="transition ease-in duration-500"
-            leave-from-class="opacity-100"
-            enter-to-class="opacity-100"
-            enter-active-class="transition ease-out duration-100"
-            leave-to-class="opacity-0"
-            enter-from-class="opacity-0"
-        >
-            <AudioVideoToggle
-                v-if="showAudioModeToggle && !isYouTube"
-                v-model="audioMode"
-                ref="audioModeToggle"
-                class="audio-mode-toggle"
-            ></AudioVideoToggle>
-        </transition>
+        </div>
     </div>
 </template>

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -68,6 +68,16 @@ const preferredLanguage = computed(
     () => props.language || appLanguagesPreferredAsRef.value[0]?.languageCode || undefined,
 );
 
+/**
+ * Which of the player's own controls this app offers.
+ *
+ * The subtitles menu is off because the app's control bar has never had one, and
+ * Luminary ships no sidecar subtitles: video.js would hide the button today
+ * anyway, but the first stream carrying a caption track would otherwise put a
+ * new control in front of every viewer without anyone deciding to.
+ */
+const controls = { subtitlesMenu: false };
+
 const source = computed<PlayerSource | null>(() => {
     const url = videoSource.value;
     if (!url) return null;
@@ -171,6 +181,7 @@ function onEnded() {
                 ref="player"
                 :source="source"
                 :preferred-language="preferredLanguage"
+                :controls="controls"
                 :data-matomo-title="content.title"
                 @loadedmetadata="onLoadedMetadata"
                 @timeupdate="onTimeUpdate"

--- a/shared/src/api/RestApi.ts
+++ b/shared/src/api/RestApi.ts
@@ -86,6 +86,11 @@ export type EncoderConfigResponse = {
     publicBaseUrl: string;
 };
 
+/** The decryption key for one media collection, as 32 hex characters. */
+export type MediaKeyResponse = {
+    keyHex: string;
+};
+
 class RestApi {
     private http: HttpReq<any>;
     /**
@@ -129,6 +134,25 @@ class RestApi {
     async getStorageStatus(bucketId: string): Promise<StorageStatusResponse | undefined> {
         return await this.http.getWithQueryParams("storage/storagestatus", {
             bucketId,
+            apiVersion: "0.0.0",
+        });
+    }
+
+    /**
+     * The AES-128 decryption key for a document's media collection, as 32 hex
+     * characters.
+     *
+     * Encrypted HLS is encrypted at rest in the bucket, and documents carry only
+     * `hlsKey_id` — an id, not a secret — so the key has to be asked for. The
+     * server hands it to anyone who may view the document and to nobody else.
+     *
+     * `undefined` covers both "this media is not encrypted" and "you may not see
+     * it", which are the same answer from the caller's side: play what the
+     * playlists give you and let playback fail if they turn out to need a key.
+     */
+    async getMediaKey(docId: string): Promise<MediaKeyResponse | undefined> {
+        return await this.http.getWithQueryParams("media/key", {
+            docId,
             apiVersion: "0.0.0",
         });
     }


### PR DESCRIPTION
Closes the first of #1900's two open items. The second — "add optional non-fullscreen controls" — comes free: it was written against `player-web`, where the controls are a fullscreen overlay, and `player-web-legacy` has video.js draw its control bar inline in every mode.

## The player

`VideoPlayer.vue` now renders `LuminaryPlayer` from `@luminary-media-converter/player-web-legacy` instead of assembling video.js itself. Viewers should see no difference — replicating this skin is the reason that package exists.

The app stops owning: control-bar layout, auto-hiding controls, the iOS keep-alive audio element, rotation and fullscreen handling, audio-track selection by preferred language, the stall nudge, audio-only mode, and the whole YouTube branch. **661 lines become 181.**

It keeps what is Luminary's rather than a player's: which URL to play, where the key comes from, the resume point, and the engagement a finished video records.

## The key — the part that was missing

Encrypted HLS is encrypted at rest in the bucket, and the key is stored as a crypto object that is never replicated. Documents carry only `hlsKey_id`, an id and not a secret. **Nothing served the key to a client, so every encrypted collection was undecryptable by every player** — the encoder could produce it and nothing could watch it. That is not on #1900's list; it turned up while wiring the swap.

`GET /media/key?docId=` closes it. Key delivery, not a second layer of access control: anything a viewer may watch, they may be handed the key for, so the permission checked is exactly `View` on the parent Post or Tag. Denial answers the same 404 as a missing document, so the endpoint is not a probe for which documents exist; an unreadable key answers 409, since that is not "no key was ever set".

## Worth a real look before this goes further

Audio-only changes mechanism — the library switches to the audio-only pseudo-angle through the controller instead of building a data-URI audio master. Same intent, different route, and no test will catch a difference. Nobody has yet watched an encrypted multi-angle stream play through this player.

## Verification

- app: 110 files, 931 passed, 1 skipped
- api endpoints + document processing: 269 passed; `processImageDto.spec.ts` fails needing a live MinIO, and is untouched by this
- `vue-tsc` clean across app and shared

## Left in place, awaiting your word

The swap orphans six files. I have not deleted them:

- `app/src/components/content/extractAndBuildAudioMaster.ts` (+ spec)
- `app/src/components/content/audioTrackLanguage.ts` (+ spec)
- `app/src/components/form/AudioVideoToggle.vue` (+ spec)
- `app/src/util/youtube.ts` (+ spec)
- `app/src/components/content/VideoPlayer.css`
- `app/src/components/content/px.png`

Each has no referrer outside its own spec. Say the word and they go in a follow-up commit.