### PR TITLE
feat(cms): preview a video before publishing it

### DIFF
--- a/api/src/endpoints/mediaKey.controller.spec.ts
+++ b/api/src/endpoints/mediaKey.controller.spec.ts
@@ -70,6 +70,16 @@ describe("MediaKeyController", () => {
         expect(mockRetrieveCryptoData).toHaveBeenCalledWith(expect.anything(), "crypto-1");
     });
 
+    it("hands the key to an editor who may see the document in the CMS", async () => {
+        // CmsView without View: an editor previewing media they are about to
+        // publish. Denying it would mean the CMS could not play what it just
+        // encoded.
+        mockGetDoc.mockResolvedValue({ docs: [contentDoc()] });
+        mockVerifyAccess.mockImplementation((_g, _t, permission) => permission === "cmsView");
+
+        expect((await get()).status).toBe(200);
+    });
+
     it("checks View on the parent type, not on the content document", async () => {
         // Content is not separately permissioned — that is why memberOf is copied
         // down onto it — so the permission that decides this is the parent's.

--- a/api/src/endpoints/mediaKey.controller.ts
+++ b/api/src/endpoints/mediaKey.controller.ts
@@ -22,11 +22,18 @@ export type MediaKeyResponseDto = {
  * undecryptable by every client, which is where this started.
  *
  * This is key *delivery*, not access control over the media itself: anything a
- * viewer may watch, they may also be handed the key for. The permission checked
- * is therefore exactly the one that decides whether they may see the document —
- * `View` on the parent Post or Tag — and no other. Anything stricter would deny
- * the key for content already on the viewer's screen; anything looser would
- * hand out keys for content they cannot see.
+ * caller may see, they may also be handed the key for. The permission checked is
+ * therefore exactly the one that decides whether the document is visible to
+ * them, and no other. Anything stricter would deny the key for content already
+ * on their screen; anything looser would hand out keys for content they cannot
+ * see.
+ *
+ * That is two permissions rather than one, because there are two ways to be
+ * shown a document: `View` is the app's, `CmsView` is the editor's, and an
+ * editor previewing media they are about to publish holds the second without
+ * necessarily holding the first. Either suffices, and no request parameter
+ * chooses between them — a caller cannot claim to be the CMS to gain anything,
+ * since both are checked against the groups they actually hold.
  *
  * The key is as recoverable as the media is watchable, and no more: it protects
  * bytes sitting in a public bucket from being played by whoever finds the URL.
@@ -70,11 +77,13 @@ export class MediaKeyController {
         const parentType: DocType =
             doc.type === DocType.Content ? (doc.parentType ?? DocType.Post) : doc.type;
 
-        const hasPermission = PermissionSystem.verifyAccess(
-            doc.memberOf ?? [],
-            parentType,
-            AclPermission.View,
-            userDetails.groups,
+        const hasPermission = [AclPermission.View, AclPermission.CmsView].some((permission) =>
+            PermissionSystem.verifyAccess(
+                doc.memberOf ?? [],
+                parentType,
+                permission,
+                userDetails.groups,
+            ),
         );
 
         // Deliberately the same 404 a missing document gets. Distinguishing them

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,7 +12,11 @@ RUN npm run build
 # player-core and hls-core underneath it.
 WORKDIR /media-convert
 COPY ./media-convert ./
-RUN npm ci
+# ci:libs, not ci: a plain install pulls in electron and electron-builder and
+# downloads the Electron binary — around 500 MB to produce five small
+# libraries and a desktop app this image will never run. The workspace list
+# lives beside build:libs in the submodule, so the two cannot drift.
+RUN npm run ci:libs
 RUN npm run build:libs
 
 # Build the app

--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -12,7 +12,11 @@ RUN npm run build
 # player-core and hls-core underneath it.
 WORKDIR /media-convert
 COPY ./media-convert ./
-RUN npm ci
+# ci:libs, not ci: a plain install pulls in electron and electron-builder and
+# downloads the Electron binary — around 500 MB to produce five small
+# libraries and a desktop app this image will never run. The workspace list
+# lives beside build:libs in the submodule, so the two cannot drift.
+RUN npm run ci:libs
 RUN npm run build:libs
 
 # Build the CMS

--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -6,6 +6,15 @@ COPY ./shared ./
 RUN npm ci
 RUN npm run build
 
+# Build the encoder's player libraries. They ship only dist/, and cms depends on
+# player-web-legacy by path (file:../media-convert/player-web-legacy), so this
+# has to happen before cms installs. The submodule's own workspace links resolve
+# player-core and hls-core underneath it.
+WORKDIR /media-convert
+COPY ./media-convert ./
+RUN npm ci
+RUN npm run build:libs
+
 # Build the CMS
 WORKDIR /cms
 COPY ./cms/package*.json ./

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -7,6 +7,7 @@
             "name": "luminary-cms",
             "dependencies": {
                 "@dagrejs/dagre": "^3.0.0",
+                "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
                 "@sentry/vue": "^7.110.1",
                 "@tailwindcss/forms": "^0.5.10",
                 "@tiptap/extension-link": "^2.26.1",
@@ -71,6 +72,32 @@
                 "vitest": "^1.6.1",
                 "vue-tsc": "^1.8.27",
                 "wait-for-expect": "^3.0.2"
+            }
+        },
+        "../media-convert/player-web-legacy": {
+            "name": "@luminary-media-converter/player-web-legacy",
+            "version": "0.0.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@luminary-media-converter/player-core": "file:../player-core",
+                "iso-639-2": "^3.0.2",
+                "video.js": "8.23.4",
+                "videojs-mobile-ui": "1.1.1",
+                "videojs-youtube": "3.0.1"
+            },
+            "devDependencies": {
+                "@vitejs/plugin-vue": "^5.2.0",
+                "@vue/test-utils": "^2.4.0",
+                "jsdom": "^26.0.0",
+                "typescript": "~5.7.0",
+                "vite": "^6.0.0",
+                "vite-plugin-css-injected-by-js": "^3.5.0",
+                "vitest": "^3.0.0",
+                "vue": "^3.5.0",
+                "vue-tsc": "^2.2.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
             }
         },
         "../shared": {
@@ -2589,6 +2616,10 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@luminary-media-converter/player-web-legacy": {
+            "resolved": "../media-convert/player-web-legacy",
+            "link": true
         },
         "node_modules/@mixmark-io/domino": {
             "version": "2.2.0",

--- a/cms/package.json
+++ b/cms/package.json
@@ -32,6 +32,7 @@
         "lodash-es": "^4.17.21",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
+        "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
         "luminary-shared": "file:../shared",
         "luxon": "^3.4.4",
         "oidc-client-ts": "^3.5.0",

--- a/cms/src/components/content/EditContentVideo.vue
+++ b/cms/src/components/content/EditContentVideo.vue
@@ -2,6 +2,7 @@
 import LDialog from "@/components/common/LDialog.vue";
 import LCard from "@/components/common/LCard.vue";
 import LInput from "@/components/forms/LInput.vue";
+import VideoPreview from "./VideoPreview.vue";
 import { VideoCameraIcon, LinkIcon, KeyIcon } from "@heroicons/vue/20/solid";
 import { type ContentParentDto } from "luminary-shared";
 import { computed, ref, watch } from "vue";
@@ -147,6 +148,8 @@ watch(
             nothing keeps a copy of it. Warned at the moment of typing rather
             than on save, because by then the old key is already gone.
         -->
+        <VideoPreview :parent="parent" />
+
         <p
             v-if="hasStoredKey && replacingKey"
             class="text-xs font-medium text-amber-600 dark:text-amber-500"

--- a/cms/src/components/content/VideoPreview.spec.ts
+++ b/cms/src/components/content/VideoPreview.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import VideoPreview from "./VideoPreview.vue";
+
+const getMediaKeyMock = vi.hoisted(() => vi.fn());
+const getBucketByIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@luminary-media-converter/player-web-legacy", async () => {
+    const { defineComponent, h } = await import("vue");
+    return {
+        LuminaryPlayer: defineComponent({
+            name: "LuminaryPlayer",
+            props: { source: { type: Object, required: true }, controls: { type: Object, default: undefined } },
+            setup: () => () => h("div", { class: "player-stub" }),
+        }),
+    };
+});
+
+vi.mock("luminary-shared", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("luminary-shared")>()),
+    getRest: () => ({ getMediaKey: getMediaKeyMock }),
+}));
+
+vi.mock("@/composables/storageSelection", () => ({
+    storageSelection: () => ({ getBucketById: getBucketByIdMock }),
+}));
+
+const parent = (media: Record<string, unknown> | undefined) =>
+    ({ _id: "post-1", mediaBucketId: "bucket-1", media }) as any;
+
+const player = (wrapper: any) => wrapper.findComponent({ name: "LuminaryPlayer" });
+
+async function mountAndOpen(media: Record<string, unknown> | undefined) {
+    const wrapper = mount(VideoPreview, { props: { parent: parent(media) } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await wrapper.find('[data-test="video-preview-load"]').trigger("click");
+    return wrapper;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getBucketByIdMock.mockReturnValue({ publicUrl: "https://cdn.example.com/media" });
+    getMediaKeyMock.mockResolvedValue(undefined);
+});
+
+describe("VideoPreview", () => {
+    it("offers nothing when the document has no video", () => {
+        const wrapper = mount(VideoPreview, { props: { parent: parent(undefined) } });
+
+        expect(wrapper.find('[data-test="video-preview"]').exists()).toBe(false);
+    });
+
+    it("does not fetch anything until asked", async () => {
+        // An editor opens many documents and previews few; a preview that plays
+        // itself is a surprise in a form.
+        const wrapper = mount(VideoPreview, {
+            props: { parent: parent({ hlsUrl: "/abc/master.m3u8" }) },
+        });
+
+        expect(player(wrapper).exists()).toBe(false);
+        expect(wrapper.find('[data-test="video-preview-load"]').exists()).toBe(true);
+    });
+
+    it("resolves a bucket-relative URL through the bucket's public URL", async () => {
+        const wrapper = await mountAndOpen({ hlsUrl: "/abc/master.m3u8" });
+
+        expect(player(wrapper).props("source").masterUrl).toBe(
+            "https://cdn.example.com/media/abc/master.m3u8",
+        );
+    });
+
+    it("leaves media hosted elsewhere alone", async () => {
+        // An external collection has no bucket to be relative to.
+        const wrapper = await mountAndOpen({ hlsUrl: "https://other.example.com/x/master.m3u8" });
+
+        expect(player(wrapper).props("source").masterUrl).toBe(
+            "https://other.example.com/x/master.m3u8",
+        );
+    });
+
+    it("uses a key the editor has just typed, before it is ever saved", async () => {
+        // Checking a key before committing it is the point of previewing.
+        const wrapper = await mountAndOpen({ hlsUrl: "/abc/master.m3u8", hlsKey: "a".repeat(32) });
+
+        expect(player(wrapper).props("source").keyHex).toBe("a".repeat(32));
+        expect(getMediaKeyMock).not.toHaveBeenCalled();
+    });
+
+    it("fetches a saved key, which the document cannot show again", async () => {
+        getMediaKeyMock.mockResolvedValue({ keyHex: "b".repeat(32) });
+
+        const wrapper = await mountAndOpen({ hlsUrl: "/abc/master.m3u8", hlsKey_id: "crypto-1" });
+
+        expect(getMediaKeyMock).toHaveBeenCalledWith("post-1");
+        expect(player(wrapper).props("source").keyHex).toBe("b".repeat(32));
+    });
+
+    it("prefers the typed key over the saved one", async () => {
+        // The editor is replacing it; previewing the old one would check the
+        // wrong thing.
+        getMediaKeyMock.mockResolvedValue({ keyHex: "b".repeat(32) });
+
+        const wrapper = await mountAndOpen({
+            hlsUrl: "/abc/master.m3u8",
+            hlsKey: "a".repeat(32),
+            hlsKey_id: "crypto-1",
+        });
+
+        expect(player(wrapper).props("source").keyHex).toBe("a".repeat(32));
+    });
+
+    it("keeps the subtitles menu out, as the app does", async () => {
+        const wrapper = await mountAndOpen({ hlsUrl: "/abc/master.m3u8" });
+
+        expect(player(wrapper).props("controls")).toEqual({ subtitlesMenu: false });
+    });
+
+    it("closes again when the collection changes", async () => {
+        // A different collection is a different thing to check.
+        const wrapper = await mountAndOpen({ hlsUrl: "/abc/master.m3u8" });
+        expect(player(wrapper).exists()).toBe(true);
+
+        await wrapper.setProps({ parent: parent({ hlsUrl: "/def/master.m3u8" }) });
+
+        expect(player(wrapper).exists()).toBe(false);
+    });
+});

--- a/cms/src/components/content/VideoPreview.vue
+++ b/cms/src/components/content/VideoPreview.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+/**
+ * Plays the video an editor has just pointed a document at.
+ *
+ * The URL and key fields say what *should* play; nothing said whether it does.
+ * An encoded collection can carry a wrong key, a path that 404s, or angles that
+ * never made it to the bucket, and every one of those looks identical in a text
+ * input — the editor finds out when a reader does.
+ *
+ * The same player the app uses, so what an editor checks here is what a viewer
+ * gets, rather than a second implementation that agrees right up until it does
+ * not.
+ */
+import { computed, ref, watch } from "vue";
+import { LuminaryPlayer, type PlayerSource } from "@luminary-media-converter/player-web-legacy";
+import { type ContentParentDto, getRest } from "luminary-shared";
+import { storageSelection } from "@/composables/storageSelection";
+import { toAbsoluteMediaUrl } from "@/util/mediaUrl";
+
+type Props = {
+    parent: ContentParentDto | undefined;
+};
+const props = defineProps<Props>();
+
+const { getBucketById } = storageSelection();
+
+/**
+ * The URL to play.
+ *
+ * Stored relative to the bucket, so it is resolved the same way the app resolves
+ * it — through the bucket's public URL. A collection hosted elsewhere is already
+ * absolute and passes through untouched.
+ */
+const masterUrl = computed(() => {
+    const url = props.parent?.media?.hlsUrl;
+    if (!url) return undefined;
+    const bucket = getBucketById(props.parent?.mediaBucketId ?? null);
+    return toAbsoluteMediaUrl(url, bucket?.publicUrl);
+});
+
+/**
+ * The key, as the player needs it.
+ *
+ * An unsaved key is in hand and is used directly — that is the whole point of
+ * previewing before saving. A saved one is never readable again from the
+ * document, so it is fetched; the server hands it to an editor who may see the
+ * document.
+ */
+const storedKey = ref<string | undefined>(undefined);
+
+watch(
+    () => [props.parent?._id, props.parent?.media?.hlsKey_id] as const,
+    async ([id, keyId]) => {
+        storedKey.value = undefined;
+        if (!id || !keyId) return;
+        storedKey.value = (await getRest().getMediaKey(id))?.keyHex;
+    },
+    { immediate: true },
+);
+
+const keyHex = computed(() => props.parent?.media?.hlsKey || storedKey.value);
+
+const source = computed<PlayerSource | null>(() =>
+    masterUrl.value ? { masterUrl: masterUrl.value, keyHex: keyHex.value } : null,
+);
+
+/**
+ * Loaded on request rather than on sight.
+ *
+ * Opening a document should not start fetching segments from a bucket — an
+ * editor opens many and previews few, and a preview that plays itself is a
+ * surprise in a form.
+ */
+const showing = ref(false);
+
+// A different document, or a different collection on the same one, is a
+// different thing to check.
+watch(masterUrl, () => (showing.value = false));
+</script>
+
+<template>
+    <div v-if="source" class="pt-2" data-test="video-preview">
+        <button
+            v-if="!showing"
+            type="button"
+            class="text-sm font-medium text-zinc-600 underline underline-offset-2 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
+            data-test="video-preview-load"
+            @click="showing = true"
+        >
+            Preview this video
+        </button>
+
+        <div v-else class="overflow-hidden rounded-md bg-black">
+            <LuminaryPlayer
+                :source="source"
+                :controls="{ subtitlesMenu: false }"
+                data-test="video-preview-player"
+            />
+        </div>
+    </div>
+</template>

--- a/cms/src/util/mediaUrl.ts
+++ b/cms/src/util/mediaUrl.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolving a stored media URL for playback in the CMS.
+ *
+ * `hlsUrl` is stored relative to the bucket the document names, so that the two
+ * cannot drift when a bucket is renamed or re-pointed. A player needs the
+ * absolute form, and the bucket's `publicUrl` is what turns one into the other.
+ *
+ * The rule is the API's — `api/src/changeRequests/documentProcessing/mediaUrl.ts`
+ * decides the stored shape on save, and this is its inverse. The app resolves
+ * the same way in `util/videoSource.ts`. Three readers of one convention; if it
+ * ever grows a case, it belongs in `luminary-shared` rather than in a fourth
+ * copy.
+ */
+
+/** Whether a stored URL is a path inside the document's own bucket. */
+export function isBucketRelative(url: string | undefined): boolean {
+    return typeof url === "string" && url.startsWith("/");
+}
+
+/**
+ * The absolute URL a player should fetch, given what is stored.
+ *
+ * An already-absolute URL is returned untouched — media hosted elsewhere has no
+ * bucket to be relative to — so a caller can apply this to every media URL
+ * without first asking which kind it holds. A relative URL with no bucket to
+ * resolve against is `undefined` rather than a broken path: there is no address
+ * to fetch, and half of one is worse than none.
+ */
+export function toAbsoluteMediaUrl(
+    stored: string | undefined,
+    publicUrl: string | undefined,
+): string | undefined {
+    if (!stored || !isBucketRelative(stored)) return stored;
+    if (!publicUrl) return undefined;
+    return `${publicUrl.replace(/\/+$/, "")}${stored}`;
+}


### PR DESCRIPTION
Stacked on #1913, which is where the player and the key endpoint arrive.

## Why

`EditContentVideo.vue` has a URL field and a key field, and no way to find out whether they work. A wrong key, a path that 404s, and angles that never reached the bucket look identical in a text input — the editor learns about it when a reader does.

## What

A `Preview this video` control under the fields, playing through the same `LuminaryPlayer` the app uses. Same player means what an editor checks is what a viewer gets, rather than a second implementation that agrees right up until it does not.

It loads on request rather than on sight: an editor opens many documents and previews few, and a form that starts pulling segments from a bucket when it renders is a surprise. It closes again when the collection changes, because that is a different thing to check.

**The key comes from whichever source has it.** A key the editor has just typed is used directly — checking one before committing it is the point — and a saved key, which the document can never show again, is fetched from `GET /media/key`.

## One widening to the key endpoint

It checked `View`, which is the app's permission. An editor previewing media they are about to publish holds `CmsView`, and may not hold `View`. Either now suffices.

No request parameter chooses between them, so a caller cannot claim to be the CMS to gain anything — both are checked against the groups they actually hold.

## Also

- `cms/package.json` and `cms/Dockerfile` gain the submodule dependency, deliberately left out of #1911 when the CMS had no player to put it in.
- `cms/src/util/mediaUrl.ts` resolves a bucket-relative URL, the inverse of the rule the API applies on save. That is now three readers of one convention — the API, the app, and this — and the file says so: a fourth means it belongs in `luminary-shared`.

## Verification

- cms: 126 files, 1042 passed
- api: mediaKey 9 passed
- `vue-tsc` clean