### PR TITLE
test(api): fix two sidecar specs that fail on a clean run

### DIFF
--- a/api/src/changeRequests/documentProcessing/processPostTagDto.sidecar.spec.ts
+++ b/api/src/changeRequests/documentProcessing/processPostTagDto.sidecar.spec.ts
@@ -95,7 +95,9 @@ describe("processPostTagDto — sidecar lifecycle", () => {
         const result = await processChangeRequest("test-user", del, ["group-super-admins"], db);
 
         expect(result.result.ok).toBe(true);
-        expect(result.warnings.filter((w) => w.includes("sidecar"))).toEqual([]);
+        // `warnings` is omitted entirely when there are none — processChangeRequest
+        // only assigns it for a non-empty array — and a clean delete produces none.
+        expect((result.warnings ?? []).filter((w) => w.includes("sidecar"))).toEqual([]);
         expect((await db.getDoc(id)).docs).toHaveLength(0);
     });
 

--- a/api/src/endpoints/sidecar.controller.spec.ts
+++ b/api/src/endpoints/sidecar.controller.spec.ts
@@ -415,7 +415,12 @@ describe("SidecarController", () => {
         });
 
         it("records a read strike on a successful fetch, keyed by the caller's identity", async () => {
+            // Both, because the second assertion below is a negative one and the
+            // suite clears nothing between tests: the eight 403/404 cases above
+            // have already struck as "test-user", so an uncleared probe mock
+            // arrives pre-called and the assertion fails on the strike they left.
             rateLimiter.recordReadStrike.mockClear();
+            rateLimiter.recordProbeStrike.mockClear();
             await get({ parentId: "post-sc-live", sidecarType: SidecarType.HlsEncryptionKey });
             expect(rateLimiter.recordReadStrike).toHaveBeenCalledWith("test-user");
             expect(rateLimiter.recordProbeStrike).not.toHaveBeenCalledWith("test-user");


### PR DESCRIPTION
The two failing specs from my review of #1915, fixed. Into your branch rather than pushed onto it, since you have been pushing to it all morning and I did not want to land on top of your working copy — take it, cherry-pick it, or ignore it and fix them your own way.

Both are spec defects. The code they cover is correct in both cases.

**`sidecar.controller.spec.ts`** — the read-strike test asserts `recordProbeStrike` was *not* called, but nothing clears it. The suite sets no `clearMocks` and its `beforeEach` resets only `requestUser`, so the eight 403/404 cases above have already struck as `"test-user"` and the negative assertion fails on strikes they left behind. The three sibling tests below it clear both mocks; this one cleared only the read mock. `recordProbeStrike` is unreachable on the 200 path — only `probeFail` calls it — so the assertion is right and its setup was not.

**`processPostTagDto.sidecar.spec.ts`** — `result.warnings.filter(...)` throws `Cannot read properties of undefined`. `processChangeRequest.ts:174` assigns `res.warnings` only when the array is non-empty, and a clean delete produces none. Guarded with `?? []`, so the assertion still means "no sidecar warnings" whether the field is absent or present.

## What I could not do

**I have not run these.** Both suites need a live CouchDB on 5984 and Docker is down on my machine — every test in them errors with `ECONNREFUSED` regardless of the fix, so a green run here would have proved nothing anyway. What I did instead:

- `tsc --noEmit` over `api/` — both specs compile.
- Re-read the code each fix depends on: `processChangeRequest.ts:174` for the `warnings` premise, and the three sibling tests in the same describe block that already clear both mocks for the other.

So please run them before merging. If your CI reports more than these two failing, I have not seen that output — I found two on `3144f71d` and confirmed both still live on `ac305b97`.

Unrelated but worth knowing: `s3.service.spec.ts` and `processImageDto.spec.ts` fail identically on the base branch (39 tests, needing a live MinIO), so they are not yours.