### PR TITLE
ci: give the workflows a way to clone the encoder submodule

### DIFF
--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -34,9 +34,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/,
-          # which is a submodule rather than a published package.
+          # The encoder's player packages are consumed from media-convert/, which is
+          # a submodule rather than a published package.
+          #
+          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
+          # scoped to this repository alone — a private sibling answers "Repository
+          # not found", so the clone fails before any step runs. The token below is
+          # a credential with read access to that repo. If the encoder repository is
+          # ever made public, this line can go and `submodules: true` is enough.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -23,9 +23,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/,
-          # which is a submodule rather than a published package.
+          # The encoder's player packages are consumed from media-convert/, which is
+          # a submodule rather than a published package.
+          #
+          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
+          # scoped to this repository alone — a private sibling answers "Repository
+          # not found", so the clone fails before any step runs. The token below is
+          # a credential with read access to that repo. If the encoder repository is
+          # ever made public, this line can go and `submodules: true` is enough.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cms-deploy-staging.yml
+++ b/.github/workflows/cms-deploy-staging.yml
@@ -33,6 +33,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # The encoder's player packages are consumed from media-convert/, which is
+          # a submodule rather than a published package.
+          #
+          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
+          # scoped to this repository alone — a private sibling answers "Repository
+          # not found", so the clone fails before any step runs. The token below is
+          # a credential with read access to that repo. If the encoder repository is
+          # ever made public, this line can go and `submodules: true` is enough.
+          submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -22,6 +22,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # The encoder's player packages are consumed from media-convert/, which is
+          # a submodule rather than a published package.
+          #
+          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
+          # scoped to this repository alone — a private sibling answers "Repository
+          # not found", so the clone fails before any step runs. The token below is
+          # a credential with read access to that repo. If the encoder repository is
+          # ever made public, this line can go and `submodules: true` is enough.
+          submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
CI has been failing on every PR against this branch — including #1915, which is how it surfaced. Two defects, both mine, from the submodule integration in #1911 and #1914.

## The app workflows ask for the submodule and cannot have it

`luminary-media-convert` is **private**, and a workflow's `GITHUB_TOKEN` is scoped to `bccsa/luminary` alone. A private sibling repository answers `Repository not found`, so checkout aborts in six seconds — before a single test runs:

```
Cloning into '/home/runner/work/luminary/luminary/media-convert'...
remote: Repository not found.
fatal: clone of 'https://github.com/bccsa/luminary-media-convert.git' ... failed
```

## The CMS workflows do not ask for it at all

#1914 added the dependency to `cms/package.json` and `cms/Dockerfile` and nowhere else. So `@luminary-media-converter/player-web-legacy` fails to resolve and every suite reaching `VideoPreview.vue` dies on import — ten of them, including all the `EditContent` specs that have nothing to do with media. `cms-deploy-staging.yml` would have failed the same way on its next run.

## What this does

All four workflows now check out the submodule with `token: ${{ secrets.MEDIA_CONVERT_TOKEN }}`.

**This needs a secret that does not exist yet** — a PAT or deploy key with read access to `bccsa/luminary-media-convert`, added to this repository as `MEDIA_CONVERT_TOKEN`. Until it exists these workflows fail exactly as they do now; nothing gets worse, and the moment it exists they pass.

If the encoder repository is ever made public, the `token:` line can be deleted and `submodules: true` is sufficient on its own. That is the cleaner end state, but it is a decision for the encoder's owners rather than something to assume here.

## How this got missed

I verified the submodule resolved in both Docker images and in a local install, and did not check the workflows. Both Docker builds pass because the submodule is already on disk when they run — the failure only exists where the checkout is fresh, which is precisely CI.