### PR TITLE
ci: fall back to the built-in token when the submodule secret is unset

### DIFF
--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -40,10 +40,16 @@ jobs:
           # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
           # scoped to this repository alone — a private sibling answers "Repository
           # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo. If the encoder repository is
-          # ever made public, this line can go and `submodules: true` is enough.
+          # a credential with read access to that repo.
+          #
+          # It falls back to the built-in token because `actions/checkout` rejects an
+          # empty `token:` outright — "Input required and not supplied" — which would
+          # break this repository's own checkout while the secret is unset, rather
+          # than leaving only the submodule to fail. With the fallback an unset secret
+          # degrades to exactly the previous behaviour. If the encoder repository is
+          # ever made public, the whole line can go and `submodules: true` suffices.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -29,10 +29,16 @@ jobs:
           # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
           # scoped to this repository alone — a private sibling answers "Repository
           # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo. If the encoder repository is
-          # ever made public, this line can go and `submodules: true` is enough.
+          # a credential with read access to that repo.
+          #
+          # It falls back to the built-in token because `actions/checkout` rejects an
+          # empty `token:` outright — "Input required and not supplied" — which would
+          # break this repository's own checkout while the secret is unset, rather
+          # than leaving only the submodule to fail. With the fallback an unset secret
+          # degrades to exactly the previous behaviour. If the encoder repository is
+          # ever made public, the whole line can go and `submodules: true` suffices.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cms-deploy-staging.yml
+++ b/.github/workflows/cms-deploy-staging.yml
@@ -40,10 +40,16 @@ jobs:
           # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
           # scoped to this repository alone — a private sibling answers "Repository
           # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo. If the encoder repository is
-          # ever made public, this line can go and `submodules: true` is enough.
+          # a credential with read access to that repo.
+          #
+          # It falls back to the built-in token because `actions/checkout` rejects an
+          # empty `token:` outright — "Input required and not supplied" — which would
+          # break this repository's own checkout while the secret is unset, rather
+          # than leaving only the submodule to fail. With the fallback an unset secret
+          # degrades to exactly the previous behaviour. If the encoder repository is
+          # ever made public, the whole line can go and `submodules: true` suffices.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -29,10 +29,16 @@ jobs:
           # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
           # scoped to this repository alone — a private sibling answers "Repository
           # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo. If the encoder repository is
-          # ever made public, this line can go and `submodules: true` is enough.
+          # a credential with read access to that repo.
+          #
+          # It falls back to the built-in token because `actions/checkout` rejects an
+          # empty `token:` outright — "Input required and not supplied" — which would
+          # break this repository's own checkout while the secret is unset, rather
+          # than leaving only the submodule to fail. With the fallback an unset secret
+          # degrades to exactly the previous behaviour. If the encoder repository is
+          # ever made public, the whole line can go and `submodules: true` suffices.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN }}
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Correcting #1918, which I got wrong.

`actions/checkout` rejects an empty `token:` outright rather than treating it as absent:

```
##[error]Input required and not supplied: token
```

So pointing it at a secret that does not exist yet did not leave the submodule clone to fail on its own, which is what I claimed on that PR. It failed **this repository's own checkout**, before any step ran — a worse failure than the one it replaced, even though both end in a red job.

`secrets.MEDIA_CONVERT_TOKEN || github.token` restores the intended behaviour:

- **Secret unset** — identical to before the token was introduced: the repository clones with the built-in token and only the private submodule is refused.
- **Secret set** — both the repository and the submodule clone.

Found by reading the actual runs on the merge commit instead of trusting what I had written in #1918's description.