### PR TITLE
ci: the encoder submodule is public, drop the token workaround

### DIFF
--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -35,21 +35,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           # The encoder's player packages are consumed from media-convert/, which is
-          # a submodule rather than a published package.
-          #
-          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
-          # scoped to this repository alone — a private sibling answers "Repository
-          # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo.
-          #
-          # It falls back to the built-in token because `actions/checkout` rejects an
-          # empty `token:` outright — "Input required and not supplied" — which would
-          # break this repository's own checkout while the secret is unset, rather
-          # than leaving only the submodule to fail. With the fallback an unset secret
-          # degrades to exactly the previous behaviour. If the encoder repository is
-          # ever made public, the whole line can go and `submodules: true` suffices.
+          # a submodule rather than a published package. The submodule repository is
+          # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -24,21 +24,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           # The encoder's player packages are consumed from media-convert/, which is
-          # a submodule rather than a published package.
-          #
-          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
-          # scoped to this repository alone — a private sibling answers "Repository
-          # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo.
-          #
-          # It falls back to the built-in token because `actions/checkout` rejects an
-          # empty `token:` outright — "Input required and not supplied" — which would
-          # break this repository's own checkout while the secret is unset, rather
-          # than leaving only the submodule to fail. With the fallback an unset secret
-          # degrades to exactly the previous behaviour. If the encoder repository is
-          # ever made public, the whole line can go and `submodules: true` suffices.
+          # a submodule rather than a published package. The submodule repository is
+          # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cms-deploy-staging.yml
+++ b/.github/workflows/cms-deploy-staging.yml
@@ -35,21 +35,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           # The encoder's player packages are consumed from media-convert/, which is
-          # a submodule rather than a published package.
-          #
-          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
-          # scoped to this repository alone — a private sibling answers "Repository
-          # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo.
-          #
-          # It falls back to the built-in token because `actions/checkout` rejects an
-          # empty `token:` outright — "Input required and not supplied" — which would
-          # break this repository's own checkout while the secret is unset, rather
-          # than leaving only the submodule to fail. With the fallback an unset secret
-          # degrades to exactly the previous behaviour. If the encoder repository is
-          # ever made public, the whole line can go and `submodules: true` suffices.
+          # a submodule rather than a published package. The submodule repository is
+          # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -24,21 +24,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           # The encoder's player packages are consumed from media-convert/, which is
-          # a submodule rather than a published package.
-          #
-          # `luminary-media-convert` is private, and a workflow's GITHUB_TOKEN is
-          # scoped to this repository alone — a private sibling answers "Repository
-          # not found", so the clone fails before any step runs. The token below is
-          # a credential with read access to that repo.
-          #
-          # It falls back to the built-in token because `actions/checkout` rejects an
-          # empty `token:` outright — "Input required and not supplied" — which would
-          # break this repository's own checkout while the secret is unset, rather
-          # than leaving only the submodule to fail. With the fallback an unset secret
-          # degrades to exactly the previous behaviour. If the encoder repository is
-          # ever made public, the whole line can go and `submodules: true` suffices.
+          # a submodule rather than a published package. The submodule repository is
+          # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
-          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
`luminary-media-convert` is public as of today. Before flipping it: full-history sweep for secret-shaped values (placeholders only — `change-me-to-a-random-secret` and friends), no key/credential files ever committed, no history rewrite (luminary pins its commits by SHA, so a rewrite would break every submodule pointer). Secret scanning and push protection are enabled on it now that it is public.

A public submodule clones with the workflow's built-in token, so `MEDIA_CONVERT_TOKEN` is no longer referenced and the secret never has to be created. This PR's own checks are the proof: the App and CMS jobs run the exact checkout that has been failing since #1911.