### PR TITLE
ci: build the encoder's libraries before running app and cms tests

### DIFF
--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -36,6 +36,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: app/package-lock.json
 
+      - name: Build the encoder's player libraries
+        # The submodule's packages ship only dist/, which is gitignored — a fresh
+        # checkout has sources and no entry points, and Vite fails with "Failed to
+        # resolve entry for package". ci:libs installs the five library workspaces
+        # without electron; build:libs builds them. Same as both Dockerfiles.
+        run: npm run ci:libs; npm run build:libs;
+        working-directory: media-convert
+
       - name: Build shared dependencies
         run: npm ci; npm run build;
         working-directory: shared

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -36,6 +36,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: cms/package-lock.json
 
+      - name: Build the encoder's player libraries
+        # The submodule's packages ship only dist/, which is gitignored — a fresh
+        # checkout has sources and no entry points, and Vite fails with "Failed to
+        # resolve entry for package". ci:libs installs the five library workspaces
+        # without electron; build:libs builds them. Same as both Dockerfiles.
+        run: npm run ci:libs; npm run build:libs;
+        working-directory: media-convert
+
       - name: Build shared dependencies
         run: npm ci; npm run build;
         working-directory: shared


### PR DESCRIPTION
With the submodule public, CI got past the clone for the first time — and hit the next missing piece: the packages ship only `dist/`, which is gitignored, so Vite fails with "Failed to resolve entry for package @luminary-media-converter/player-web-legacy". Both Dockerfiles already run `ci:libs` + `build:libs` in the submodule; the unit-test workflows now do the same. Verification is #1910's next check run, which exercises exactly this path.