### PR TITLE
feat(cms): request encryption again, and retire the workarounds it forced

### DIFF
--- a/cms/src/composables/useMediaEncoder.spec.ts
+++ b/cms/src/composables/useMediaEncoder.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * One assertion, on the value that was wrong for months.
+ *
+ * `encryption: { required: … }` was switched off while the app played HLS with
+ * hls.js, which cannot read LMCENC playlists. Nothing pinned it, so the switch
+ * outlived its reason: the player gained a decryption layer and the CMS carried
+ * on asking for plaintext output, leaving the whole key path — sidecars, masking,
+ * `GET /sidecar` — unused in production.
+ *
+ * A test rather than a comment, because a comment is what it had.
+ */
+const createEncoderSessionMock = vi.hoisted(() => vi.fn());
+const getEncoderConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/util/mediaEncoder", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/util/mediaEncoder")>()),
+    createEncoderSession: createEncoderSessionMock,
+    checkEncoderHealth: vi.fn().mockResolvedValue({ available: true, apiVersion: "0.0.1" }),
+    subscribeToEncoderSession: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("luminary-shared", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("luminary-shared")>()),
+    getRest: () => ({ getEncoderConfig: getEncoderConfigMock }),
+}));
+
+import { useMediaEncoder } from "./useMediaEncoder";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getEncoderConfigMock.mockResolvedValue({
+        s3: { endPoint: "s3.example.com", bucket: "media" },
+        publicBaseUrl: "https://cdn.example.com/media",
+    });
+    // Never resolves further; the assertion is about what was requested.
+    createEncoderSessionMock.mockResolvedValue({ sessionId: "s1", readToken: "r1" });
+});
+
+describe("useMediaEncoder", () => {
+    it("asks the encoder to encrypt", async () => {
+        const { start } = useMediaEncoder();
+
+        await start({
+            documentId: "post-1",
+            title: "Episode 1",
+            mediaBucketId: "bucket-1",
+            onMediaReady: vi.fn(),
+        }).catch(() => {
+            // The session opens an event stream this test does not drive; only the
+            // request shape matters here.
+        });
+
+        expect(createEncoderSessionMock).toHaveBeenCalledWith(
+            expect.objectContaining({ encryption: { required: true } }),
+        );
+    });
+});

--- a/cms/src/composables/useMediaEncoder.ts
+++ b/cms/src/composables/useMediaEncoder.ts
@@ -84,14 +84,12 @@ export function useMediaEncoder() {
                 title: options.title,
                 s3: config.s3,
                 publicBaseUrl: config.publicBaseUrl,
-                // TEMPORARY: no encryption requested. An encrypted collection has
-                // LMCENC-encrypted playlists and an `#EXT-X-KEY` naming
-                // `luminary://key`, neither of which the app's current video.js /
-                // hls.js player can read — it fails parsing the master before the
-                // key is even relevant. Set this back to `{ required: true }` as
-                // part of adopting player-web.
-                // See docs/guides/media-encoder-integration.md
-                encryption: { required: false },
+                // A requirement, not a key policy: the encoder generates and holds
+                // the key either way. Encryption was switched off while the app
+                // still played HLS with hls.js, which cannot read LMCENC playlists;
+                // it now plays through `player-web-legacy`, which decrypts them and
+                // fetches the key from the sidecar endpoint (ADR 0019).
+                encryption: { required: true },
             });
 
             sessionId.value = session.sessionId;

--- a/docs/adr/0019-hls-encryption-keys-as-non-replicated-sidecars.md
+++ b/docs/adr/0019-hls-encryption-keys-as-non-replicated-sidecars.md
@@ -122,10 +122,13 @@ permission check and the absence of a bulk read path do.*
 - **Offline playback of encrypted media** is out of scope here. Persisting keys client-side is the
   only way an offline-first app plays encrypted downloads offline, and it partly undoes the
   no-bulk-extraction property.
-- **No end-to-end verification yet.** The consumer (the app player's decryption layer) does not
-  exist on this branch; encryption is currently switched off in the encoder. The endpoint will sit
-  unused until that lands, which is an argument for building it correctly and cheaply — not for not
-  building it. The round-trip tests substitute for end-to-end verification.
+- **~~No end-to-end verification yet.~~** Resolved after this ADR was accepted. The consumer landed
+  (`VideoPlayer.vue` renders `LuminaryPlayer`, which decrypts LMCENC playlists and takes the key
+  from this endpoint), and encryption is requested again in `useMediaEncoder.ts`. Verified against a
+  real encoder session: an LMCENC-encrypted collection in S3, the key held only in a sidecar, the
+  document carrying just `hlsKey_id` — `GET /sidecar` unmasked to exactly the key the encoder
+  generated, and the video played in the app in a browser. The round-trip tests are no longer
+  standing in for end-to-end verification; both exist.
 
 ## Related
 

--- a/docs/guides/media-encoder-integration.md
+++ b/docs/guides/media-encoder-integration.md
@@ -36,51 +36,43 @@ uploaded through this API.
 same fields the encoder writes — so a hand-entered collection and an encoded one are
 indistinguishable downstream.
 
-## Temporary — remove when `player-web` is adopted
+## The player, and what adopting it retired
 
-The app plays HLS with video.js / hls.js. That player cannot read an **encrypted** collection:
-the playlists are LMCENC-encrypted (so it receives ciphertext on an HTTP 200 and fails parsing
-the master) and `#EXT-X-KEY` names the `luminary://key` sentinel, which a browser cannot fetch.
-Decryption has to happen before hls.js sees the bytes, which is what `player-core` adds.
+The app and the CMS play HLS through `LuminaryPlayer` from the encoder's
+`player-web-legacy` package — Video.js 8 over the shared `player-core` pipeline. It
+decrypts LMCENC playlists before the engine sees them and serves the AES key from
+memory for the `luminary://key` sentinel, which is what makes an encrypted
+collection playable at all. `player-web-legacy` rather than `player-web` (the hls.js
+build) because it reproduces the chrome the app already drew, so the swap was
+invisible to viewers.
 
-Everything in this section exists only because that integration has not happened yet.
+Encryption is requested on every session (`encryption: { required: true }` in
+[`useMediaEncoder.ts`](../../cms/src/composables/useMediaEncoder.ts)). The CMS states
+a *requirement*; the encoder still generates and holds the key, and delivers it to
+entitled callers through the sidecar endpoint — see
+[ADR 0019](../adr/0019-hls-encryption-keys-as-non-replicated-sidecars.md).
 
-| # | What | Where | Remove by |
-|---|------|-------|-----------|
-| 1 | **Encryption is not requested.** `encryption: { required: false }` on every session, so output is plaintext and the current player can read it. | [`useMediaEncoder.ts`](../../cms/src/composables/useMediaEncoder.ts) | Setting it back to `{ required: true }` |
-| 2 | **Player debug logging**, behind `?playerdebug=true`. | [`VideoPlayer.vue`](../../app/src/components/content/VideoPlayer.vue) | Deleting the block |
-| 3 | **Plaintext shim objects in S3.** Prefixes ending `-plaintext/` holding decrypted playlists **and a published `key.bin`**. Written by hand for two collections encoded before item 1 was in place. | The media bucket, not this repo | Deleting those prefixes |
+Three workarounds existed while the old player could not read encrypted output. Two
+are gone:
 
-**Item 3 is the one to be uncomfortable about.** Publishing the decryption key as a public
-object beside the video makes the encryption decorative — precisely what the encoder refuses to
-do by design. It exists only so two already-encrypted test collections could be played, it was
-never applied to anything but local dev, and it must not be reproduced. With item 1 in place no
-new collection needs it.
+| # | What it was | Status |
+|---|-------------|--------|
+| 1 | `encryption: { required: false }` on every session, so output was plaintext | **Removed.** Encryption is requested again, and pinned by a test so it cannot drift back unnoticed. |
+| 2 | Player debug logging behind `?playerdebug=true` | **Removed** with the player swap; the old `VideoPlayer.vue` that carried it is gone. |
+| 3 | **Plaintext shim objects in S3** — prefixes ending `-plaintext/` holding decrypted playlists **and a published `key.bin`** | **Outstanding, outside this repo.** See below. |
 
-Also temporary in the sense that `player-core` replaces the code, though both are genuine bug
-fixes worth keeping until then:
+### Item 3 — the published keys
 
-- **All audio tracks disabled when none matches the app language** — `setAudioTrackLanguage`
-  disabled tracks as it walked the list, so an encode whose audio groups are quality tiers
-  (`HD`, `Standard`, `Bandwidth Saving`, no `LANGUAGE` attribute) left the stream with no audio
-  rendition. Playback stalled a few seconds in and the stall handler looped. Now the choice is
-  made first (`pickAudioTrack`) and no match leaves the player's own selection alone.
-- **Audio-only master built with one variant per track** instead of one per group, so several
-  renditions of one group each became a variant while all still named that group — the player
-  played a variant *and* the group's default rendition. Also declared `#EXT-X-VERSION:4` for
-  playlists using `#EXT-X-MAP`, which needs 6 or higher. See
-  [`extractAndBuildAudioMaster.ts`](../../app/src/components/content/extractAndBuildAudioMaster.ts).
+Publishing a decryption key as a public object beside the video makes the encryption
+decorative, which is precisely what the encoder refuses to do by design. These were
+written by hand for two collections encoded before item 1 was in place, and the
+practice must not be reproduced — no new collection needs it.
 
-## Blocked on
-
-**`player-web` / `player-core` / `hls` are `private: true` and published to no registry**, so
-Luminary cannot depend on them. Open-sourcing them is a prerequisite; the integration itself is
-planned with Ivan.
-
-Adopting them removes, in one step: the LMCENC limitation, the published key, the per-encode
-shim, and the need to keep encryption switched off. They also bring angle extraction, quality
-capping, chapters, subtitles, recovery policy and a "not available yet" state that polls until
-the playlist appears.
+They live in a media bucket rather than in this repository, so removing them is a
+bucket operation someone with access has to perform: **delete any prefix ending
+`-plaintext/`, and confirm no `key.bin` remains published anywhere in the media
+buckets.** It was believed to be local-dev only; that belief has not been verified
+against the real buckets, and until it is, this stays open.
 
 ## Not done yet
 


### PR DESCRIPTION
Separate PR, because this turns something on rather than tidying something up.

## What changes

`useMediaEncoder.ts` sends `encryption: { required: true }` again. **Every new encode the CMS starts will produce an encrypted collection.** Existing plaintext collections keep playing — the player handles both — but from here the sidecar path is load-bearing for real content, where so far only test material has exercised it.

## Why now

Encryption was switched off while the app played HLS with hls.js, which cannot read LMCENC playlists: it receives ciphertext on an HTTP 200 and fails parsing the master before the key matters. That is no longer the player. The app renders `LuminaryPlayer` from `player-web-legacy`, which decrypts the playlists and takes the key from `GET /sidecar`.

**The switch outlived its reason because nothing pinned it** — `encryption.required` had no test, only a comment saying to set it back. So the decryption layer landed, the sidecar service shipped, and the CMS carried on asking for plaintext. There is a test now.

## Verified end to end, not inferred

Against a real encoder session, before making this change:

| Step | Result |
| --- | --- |
| Encoder wrote an encrypted collection to S3 | `master.m3u8` begins `LMCENC01` |
| Document carries no key | `hlsKey_id` only; the key is in a sidecar |
| `GET /sidecar` unmasked | exact match with the encoder's key |
| Playback in the app, in a browser | plays |

## Documentation

The guide's **"Temporary — remove when `player-web` is adopted"** section listed three workarounds. Two retire here: the disabled encryption, and the `?playerdebug=true` block that went with the old player. Its **"Blocked on"** section is deleted — it said the player packages were private and unpublishable, and the encoder repository is public now.

**The third stays open, deliberately visible:** plaintext shim prefixes in S3 ending `-plaintext/`, holding decrypted playlists *and a published `key.bin`*. Publishing a key beside the video makes the encryption decorative. It is a bucket operation outside this repository, so the guide now says exactly what has to happen — delete any `-plaintext/` prefix and confirm no `key.bin` remains published — rather than dropping it from a list nobody reads again. It was believed local-dev only; that belief is unverified against the real buckets.

ADR 0019's "no end-to-end verification yet" consequence is struck through with what replaced it, since it was accurate when Dirk wrote it and is not now.

## Suggested before merge

One CMS-initiated encode, watched end to end, so the first encrypted collection a real editor produces is one somebody watched being produced.

cms: 127 files, 1048 passed.