### PR TITLE
build: rename the submodule directory to luminary-media-convert

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,10 +7,10 @@
 
 # Test fixtures and desktop build output from the encoder submodule: large,
 # and nothing in an image needs them.
-media-convert/test-media
-media-convert/app-electron/bin
-media-convert/app-electron/release
-media-convert/api/work
+luminary-media-convert/test-media
+luminary-media-convert/app-electron/bin
+luminary-media-convert/app-electron/release
+luminary-media-convert/api/work
 
 # NOT .env: the deploy workflow writes app/.env immediately before `docker build`,
 # and the PWA plugin reads its icon paths from it. Excluding it here would fail

--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/, which is
+          # The encoder's player packages are consumed from luminary-media-convert/, which is
           # a submodule rather than a published package. The submodule repository is
           # public, so the built-in token suffices; no extra credential is needed.
           submodules: true

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/, which is
+          # The encoder's player packages are consumed from luminary-media-convert/, which is
           # a submodule rather than a published package. The submodule repository is
           # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
@@ -42,7 +42,7 @@ jobs:
         # resolve entry for package". ci:libs installs the five library workspaces
         # without electron; build:libs builds them. Same as both Dockerfiles.
         run: npm run ci:libs; npm run build:libs;
-        working-directory: media-convert
+        working-directory: luminary-media-convert
 
       - name: Build shared dependencies
         run: npm ci; npm run build;

--- a/.github/workflows/cms-deploy-staging.yml
+++ b/.github/workflows/cms-deploy-staging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/, which is
+          # The encoder's player packages are consumed from luminary-media-convert/, which is
           # a submodule rather than a published package. The submodule repository is
           # public, so the built-in token suffices; no extra credential is needed.
           submodules: true

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from media-convert/, which is
+          # The encoder's player packages are consumed from luminary-media-convert/, which is
           # a submodule rather than a published package. The submodule repository is
           # public, so the built-in token suffices; no extra credential is needed.
           submodules: true
@@ -42,7 +42,7 @@ jobs:
         # resolve entry for package". ci:libs installs the five library workspaces
         # without electron; build:libs builds them. Same as both Dockerfiles.
         run: npm run ci:libs; npm run build:libs;
-        working-directory: media-convert
+        working-directory: luminary-media-convert
 
       - name: Build shared dependencies
         run: npm ci; npm run build;

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "luminary-media-convert"]
-	path = media-convert
+	path = luminary-media-convert
 	url = https://github.com/bccsa/luminary-media-convert.git
 	branch = luminary-1897-encrypted-hls

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,11 +7,11 @@ RUN npm ci
 RUN npm run build
 
 # Build the encoder's player libraries. They ship only dist/, and app depends on
-# player-web-legacy by path (file:../media-convert/player-web-legacy), so this
+# player-web-legacy by path (file:../luminary-media-convert/player-web-legacy), so this
 # has to happen before app installs. The submodule's own workspace links resolve
 # player-core and hls-core underneath it.
-WORKDIR /media-convert
-COPY ./media-convert ./
+WORKDIR /luminary-media-convert
+COPY ./luminary-media-convert ./
 # ci:libs, not ci: a plain install pulls in electron and electron-builder and
 # downloads the Electron binary — around 500 MB to produce five small
 # libraries and a desktop app this image will never run. The workspace list

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,7 +7,7 @@
             "name": "luminary-app",
             "dependencies": {
                 "@headlessui/vue": "^1.7.19",
-                "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
+                "@luminary-media-converter/player-web-legacy": "file:../luminary-media-convert/player-web-legacy",
                 "@sentry/vue": "^7.110.1",
                 "@vueuse/core": "^10.9.0",
                 "dexie": "^4.0.11",
@@ -71,7 +71,7 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
-        "../media-convert/player-web-legacy": {
+        "../luminary-media-convert/player-web-legacy": {
             "name": "@luminary-media-converter/player-web-legacy",
             "version": "0.0.1",
             "license": "Apache-2.0",
@@ -2642,7 +2642,7 @@
             }
         },
         "node_modules/@luminary-media-converter/player-web-legacy": {
-            "resolved": "../media-convert/player-web-legacy",
+            "resolved": "../luminary-media-convert/player-web-legacy",
             "link": true
         },
         "node_modules/@nodelib/fs.scandir": {

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.19",
-        "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
+        "@luminary-media-converter/player-web-legacy": "file:../luminary-media-convert/player-web-legacy",
         "@sentry/vue": "^7.110.1",
         "@vueuse/core": "^10.9.0",
         "dexie": "^4.0.11",

--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -7,11 +7,11 @@ RUN npm ci
 RUN npm run build
 
 # Build the encoder's player libraries. They ship only dist/, and cms depends on
-# player-web-legacy by path (file:../media-convert/player-web-legacy), so this
+# player-web-legacy by path (file:../luminary-media-convert/player-web-legacy), so this
 # has to happen before cms installs. The submodule's own workspace links resolve
 # player-core and hls-core underneath it.
-WORKDIR /media-convert
-COPY ./media-convert ./
+WORKDIR /luminary-media-convert
+COPY ./luminary-media-convert ./
 # ci:libs, not ci: a plain install pulls in electron and electron-builder and
 # downloads the Electron binary — around 500 MB to produce five small
 # libraries and a desktop app this image will never run. The workspace list

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -7,7 +7,7 @@
             "name": "luminary-cms",
             "dependencies": {
                 "@dagrejs/dagre": "^3.0.0",
-                "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
+                "@luminary-media-converter/player-web-legacy": "file:../luminary-media-convert/player-web-legacy",
                 "@sentry/vue": "^7.110.1",
                 "@tailwindcss/forms": "^0.5.10",
                 "@tiptap/extension-link": "^2.26.1",
@@ -74,7 +74,7 @@
                 "wait-for-expect": "^3.0.2"
             }
         },
-        "../media-convert/player-web-legacy": {
+        "../luminary-media-convert/player-web-legacy": {
             "name": "@luminary-media-converter/player-web-legacy",
             "version": "0.0.1",
             "license": "Apache-2.0",
@@ -2618,7 +2618,7 @@
             }
         },
         "node_modules/@luminary-media-converter/player-web-legacy": {
-            "resolved": "../media-convert/player-web-legacy",
+            "resolved": "../luminary-media-convert/player-web-legacy",
             "link": true
         },
         "node_modules/@mixmark-io/domino": {

--- a/cms/package.json
+++ b/cms/package.json
@@ -32,7 +32,7 @@
         "lodash-es": "^4.17.21",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
-        "@luminary-media-converter/player-web-legacy": "file:../media-convert/player-web-legacy",
+        "@luminary-media-converter/player-web-legacy": "file:../luminary-media-convert/player-web-legacy",
         "luminary-shared": "file:../shared",
         "luxon": "^3.4.4",
         "oidc-client-ts": "^3.5.0",


### PR DESCRIPTION
`media-convert/` named the checkout after neither the repository it comes from (`bccsa/luminary-media-convert`) nor the packages it provides (`@luminary-media-converter/*`) — three near-identical names with no rule connecting them.

**The pin is untouched:** still `23288e8`, verified equal before and after.

Worth knowing for anyone repeating this: `git mv media-convert luminary-media-convert` **nested** the submodule inside a new directory rather than renaming it, leaving `.gitmodules` pointing at `luminary-media-convert/media-convert` and the contents untracked. This went through `deinit` → `rm --cached` → re-add at the new path → checkout of the recorded commit instead.

Everything that referenced the path moved with it:

- `.gitmodules` — `path` only; the URL is unchanged
- both `Dockerfile`s — `WORKDIR`, `COPY`, and the comment naming the `file:` dependency
- both `package.json`s — `file:../luminary-media-convert/player-web-legacy`
- the four workflows that check out and build it
- `.dockerignore`

Lockfiles were **regenerated by npm**, not hand-edited, so their `resolved` paths are npm's own.

The `@luminary-media-converter` npm scope is deliberately unchanged — only the directory moved.

## Verification

- Submodule libraries build at the new path; `app/node_modules/@luminary-media-converter/player-web-legacy` resolves to `../../../luminary-media-convert/player-web-legacy`
- cms: 126 files, 1047 passed
- app: 106 files, 901 passed, 1 skipped

One full app run failed on `SingleContent.spec.ts > switches the language of content` (`translation options should be at least 2: expected 0`). It passes in isolation three times over and on two subsequent full runs, and asserts on translation options rather than anything path-related — a pre-existing flake, not this change.