### PR TITLE
test(app): wait for the language options instead of a single tick

### DIFF
--- a/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
+++ b/app/src/pages/SingleContent/__tests__/SingleContent.spec.ts
@@ -661,11 +661,16 @@ describe("SingleContent", () => {
         // Open the language dropdown (click the DropdownMenu trigger that has the toggle handler)
         const dropdownMenu = wrapper!.findComponent(DropdownMenu);
         await dropdownMenu.find("[role='button']").trigger("click");
-        await nextTick();
 
-        // Options are in the dropdown panel (role=menu)
-        const options = wrapper!.findAll("[role='menu'] button");
-        expect(options.length, "translation options should be at least 2").toBeGreaterThan(1);
+        // Waited for, not ticked past: the options come from translations loaded
+        // out of IndexedDB, the same asynchronous source the two waits above
+        // exist for. A single `nextTick` wins that race on a fast machine and
+        // loses it on a slower one.
+        let options = wrapper!.findAll("[role='menu'] button");
+        await waitForExpect(() => {
+            options = wrapper!.findAll("[role='menu'] button");
+            expect(options.length, "translation options should be at least 2").toBeGreaterThan(1);
+        });
 
         // Choose the French option explicitly if present, otherwise pick the second option
         const frenchOption =


### PR DESCRIPTION
The one flaky test in the app suite. It opens the language dropdown, waits a single `nextTick`, then asserts at least two options exist — but the options come from translations loaded out of IndexedDB, the same asynchronous source the two `waitForExpect` blocks above it exist for.

Failed once in a full run with `expected 0 to be greater than 1`; passes in isolation three times and on every subsequent full run. A timing guess rather than a wait for the asserted thing, so it will fail CI eventually and look like a real breakage in language switching.

Verified: the spec three times in isolation, and the full app suite twice — exit 0, 901 passed.