### PR TITLE
ci: the encoder submodule is private again, restore the token

### DIFF
--- a/.github/workflows/app-deploy-staging.yml
+++ b/.github/workflows/app-deploy-staging.yml
@@ -34,10 +34,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from luminary-media-convert/, which is
-          # a submodule rather than a published package. The submodule repository is
-          # public, so the built-in token suffices; no extra credential is needed.
+          # The encoder's player packages are consumed from luminary-media-convert/,
+          # which is a submodule rather than a published package.
+          #
+          # That repository is private, and a workflow's GITHUB_TOKEN reaches only the
+          # repository it runs in — a private sibling answers "Repository not found"
+          # and checkout aborts before any step runs. MEDIA_CONVERT_TOKEN is a
+          # credential with read access to it.
+          #
+          # The fallback matters: `actions/checkout` rejects an empty `token:`
+          # outright ("Input required and not supplied"), which would break this
+          # repository's own checkout while the secret is unset, rather than leaving
+          # only the submodule to fail.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/app-unit-tests.yml
+++ b/.github/workflows/app-unit-tests.yml
@@ -23,10 +23,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from luminary-media-convert/, which is
-          # a submodule rather than a published package. The submodule repository is
-          # public, so the built-in token suffices; no extra credential is needed.
+          # The encoder's player packages are consumed from luminary-media-convert/,
+          # which is a submodule rather than a published package.
+          #
+          # That repository is private, and a workflow's GITHUB_TOKEN reaches only the
+          # repository it runs in — a private sibling answers "Repository not found"
+          # and checkout aborts before any step runs. MEDIA_CONVERT_TOKEN is a
+          # credential with read access to it.
+          #
+          # The fallback matters: `actions/checkout` rejects an empty `token:`
+          # outright ("Input required and not supplied"), which would break this
+          # repository's own checkout while the secret is unset, rather than leaving
+          # only the submodule to fail.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cms-deploy-staging.yml
+++ b/.github/workflows/cms-deploy-staging.yml
@@ -34,10 +34,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from luminary-media-convert/, which is
-          # a submodule rather than a published package. The submodule repository is
-          # public, so the built-in token suffices; no extra credential is needed.
+          # The encoder's player packages are consumed from luminary-media-convert/,
+          # which is a submodule rather than a published package.
+          #
+          # That repository is private, and a workflow's GITHUB_TOKEN reaches only the
+          # repository it runs in — a private sibling answers "Repository not found"
+          # and checkout aborts before any step runs. MEDIA_CONVERT_TOKEN is a
+          # credential with read access to it.
+          #
+          # The fallback matters: `actions/checkout` rejects an empty `token:`
+          # outright ("Input required and not supplied"), which would break this
+          # repository's own checkout while the secret is unset, rather than leaving
+          # only the submodule to fail.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Create .env file
         run: |

--- a/.github/workflows/cms-unit-tests.yml
+++ b/.github/workflows/cms-unit-tests.yml
@@ -23,10 +23,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          # The encoder's player packages are consumed from luminary-media-convert/, which is
-          # a submodule rather than a published package. The submodule repository is
-          # public, so the built-in token suffices; no extra credential is needed.
+          # The encoder's player packages are consumed from luminary-media-convert/,
+          # which is a submodule rather than a published package.
+          #
+          # That repository is private, and a workflow's GITHUB_TOKEN reaches only the
+          # repository it runs in — a private sibling answers "Repository not found"
+          # and checkout aborts before any step runs. MEDIA_CONVERT_TOKEN is a
+          # credential with read access to it.
+          #
+          # The fallback matters: `actions/checkout` rejects an empty `token:`
+          # outright ("Input required and not supplied"), which would break this
+          # repository's own checkout while the secret is unset, rather than leaving
+          # only the submodule to fail.
           submodules: true
+          token: ${{ secrets.MEDIA_CONVERT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
The encoder repository was made public this afternoon and private again this evening, so the workflows need the credential back — this reverses #1920.

**CI will be red until `MEDIA_CONVERT_TOKEN` exists.** A PAT or deploy key with read access to `bccsa/luminary-media-convert`, added to this repository as that secret. App and CMS checkout fails on the submodule clone until then; this is accepted, not a regression to investigate.

`|| github.token` is load-bearing rather than defensive: `actions/checkout` rejects an empty `token:` outright ("Input required and not supplied"), so pointing at a secret that does not exist would break this repository's *own* checkout rather than leaving only the private submodule to fail. That was #1919's lesson, learned the hard way.

A fine-grained PAT scoped to that one repository with `Contents: Read-only` is the narrowest option; a read-only deploy key avoids account-wide reach but needs an SSH setup step instead of `token:` — say which and I will adjust.