### PR TITLE
fix(app): close the per-route JSDOM in the SSG prerender (#1936)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -55,6 +55,7 @@
                 "fake-indexeddb": "^6.2.5",
                 "jsdom": "^23.2.0",
                 "npm-run-all2": "^6.2.6",
+                "patch-package": "^8.0.1",
                 "postcss": "^8.5.4",
                 "prettier": "^3.0.3",
                 "prettier-plugin-tailwindcss": "^0.5.11",
@@ -4195,6 +4196,13 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
         "node_modules/abbrev": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -4856,6 +4864,22 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/clean-css": {
@@ -6215,6 +6239,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "micromatch": "^4.0.2"
             }
         },
         "node_modules/flat-cache": {
@@ -7727,10 +7761,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "dev": true,
             "license": "MIT"
         },
@@ -7770,6 +7831,16 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "license": "Public Domain",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/jsonpointer": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
@@ -7797,6 +7868,16 @@
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kolorist": {
@@ -8133,6 +8214,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
@@ -8719,6 +8810,88 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/patch-package": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^10.0.0",
+                "json-stable-stringify": "^1.0.2",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.6",
+                "open": "^7.4.2",
+                "semver": "^7.5.3",
+                "slash": "^2.0.0",
+                "tmp": "^0.2.4",
+                "yaml": "^2.2.2"
+            },
+            "bin": {
+                "patch-package": "index.js"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">5"
+            }
+        },
+        "node_modules/patch-package/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/patch-package/node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package/node_modules/slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/patch-package/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/path-browserify": {
@@ -10786,6 +10959,16 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tmp": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12557,6 +12740,22 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "devOptional": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,8 @@
         "type-check": "vue-tsc --build --force",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
         "lint:fix": "npm run lint -- --fix",
-        "format": "prettier --write src/"
+        "format": "prettier --write src/",
+        "postinstall": "patch-package"
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.19",
@@ -67,6 +68,7 @@
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^23.2.0",
         "npm-run-all2": "^6.2.6",
+        "patch-package": "^8.0.1",
         "postcss": "^8.5.4",
         "prettier": "^3.0.3",
         "prettier-plugin-tailwindcss": "^0.5.11",

--- a/app/patches/README.md
+++ b/app/patches/README.md
@@ -1,0 +1,21 @@
+# Dependency patches
+
+Applied automatically on `npm install` by the `postinstall` script
+([patch-package](https://github.com/ds300/patch-package)).
+
+## `vite-ssg+0.23.8.patch`
+
+Adds `jsdom.window.close()` after `jsdom.serialize()` in the prerender loop.
+
+`vite-ssg` builds a `new JSDOM(renderedHTML)` for every prerendered route and never closes it.
+Each unclosed instance holds a full DOM tree plus its own Node `vm.Context`, retaining ~13 MB —
+measured at 3900 MB vs 160 MB of heap across 300 instances, a 24x difference. Over a full-site
+prerender that exhausts any heap the build could reasonably be given, and `build:web` dies with
+`Reached heap limit Allocation failed - JavaScript heap out of memory`.
+
+Closing after `serialize()` is safe: `renderPreloadLinks` and `renderDOMHead` both run before
+it, and `onPageRendered` afterwards only manipulates the already-serialised HTML string.
+
+The same unclosed-JSDOM code is present in every published `vite-ssg` up to and including
+28.3.0, so there is no upgrade that removes the need for this patch. Drop it only once a
+release actually closes the window itself.

--- a/app/patches/vite-ssg+0.23.8.patch
+++ b/app/patches/vite-ssg+0.23.8.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/vite-ssg/dist/node.mjs b/node_modules/vite-ssg/dist/node.mjs
+index 6faa9cd..a8fc2d2 100644
+--- a/node_modules/vite-ssg/dist/node.mjs
++++ b/node_modules/vite-ssg/dist/node.mjs
+@@ -1043,6 +1043,7 @@ async function build(ssgOptions = {}, viteConfig = {}) {
+         if (head)
+           await renderDOMHead(head, { document: jsdom.window.document });
+         const html = jsdom.serialize();
++        jsdom.window.close();
+         let transformed = await onPageRendered?.(route, html, appCtx) || html;
+         if (critters)
+           transformed = await critters.process(transformed);

--- a/app/src/ssg/README.md
+++ b/app/src/ssg/README.md
@@ -56,6 +56,7 @@ Run from `app/`:
 | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `npm run build:web`                         | **Full** prerender → `dist-web/` (every public route) + `ssg-deps.json` + `sitemap.xml` + `robots.txt` + `llms.txt`. |
 | `SSG_ONLY_ROUTES="/a,/b" npm run build:web` | **Scoped** rebuild of only those routes; preserves all other files; **merges** their entries into `ssg-deps.json`.   |
+| `SSG_EMIT_REDIRECTS=1 …` | Marks a **scoped** build as the pass that owns redirect artifacts, which scoped builds otherwise skip (the ISR watcher maintains the index between builds). For a driver that renders the site in several scoped passes and so never runs an unscoped build — without this, nothing in the run would emit them. |
 | `npm run preview:web`                       | Serve `dist-web/` locally (test in Incognito / unregister old service workers first).                                |
 
 The normal SPA build (`npm run build` → `dist/`, with its service worker) is
@@ -264,7 +265,11 @@ algorithm }` (`docFacetShards.ts`'s `docFacetsIndex()`); each doc's entry lives 
       tolerating this class of gap.
 - **Scoped rebuild** (`SSG_ONLY_ROUTES=... npm run build:web`): renders only those routes,
   `emptyOutDir:false` (keep other files), **merges** the manifest (not overwrites),
-  restores the SPA `index.html` if `/` wasn't in scope.
+  restores the SPA `index.html` if `/` wasn't in scope. Redirect artifacts are **not** written:
+  they are re-read from the API and rewritten wholesale, and between builds the ISR watcher owns
+  that index — so a scoped pass re-reading the API could revert a change the watcher already
+  applied. `SSG_EMIT_REDIRECTS=1` (above) hands ownership to a scoped pass for drivers that never
+  run an unscoped build.
 
 ### Build scope
 

--- a/app/vite.config.web.ts
+++ b/app/vite.config.web.ts
@@ -198,6 +198,14 @@ const SCOPED_DELETE_CMD_IDS: string[] = (process.env.SSG_DELETE_CMD_IDS || "")
     .map((id) => id.trim())
     .filter(Boolean);
 
+// Redirect artifacts are re-read in full from the API and rewritten wholesale, so exactly one
+// pass of a run should own them. Normally that is the unscoped full build: a scoped rebuild skips
+// them because the ISR watcher maintains the index itself between builds, and re-reading the API
+// there could revert a change the watcher has already applied locally but that the API has not
+// caught up with. `SSG_EMIT_REDIRECTS=1` marks a scoped pass as the one that owns them, for a
+// driver that renders the site in several scoped passes and so never runs an unscoped build.
+const EMIT_REDIRECTS = process.env.SSG_EMIT_REDIRECTS === "1";
+
 const indexHtmlPath = () => join(process.cwd(), OUT_DIR, "index.html");
 const manifestPath = () => join(process.cwd(), OUT_DIR, "ssg-deps.json");
 const redirectIndexPath = () => join(process.cwd(), OUT_DIR, "ssg-redirect-index.json");
@@ -773,7 +781,7 @@ const config: UserConfig & { ssgOptions: ViteSSGOptions } = {
                 writeRouteIndex();
                 writeDocFacets();
                 writeDeleteQueue(await fetchDeleteCmds(SSG_API_URL));
-                if (!IS_SCOPED) {
+                if (!IS_SCOPED || EMIT_REDIRECTS) {
                     await writeRedirectFiles(SSG_API_URL);
                 }
                 // Sitemap/robots/llms reflect the full route set on both full and scoped builds.


### PR DESCRIPTION
Part of #1936 (removes the JSDOM contributor; the unhead and cache-seed contributors remain — see the update below)

## The bug

`vite-ssg` constructs a `new JSDOM(renderedHTML)` for **every** prerendered route and never
closes it (`node_modules/vite-ssg/dist/node.mjs`, the render loop):

```js
const jsdom = new JSDOM(renderedHTML);
renderPreloadLinks(jsdom.window.document, ctx.modules || new Set(), ssrManifest);
if (head)
  await renderDOMHead(head, { document: jsdom.window.document });
const html = jsdom.serialize();
// ← never closed
```

Grepping the whole file for `.close()` returns nothing. Each instance holds a full DOM tree
built from a 135–155 KiB page, plus its own Node `vm.Context` with its own globals and
prototypes — none of it reclaimed without an explicit close.

Over a full-site prerender this exhausts any heap the build can be given, and `build:web` dies:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

## Measurement

300 instances of a representative ~200 KiB page, with and without the close:

| | `heapUsed` after 300 instances |
|---|---|
| Without `close()` | **3900 MB** (~13 MB retained each) |
| With `close()` | **160 MB** (~0.5 MB each) |

**24× reduction** from one line.

The GC log from the failing build confirms retention rather than GC pressure — scavenges
reclaim only single-digit MB against a ~2020 MB live set:

```
Scavenge 2026.0 (2078.5) -> 2019.0 (2078.4) MB
Scavenge 2027.4 (2079.6) -> 2024.0 (2097.4) MB
```

> **Update (measured):** this removes the JSDOM contributor *completely* — a closed per-route JSDOM
> retains 2.75 MB/page vs 2.74 MB/page with JSDOM bypassed entirely, i.e. nothing. But it is **not**
> the whole leak: `@unhead/dom` accounts for ~3.5 MB/page and the per-page response-cache seed for
> ~2.75 MB/page. Land this on its merits; it does not on its own make a full-site build complete.
> See the comment below for the bisect table and method.

## The fix

`jsdom.window.close()` immediately after `jsdom.serialize()`, applied via `patch-package`.

Safe at that point: `renderPreloadLinks` and `renderDOMHead` both run *before* the serialize,
and `onPageRendered` afterwards only manipulates the already-serialised HTML string — nothing
touches the DOM once it's closed.

## Why a patch rather than an upgrade

The identical unclosed-JSDOM code is present in the **latest** published `vite-ssg` (28.3.0),
verified directly — there's no version to upgrade to that fixes this. Worth raising upstream
separately, but that shouldn't gate unblocking our build. `patches/README.md` records when the
patch can be dropped.

This introduces `patch-package`; the repo had no dependency-patching tooling before.

## Verification

- Patch applies to a pristine dependency: removed `node_modules/vite-ssg`, reinstalled clean
  (confirmed `jsdom.window.close` absent), ran `npm run postinstall` → applied `✔`, and the
  resulting file passes `node --check`.
- Lockfile changes are limited to `patch-package` and its own dependency tree.

**Not yet verified:** a full `build:web` run to completion against a production-sized dataset.
That needs the deployment environment and is the real end-to-end confirmation — worth doing
before this is relied on.


