### PR TITLE
APP: player stalls after ~5s when no audio track matches the app language

### DIFF
--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -5,7 +5,7 @@ import "videojs-mobile-ui";
 import type Player from "video.js/dist/types/player";
 import { type ContentDto } from "luminary-shared";
 import px from "./px.png";
-import { matchTrackLanguage } from "./audioTrackLanguage";
+import { selectAudioTrackIndex } from "./audioTrackLanguage";
 import LImage from "../images/LImage.vue";
 import { appLanguagesPreferredAsRef, queryParams } from "@/globalConfig";
 import { getMediaProgress, removeMediaProgress, setMediaProgress } from "@/contentProgress";
@@ -91,20 +91,20 @@ function setAudioTrackLanguage(languageCode: string | null) {
         return;
     }
 
-    let trackFound = false;
-    for (let i = 0; i < audioTracks.length; i++) {
-        const track = audioTracks[i];
+    const trackLanguages: (string | null)[] = [];
+    for (let i = 0; i < audioTracks.length; i++) trackLanguages.push(audioTracks[i].language);
 
-        if (matchTrackLanguage(track.language, languageCode)) {
-            track.enabled = true;
-            trackFound = true;
-        } else {
-            track.enabled = false;
-        }
+    const matchIndex = selectAudioTrackIndex(trackLanguages, languageCode);
+    if (matchIndex === -1) {
+        // No track matches the app language — keep whatever track is currently enabled so audio
+        // keeps playing. Disabling every track leaves the player with no audio and it stalls once
+        // the buffer drains.
+        console.warn(`No matching audio track found for language: ${languageCode}`);
+        return;
     }
 
-    if (!trackFound) {
-        console.warn(`No matching audio track found for language: ${languageCode}`);
+    for (let i = 0; i < audioTracks.length; i++) {
+        audioTracks[i].enabled = i === matchIndex;
     }
 }
 

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -91,8 +91,10 @@ function setAudioTrackLanguage(languageCode: string | null) {
         return;
     }
 
-    const trackLanguages: (string | null)[] = [];
-    for (let i = 0; i < audioTracks.length; i++) trackLanguages.push(audioTracks[i].language);
+    // audioTracks is a video.js AudioTrackList (array-like, not a real Array) — copy it to an
+    // array once so we can use map/forEach on it.
+    const tracks = Array.from(audioTracks) as { language: string | null; enabled: boolean }[];
+    const trackLanguages = tracks.map((track) => track.language);
 
     const matchIndex = selectAudioTrackIndex(trackLanguages, languageCode);
     if (matchIndex === -1) {
@@ -103,9 +105,7 @@ function setAudioTrackLanguage(languageCode: string | null) {
         return;
     }
 
-    for (let i = 0; i < audioTracks.length; i++) {
-        audioTracks[i].enabled = i === matchIndex;
-    }
+    tracks.forEach((track, i) => (track.enabled = i === matchIndex));
 }
 
 function syncKeepAudioStateAlive() {

--- a/app/src/components/content/audioTrackLanguage.spec.ts
+++ b/app/src/components/content/audioTrackLanguage.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchTrackLanguage } from "./audioTrackLanguage";
+import { matchTrackLanguage, selectAudioTrackIndex } from "./audioTrackLanguage";
 
 describe("matchTrackLanguage", () => {
     it("matches a 3-letter code (as Android / Chrome reports)", () => {
@@ -39,5 +39,20 @@ describe("matchTrackLanguage", () => {
         expect(matchTrackLanguage("eng", null)).toBe(false);
         expect(matchTrackLanguage(undefined, undefined)).toBe(false);
         expect(matchTrackLanguage("", "en")).toBe(false);
+    });
+});
+
+describe("selectAudioTrackIndex", () => {
+    it("returns the index of the matching track", () => {
+        expect(selectAudioTrackIndex(["fra", "eng", "spa"], "en")).toBe(1);
+        expect(selectAudioTrackIndex(["en-US", "fr-FR"], "fr")).toBe(1);
+    });
+
+    // Regression: when no track matches the app language the caller must NOT disable every
+    // track (that leaves the player with no audio and it stalls after ~5s once the buffer drains).
+    it("returns -1 when no track matches — keep the current track", () => {
+        expect(selectAudioTrackIndex(["fra", "spa"], "en")).toBe(-1);
+        expect(selectAudioTrackIndex([null, undefined, ""], "en")).toBe(-1);
+        expect(selectAudioTrackIndex([], "en")).toBe(-1);
     });
 });

--- a/app/src/components/content/audioTrackLanguage.ts
+++ b/app/src/components/content/audioTrackLanguage.ts
@@ -20,3 +20,15 @@ export function matchTrackLanguage(
     // convert to the 2-letter app code. A language can have two 3-letter codes.
     return iso.iso6392TTo1[track] === target || iso.iso6392BTo1[track] === target;
 }
+
+/**
+ * Index of the audio track to enable for `languageCode`, or -1 when none matches. Callers
+ * MUST treat -1 as "keep the current track" — disabling every track leaves the player with no
+ * audio and it stalls once the buffer drains.
+ */
+export function selectAudioTrackIndex(
+    trackLanguages: (string | null | undefined)[],
+    languageCode: string | null | undefined,
+): number {
+    return trackLanguages.findIndex((lang) => matchTrackLanguage(lang, languageCode));
+}


### PR DESCRIPTION
**Bug:** on a video with multiple audio tracks where none matches the app language (e.g. English), playback stops after ~5 seconds.

**Cause:** `VideoPlayer.vue`'s `setAudioTrackLanguage` looped over the tracks and set `track.enabled = false` for every non-matching one. When *no* track matched, that disabled **all** audio tracks — the player then ran out its buffer (~5s) with no audio track selected and stalled.

**Fix:** find the matching track first; if there's no match, **keep the currently-enabled (default) track** and return, instead of disabling everything. Only when a track matches do we switch to it.

- Extracted the selection into a pure, tested helper `selectAudioTrackIndex(trackLanguages, languageCode)` in `audioTrackLanguage.ts` — returns the match index, or `-1` meaning "keep the current track".
- Added regression tests (match → index; no match / empty → `-1`).

Verified: type-check clean, lint clean, 21 tests pass across `audioTrackLanguage.spec.ts` + `VideoPlayer.spec.ts`. Not device-verified — worth a quick check on a real multi-audio video with a non-matching app language.