### PR TITLE
APP: video won't play when no audio track matches the app language

### DIFF
--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -274,23 +274,26 @@ onMounted(async () => {
             }
         });
 
-        // Handle the "waiting" event, which occurs when the player is buffering
+        // Recover from a wedged buffer, but at most once every few seconds. Seeking aborts
+        // in-flight HLS segment requests, so nudging on every "waiting" event feeds the very
+        // buffer starvation it tries to fix — VHS then reports "excessive segment downloading"
+        // and thrashes through renditions. Re-selecting the audio track here is dropped too: it
+        // is unrelated to buffering and re-touching the track list resets the audio loader.
+        let lastStallNudge = 0;
         player.on("waiting", () => {
             const currentTime = player?.currentTime() || 0; // Get the current playback time
             setTimeout(() => {
-                // Check if the player is still stalled after 2 seconds
-                if (player?.currentTime() === currentTime && !player?.paused()) {
+                // Still stalled at the same time, playing, and past the nudge cooldown.
+                if (
+                    player?.currentTime() === currentTime &&
+                    !player?.paused() &&
+                    Date.now() - lastStallNudge > 6000
+                ) {
                     console.warn("Player stalled, attempting to refresh buffer");
+                    lastStallNudge = Date.now();
 
                     // Slightly adjust the current time to refresh the buffer
                     player?.currentTime(currentTime + 0.001);
-
-                    // Reapply the preferred audio track language only if not restoring
-                    if (!isRestoringTrack.value) {
-                        setAudioTrackLanguage(
-                            appLanguagesPreferredAsRef.value[0].languageCode || null,
-                        );
-                    }
                 }
             }, 2000);
         });

--- a/app/src/components/content/VideoPlayer.vue
+++ b/app/src/components/content/VideoPlayer.vue
@@ -5,7 +5,7 @@ import "videojs-mobile-ui";
 import type Player from "video.js/dist/types/player";
 import { type ContentDto } from "luminary-shared";
 import px from "./px.png";
-import { selectAudioTrackIndex } from "./audioTrackLanguage";
+import { selectAudioTrackIndex, fallbackTrackIndex } from "./audioTrackLanguage";
 import LImage from "../images/LImage.vue";
 import { appLanguagesPreferredAsRef, queryParams } from "@/globalConfig";
 import { getMediaProgress, removeMediaProgress, setMediaProgress } from "@/contentProgress";
@@ -97,15 +97,17 @@ function setAudioTrackLanguage(languageCode: string | null) {
     const trackLanguages = tracks.map((track) => track.language);
 
     const matchIndex = selectAudioTrackIndex(trackLanguages, languageCode);
+
+    // Always enable exactly one track. When no track matches the app language, fall back to a
+    // default (the currently-enabled/stream default, else the first) — leaving every track
+    // disabled gives the player no audio rendition, so playback never starts.
+    const enabledIndex =
+        matchIndex !== -1 ? matchIndex : fallbackTrackIndex(tracks.map((track) => track.enabled));
     if (matchIndex === -1) {
-        // No track matches the app language — keep whatever track is currently enabled so audio
-        // keeps playing. Disabling every track leaves the player with no audio and it stalls once
-        // the buffer drains.
         console.warn(`No matching audio track found for language: ${languageCode}`);
-        return;
     }
 
-    tracks.forEach((track, i) => (track.enabled = i === matchIndex));
+    tracks.forEach((track, i) => (track.enabled = i === enabledIndex));
 }
 
 function syncKeepAudioStateAlive() {

--- a/app/src/components/content/audioTrackLanguage.spec.ts
+++ b/app/src/components/content/audioTrackLanguage.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { matchTrackLanguage, selectAudioTrackIndex } from "./audioTrackLanguage";
+import {
+    matchTrackLanguage,
+    selectAudioTrackIndex,
+    fallbackTrackIndex,
+} from "./audioTrackLanguage";
 
 describe("matchTrackLanguage", () => {
     it("matches a 3-letter code (as Android / Chrome reports)", () => {
@@ -50,9 +54,20 @@ describe("selectAudioTrackIndex", () => {
 
     // Regression: when no track matches the app language the caller must NOT disable every
     // track (that leaves the player with no audio and it stalls after ~5s once the buffer drains).
-    it("returns -1 when no track matches — keep the current track", () => {
+    it("returns -1 when no track matches", () => {
         expect(selectAudioTrackIndex(["fra", "spa"], "en")).toBe(-1);
         expect(selectAudioTrackIndex([null, undefined, ""], "en")).toBe(-1);
         expect(selectAudioTrackIndex([], "en")).toBe(-1);
+    });
+});
+
+describe("fallbackTrackIndex", () => {
+    // When nothing matches, one track must still be enabled or HLS never starts playing.
+    it("keeps the already-enabled (stream default) track", () => {
+        expect(fallbackTrackIndex([false, true, false])).toBe(1);
+    });
+
+    it("falls back to the first track when none is enabled", () => {
+        expect(fallbackTrackIndex([false, false, false])).toBe(0);
     });
 });

--- a/app/src/components/content/audioTrackLanguage.ts
+++ b/app/src/components/content/audioTrackLanguage.ts
@@ -32,3 +32,13 @@ export function selectAudioTrackIndex(
 ): number {
     return trackLanguages.findIndex((lang) => matchTrackLanguage(lang, languageCode));
 }
+
+/**
+ * Which track to enable when no language matches: the one already enabled (the stream's
+ * default), else the first. The player must always have exactly one enabled audio track —
+ * with none enabled, HLS playback never starts. Assumes at least one track exists.
+ */
+export function fallbackTrackIndex(enabled: boolean[]): number {
+    const current = enabled.findIndex(Boolean);
+    return current === -1 ? 0 : current;
+}


### PR DESCRIPTION
Follow-up to #1938. Two related fixes for videos whose audio tracks don't include the app language (e.g. English).

## 1. Video wouldn't start at all

On such content, clicking play did nothing — playback never started.

**Cause:** #1938 fixed the *disable-every-track* stall by keeping the current track when nothing matches. But if **no track was enabled** at that point (the case for this content), "keep the current track" keeps nothing enabled — and with no enabled audio rendition, HLS never starts.

**Fix:** always enable **exactly one** track. When no track matches the app language, fall back to a default — the track already enabled (the stream default), else the first — via a small tested helper `fallbackTrackIndex`.

## 2. Playback started, then stalled mid-video

With (1) in place the video starts, but stalls a few seconds in. The console shows VHS flagging **audio** segment downloading as excessive and thrashing through every video rendition (480→720→1080→360→240), plus a repeating "Player stalled, attempting to refresh buffer".

**Cause (app-side amplifier):** the `waiting` stall-recovery seeked `currentTime + 0.001` on *every* waiting event and re-applied the audio track. Seeking aborts in-flight HLS segment requests, which is exactly the condition VHS reports as "excessive segment downloading" — so the recovery fed the starvation it was trying to fix, turning a transient hiccup into a hard stall.

**Fix:** throttle the buffer-refresh seek to at most once per 6s, and drop the audio-track re-selection from the `waiting` handler (it's unrelated to buffering and re-touching the track list resets the audio loader).

> Note: the *root* cause of the stall on the `cameroon-test-video` asset is likely media-side — VHS keeps flagging **audio** (not video) segments, so the demuxed audio rendition itself is the bottleneck (slow/heavy segments or poor CDN caching). This PR stops the app from amplifying that, but a genuinely slow audio rendition should also be checked in the convert pipeline.

## Verification

Type-check clean, lint clean, 23 tests pass across `audioTrackLanguage.spec.ts` + `VideoPlayer.spec.ts`. Not device-verified — worth a check on the same staging content that wouldn't start/stalled.
