### PR TITLE
APP: return to the gated deep link after login instead of the home page

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,10 @@ env:
 jobs:
     e2e:
         runs-on: ubuntu-latest
+        # APP_BASE_URL/CMS_BASE_URL and the test-user credentials are scoped to
+        # this environment; without it `vars`/`secrets` resolve empty and the
+        # Playwright config throws before any test loads.
+        environment: end-to-end
         timeout-minutes: 20
         defaults:
             run:

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -74,6 +74,7 @@ import {
     ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuthCache,
+    currentReturnTo,
     hasPersistedSession,
     isAuthenticated,
     isAuthPluginInstalled,
@@ -84,6 +85,7 @@ import {
     refreshTokenSilently,
     refreshTokenWithOutcome,
     resolveActiveProvider,
+    sanitizeReturnTo,
     setupAuth,
     showProviderSelectionModal,
     useAuth,
@@ -312,6 +314,73 @@ describe("auth", () => {
             await loginWithProvider(providerA);
 
             expect(mockSigninRedirect).toHaveBeenCalledWith({});
+        });
+
+        it("carries the current page through the redirect as local state", async () => {
+            mockClearStaleState.mockResolvedValue(undefined);
+            mockSigninRedirect.mockResolvedValue(undefined);
+            history.replaceState(null, "", "/eng/restricted-article?x=1#top");
+
+            await loginWithProvider(providerA);
+
+            expect(mockSigninRedirect).toHaveBeenCalledWith({
+                state: { returnTo: "/eng/restricted-article?x=1#top" },
+            });
+        });
+
+        it("prefers an explicitly supplied destination over the current page", async () => {
+            mockClearStaleState.mockResolvedValue(undefined);
+            mockSigninRedirect.mockResolvedValue(undefined);
+            history.replaceState(null, "", "/eng/some-other-page");
+
+            await loginWithProvider(providerA, { returnTo: "/eng/restricted-article" });
+
+            expect(mockSigninRedirect).toHaveBeenCalledWith({
+                state: { returnTo: "/eng/restricted-article" },
+            });
+        });
+
+        it("keeps the prompt alongside the destination", async () => {
+            mockClearStaleState.mockResolvedValue(undefined);
+            mockSigninRedirect.mockResolvedValue(undefined);
+            history.replaceState(null, "", "/eng/restricted-article");
+
+            await loginWithProvider(providerA, { prompt: "login" });
+
+            expect(mockSigninRedirect).toHaveBeenCalledWith({
+                prompt: "login",
+                state: { returnTo: "/eng/restricted-article" },
+            });
+        });
+    });
+
+    describe("currentReturnTo / sanitizeReturnTo", () => {
+        it("captures the path, query and hash of the current page", () => {
+            history.replaceState(null, "", "/eng/post-slug?autoplay=true#chapter-2");
+
+            expect(currentReturnTo()).toBe("/eng/post-slug?autoplay=true#chapter-2");
+        });
+
+        it("treats the home page as no destination", () => {
+            history.replaceState(null, "", "/");
+
+            expect(currentReturnTo()).toBeUndefined();
+        });
+
+        it("drops a spent authorization code when login is restarted from a callback URL", () => {
+            history.replaceState(null, "", "/eng/post-slug?code=abc&state=xyz&autoplay=true");
+
+            expect(currentReturnTo()).toBe("/eng/post-slug?autoplay=true");
+        });
+
+        it("rejects destinations that would navigate off-site", () => {
+            expect(sanitizeReturnTo("//evil.example.com/phish")).toBeUndefined();
+            expect(sanitizeReturnTo("/\\evil.example.com/phish")).toBeUndefined();
+            expect(sanitizeReturnTo("https://evil.example.com")).toBeUndefined();
+            expect(sanitizeReturnTo("eng/post-slug")).toBeUndefined();
+            expect(sanitizeReturnTo(undefined)).toBeUndefined();
+            expect(sanitizeReturnTo({ returnTo: "/eng/post-slug" })).toBeUndefined();
+            expect(sanitizeReturnTo("/eng/post-slug")).toBe("/eng/post-slug");
         });
     });
 
@@ -694,6 +763,48 @@ describe("auth", () => {
             // refreshTokenSilently() must still run on the callback path.
             expect(mockGetUser).toHaveBeenCalledTimes(1);
             expect(mockSigninSilent).not.toHaveBeenCalled();
+        });
+
+        it("returns to the page the login was started from", async () => {
+            persistActiveProvider(providerA);
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+            mockSigninRedirectCallback.mockResolvedValue({
+                ...user,
+                state: { returnTo: "/eng/restricted-article" },
+            });
+            mockGetUser.mockResolvedValue(user);
+
+            await setupAuth(appStub, routerStub);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(routerStub.replace).toHaveBeenCalledWith("/eng/restricted-article");
+        });
+
+        it("stays on the callback landing page when no destination was carried", async () => {
+            persistActiveProvider(providerA);
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+            mockSigninRedirectCallback.mockResolvedValue(user);
+            mockGetUser.mockResolvedValue(user);
+
+            await setupAuth(appStub, routerStub);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(routerStub.replace).not.toHaveBeenCalled();
+        });
+
+        it("refuses an off-site destination returned with the callback", async () => {
+            persistActiveProvider(providerA);
+            history.replaceState(null, "", "/?code=abc&state=xyz");
+            mockSigninRedirectCallback.mockResolvedValue({
+                ...user,
+                state: { returnTo: "//evil.example.com/phish" },
+            });
+            mockGetUser.mockResolvedValue(user);
+
+            await setupAuth(appStub, routerStub);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(routerStub.replace).not.toHaveBeenCalled();
         });
 
         it("removes callback parameters before Vue Router is installed", async () => {

--- a/app/src/auth.spec.ts
+++ b/app/src/auth.spec.ts
@@ -74,6 +74,7 @@ import {
     ACTIVE_PROVIDER_KEY,
     activeProviderId,
     clearAuthCache,
+    closeProviderModal,
     currentReturnTo,
     hasPersistedSession,
     isAuthenticated,
@@ -81,6 +82,7 @@ import {
     loginWithProvider,
     openProviderModal,
     persistActiveProvider,
+    providerModalReturnTo,
     readPersistedProvider,
     refreshTokenSilently,
     refreshTokenWithOutcome,
@@ -139,6 +141,7 @@ function resetWorld(): void {
     history.replaceState(null, "", "/");
     clearAuthCache();
     showProviderSelectionModal.value = false;
+    providerModalReturnTo.value = undefined;
 
     for (const mock of [
         mockUserManager,
@@ -436,6 +439,31 @@ describe("auth", () => {
             expect(showProviderSelectionModal.value).toBe(false);
             openProviderModal();
             expect(showProviderSelectionModal.value).toBe(true);
+        });
+
+        it("keeps the destination the caller captured at click time", () => {
+            history.replaceState(null, "", "/eng/privacy-policy");
+
+            openProviderModal("/eng/restricted-article");
+
+            expect(providerModalReturnTo.value).toBe("/eng/restricted-article");
+        });
+
+        it("falls back to the current page when the caller passes no destination", () => {
+            history.replaceState(null, "", "/eng/restricted-article");
+
+            openProviderModal();
+
+            expect(providerModalReturnTo.value).toBe("/eng/restricted-article");
+        });
+
+        it("drops the destination when the modal is closed without a pick", () => {
+            openProviderModal("/eng/restricted-article");
+
+            closeProviderModal();
+
+            expect(showProviderSelectionModal.value).toBe(false);
+            expect(providerModalReturnTo.value).toBeUndefined();
         });
     });
 

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -574,17 +574,32 @@ export function clearAuthCache(): void {
     }
 }
 
-export function openProviderModal(): void {
+/**
+ * Destination the pending provider pick should return to. Captured when the
+ * modal opens rather than when the redirect starts, because the privacy-policy
+ * gate can defer the pick across a route change.
+ */
+export const providerModalReturnTo = ref<string | undefined>(undefined);
+
+export function openProviderModal(returnTo?: string): void {
+    providerModalReturnTo.value = returnTo ?? currentReturnTo();
     showProviderSelectionModal.value = true;
+}
+
+export function closeProviderModal(): void {
+    providerModalReturnTo.value = undefined;
+    showProviderSelectionModal.value = false;
 }
 
 export default {
     setupAuth,
     openProviderModal,
+    closeProviderModal,
     clearAuthCache,
     activeProviderId,
     showProviderSelectionModal,
     loginWithProvider,
+    providerModalReturnTo,
     resolveActiveProvider,
     refreshTokenSilently,
     hasPersistedSession,

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -203,6 +203,59 @@ function installManager(provider: ProviderConfig): UserManager {
     return manager;
 }
 
+/** Custom state round-tripped through the OIDC state store across a login redirect. */
+type SigninState = { returnTo?: string };
+
+function appBasePath(): string {
+    const base = import.meta.env.BASE_URL || "/";
+    return base.endsWith("/") ? base : `${base}/`;
+}
+
+/**
+ * Router-relative location to come back to after a login redirect. `redirect_uri`
+ * is pinned to the origin (providers allow-list it exactly), so the destination
+ * has to travel separately and be restored client-side.
+ */
+export function currentReturnTo(): string | undefined {
+    if (typeof location === "undefined") return undefined;
+    const base = appBasePath();
+    const path = location.pathname.startsWith(base)
+        ? `/${location.pathname.slice(base.length)}`
+        : location.pathname;
+    // Starting a login from a callback URL would otherwise carry a spent
+    // authorization code into the destination.
+    const params = new URLSearchParams(location.search);
+    params.delete("code");
+    params.delete("state");
+    const search = params.toString();
+    return sanitizeReturnTo(`${path}${search ? `?${search}` : ""}${location.hash}`);
+}
+
+/**
+ * Accept only app-internal paths. `//host` and `/\host` are read as
+ * protocol-relative URLs by browsers, so they would navigate off-site.
+ */
+export function sanitizeReturnTo(value: unknown): string | undefined {
+    if (typeof value !== "string" || !value.startsWith("/")) return undefined;
+    if (value.startsWith("//") || value.startsWith("/\\")) return undefined;
+    return value === "/" ? undefined : value;
+}
+
+/**
+ * `state` rides in the local OIDC state store, never in the request to the
+ * provider, so the destination cannot be tampered with in transit.
+ */
+function signinArgs(
+    prompt: OidcPrompt | undefined,
+    returnTo: string | undefined,
+): { prompt?: OidcPrompt; state?: SigninState } {
+    const destination = returnTo ?? currentReturnTo();
+    return {
+        ...(prompt ? { prompt } : {}),
+        ...(destination ? { state: { returnTo: destination } } : {}),
+    };
+}
+
 /**
  * Drop the one-time authorization-code credentials from the current history
  * entry. Leaving them behind keeps a redeemable code in history and in outbound
@@ -245,6 +298,18 @@ export async function setupAuth(_app: App<Element>, router: Router): Promise<voi
             stripAuthCallbackParams();
             try {
                 oidcUser.value = await manager.signinRedirectCallback(url.href);
+                const returnTo = sanitizeReturnTo(
+                    (oidcUser.value.state as SigninState | undefined)?.returnTo,
+                );
+                // The router's initial navigation targets the origin-level
+                // `redirect_uri`, so the page the login started from has to be
+                // restored once that navigation has settled.
+                if (returnTo) {
+                    void router
+                        .isReady()
+                        .then(() => router.replace(returnTo))
+                        .catch((navigationError) => Sentry?.captureException(navigationError));
+                }
             } catch (error) {
                 // A refresh on the callback URL after it already succeeded once
                 // retries the same, by-then-consumed code+state and always
@@ -404,7 +469,7 @@ export async function refreshTokenSilently(opts?: {
 /** Start an OIDC authorization-code + PKCE redirect for a selected provider. */
 export async function loginWithProvider(
     provider: ProviderConfig,
-    opts?: { prompt?: OidcPrompt },
+    opts?: { prompt?: OidcPrompt; returnTo?: string },
 ): Promise<void> {
     persistActiveProvider(provider);
     const manager = installManager(provider);
@@ -417,7 +482,7 @@ export async function loginWithProvider(
     // `extraQueryParams` on a signin call REPLACES the manager-level object in
     // oidc-client-ts; using it for prompt would drop Auth0's API audience and
     // produce an opaque access token. `prompt` is a standard first-class option.
-    await manager.signinRedirect(prompt ? { prompt } : {});
+    await manager.signinRedirect(signinArgs(prompt, opts?.returnTo));
 }
 
 /**
@@ -441,7 +506,8 @@ export function useAuth() {
         isLoading,
         isAuthenticated,
         user,
-        loginWithRedirect: () => installedOidc?.signinRedirect(),
+        loginWithRedirect: (opts?: { returnTo?: string }) =>
+            installedOidc?.signinRedirect(signinArgs(undefined, opts?.returnTo)),
         logout: async (opts?: LogoutOptions) => {
             const manager = installedOidc;
             if (!manager) return;

--- a/app/src/components/authProvider/AuthProviderSelectionModal.spec.ts
+++ b/app/src/components/authProvider/AuthProviderSelectionModal.spec.ts
@@ -18,7 +18,9 @@ vi.mock("vue-i18n", () => ({
 }));
 
 vi.mock("@/auth", () => ({
+    closeProviderModal: vi.fn(),
     loginWithProvider: vi.fn(),
+    providerModalReturnTo: ref<string | undefined>("/eng/restricted-article"),
     showProviderSelectionModal: ref(true),
 }));
 
@@ -30,7 +32,7 @@ vi.mock("@/components/images/LImage.vue", () => ({
     },
 }));
 
-import { loginWithProvider, showProviderSelectionModal } from "@/auth";
+import { closeProviderModal, loginWithProvider, showProviderSelectionModal } from "@/auth";
 
 const mockProviderA: AuthProviderDto = {
     _id: "provider-a",
@@ -145,6 +147,7 @@ describe("AuthProviderSelectionModal.vue", () => {
         expect(loginWithProvider).toHaveBeenCalledTimes(1);
         expect(loginWithProvider).toHaveBeenCalledWith(
             expect.objectContaining({ _id: "provider-a" }),
+            { returnTo: "/eng/restricted-article" },
         );
     });
 
@@ -167,7 +170,7 @@ describe("AuthProviderSelectionModal.vue", () => {
         expect(style).toContain("color");
     });
 
-    it("sets showProviderSelectionModal to false when the modal emits close", async () => {
+    it("closes the provider modal when the modal emits close", async () => {
         showProviderSelectionModal.value = true;
 
         const wrapper = mount(AuthProviderSelectionModal, {
@@ -176,7 +179,7 @@ describe("AuthProviderSelectionModal.vue", () => {
 
         await wrapper.findComponent({ name: "LModal" }).vm.$emit("close");
 
-        expect(showProviderSelectionModal.value).toBe(false);
+        expect(closeProviderModal).toHaveBeenCalledTimes(1);
     });
 
     it("is hidden when isVisible is false", () => {

--- a/app/src/components/authProvider/AuthProviderSelectionModal.vue
+++ b/app/src/components/authProvider/AuthProviderSelectionModal.vue
@@ -2,7 +2,7 @@
 import LModal from "@/components/form/LModal.vue";
 import LImage from "@/components/images/LImage.vue";
 import { ExclamationTriangleIcon } from "@heroicons/vue/24/outline";
-import { showProviderSelectionModal, loginWithProvider } from "@/auth";
+import { closeProviderModal, loginWithProvider, providerModalReturnTo } from "@/auth";
 import { DocType, useHybridQuery, type AuthProviderDto } from "luminary-shared";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -27,11 +27,11 @@ const hasIcon = (provider: AuthProviderDto) =>
     provider.imageData?.fileCollections?.some((fc) => fc.imageFiles?.length > 0) ?? false;
 
 const handleProviderSelect = (provider: AuthProviderDto) => {
-    loginWithProvider(provider);
+    loginWithProvider(provider, { returnTo: providerModalReturnTo.value });
 };
 
 const handleClose = () => {
-    showProviderSelectionModal.value = false;
+    closeProviderModal();
 };
 </script>
 

--- a/app/src/composables/useAuthWithPrivacyPolicy.spec.ts
+++ b/app/src/composables/useAuthWithPrivacyPolicy.spec.ts
@@ -7,7 +7,7 @@ import { userPreferencesAsRef } from "@/globalConfig";
 import { ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import waitForExpect from "wait-for-expect";
-import { isAuthPluginInstalled, openProviderModal, useAuth } from "@/auth";
+import { currentReturnTo, isAuthPluginInstalled, openProviderModal, useAuth } from "@/auth";
 
 // Mock userPreferencesAsRef
 vi.mock("@/globalConfig", () => ({
@@ -174,6 +174,7 @@ describe("useAuthWithPrivacyPolicy", () => {
         beforeEach(() => {
             isAuthPluginInstalled.value = false;
             (openProviderModal as Mock).mockClear();
+            (currentReturnTo as Mock).mockReturnValue("/eng/restricted-article");
         });
 
         it("gates openProviderModal behind the privacy policy when not accepted", () => {
@@ -216,6 +217,24 @@ describe("useAuthWithPrivacyPolicy", () => {
                 expect(openProviderModal).toHaveBeenCalledTimes(1);
                 expect(showPrivacyPolicyModal.value).toBe(false);
                 expect(hasPendingLogin.value).toBe(false);
+            });
+        });
+
+        it("carries the destination captured at click time into a deferred provider pick", async () => {
+            userPreferencesMock.value.privacyPolicy.status = "not_accepted";
+            (userPreferencesAsRef as any).value = userPreferencesMock.value;
+
+            const { loginWithRedirect, completePendingLogin } = useAuthWithPrivacyPolicy();
+            loginWithRedirect();
+
+            // The privacy-policy modal's "read more" navigates away before acceptance.
+            (currentReturnTo as Mock).mockReturnValue("/eng/privacy-policy");
+            userPreferencesMock.value.privacyPolicy.status = "accepted";
+            (userPreferencesAsRef as any).value = userPreferencesMock.value;
+            completePendingLogin();
+
+            await waitForExpect(() => {
+                expect(openProviderModal).toHaveBeenCalledWith("/eng/restricted-article");
             });
         });
 

--- a/app/src/composables/useAuthWithPrivacyPolicy.spec.ts
+++ b/app/src/composables/useAuthWithPrivacyPolicy.spec.ts
@@ -27,6 +27,7 @@ vi.mock("@/auth", async () => {
     return {
         isAuthPluginInstalled: mockRef(false),
         openProviderModal: vi.fn(),
+        currentReturnTo: vi.fn(() => "/eng/restricted-article"),
         useAuth: vi.fn(() => ({
             isLoading: mockRef(false),
             isAuthenticated: mockRef(false),
@@ -103,6 +104,21 @@ describe("useAuthWithPrivacyPolicy", () => {
             expect(loginWithRedirectMock).toHaveBeenCalled();
             expect(showPrivacyPolicyModal.value).toBe(false);
             expect(hasPendingLogin.value).toBe(false);
+        });
+    });
+
+    it("carries the page the login was started from through the privacy-policy gate", async () => {
+        const { loginWithRedirect, completePendingLogin } = useAuthWithPrivacyPolicy();
+        loginWithRedirect();
+
+        userPreferencesMock.value.privacyPolicy.status = "accepted";
+        (userPreferencesAsRef as any).value = userPreferencesMock.value;
+        completePendingLogin();
+
+        await waitForExpect(() => {
+            expect(loginWithRedirectMock).toHaveBeenCalledWith({
+                returnTo: "/eng/restricted-article",
+            });
         });
     });
 

--- a/app/src/composables/useAuthWithPrivacyPolicy.ts
+++ b/app/src/composables/useAuthWithPrivacyPolicy.ts
@@ -1,6 +1,12 @@
 import { computed, ref } from "vue";
 import { userPreferencesAsRef } from "@/globalConfig";
-import { isAuthPluginInstalled, openProviderModal, useAuth, type LogoutOptions } from "@/auth";
+import {
+    currentReturnTo,
+    isAuthPluginInstalled,
+    openProviderModal,
+    useAuth,
+    type LogoutOptions,
+} from "@/auth";
 
 // Global state for privacy policy modal
 export const showPrivacyPolicyModal = ref(false);
@@ -76,7 +82,12 @@ export function useAuthWithPrivacyPolicy() {
 
     const { isAuthenticated, user, loginWithRedirect: originalLoginWithRedirect, logout } = auth;
 
-    const loginWithRedirect = () => gateBehindPrivacyPolicy(() => originalLoginWithRedirect());
+    // Capture the destination when the user clicks login, not when the redirect
+    // finally starts — the privacy-policy modal can defer that across a route change.
+    const loginWithRedirect = () => {
+        const returnTo = currentReturnTo();
+        gateBehindPrivacyPolicy(() => originalLoginWithRedirect({ returnTo }));
+    };
 
     return {
         isAuthenticated,

--- a/app/src/composables/useAuthWithPrivacyPolicy.ts
+++ b/app/src/composables/useAuthWithPrivacyPolicy.ts
@@ -71,7 +71,11 @@ export function useAuthWithPrivacyPolicy() {
             isAuthenticated: computed(() => false),
             user: computed(() => null),
             logout: (_opts?: LogoutOptions) => {},
-            loginWithRedirect: () => gateBehindPrivacyPolicy(() => openProviderModal()),
+            // Same capture-on-click reasoning as the installed-provider branch below.
+            loginWithRedirect: () => {
+                const returnTo = currentReturnTo();
+                gateBehindPrivacyPolicy(() => openProviderModal(returnTo));
+            },
             isPrivacyPolicyAccepted,
             showPrivacyPolicyModal,
             hasPendingLogin,

--- a/app/src/pages/NotFoundPage.vue
+++ b/app/src/pages/NotFoundPage.vue
@@ -41,7 +41,11 @@ onMounted(async () => {
             </div>
             <div v-else class="mt-10 text-center text-base leading-7 text-zinc-600 dark:text-white">
                 {{ t("notfoundpage.unauthenticated.loginPrompt.before") }}
-                <span class="cursor-pointer text-yellow-700 underline" @click="loginWithRedirect()">
+                <span
+                    data-test="login-prompt"
+                    class="cursor-pointer text-yellow-700 underline"
+                    @click="loginWithRedirect()"
+                >
                     {{ t("notfoundpage.unauthenticated.loginPrompt.linkText") }}
                 </span>
                 {{ t("notfoundpage.unauthenticated.loginPrompt.after") }}

--- a/app/src/tests/mockAuth.ts
+++ b/app/src/tests/mockAuth.ts
@@ -18,6 +18,8 @@ export function createAuthMock() {
         hasPersistedSession: vi.fn(() => false),
         isAuthPluginInstalled: ref(true),
         openProviderModal: vi.fn(),
+        closeProviderModal: vi.fn(),
+        providerModalReturnTo: ref<string | undefined>(undefined),
         showProviderSelectionModal: ref(false),
         useAuth: vi.fn(() => ({
             isLoading: ref(false),

--- a/playwright-tests/app/flows/login-return-to.spec.ts
+++ b/playwright-tests/app/flows/login-return-to.spec.ts
@@ -1,0 +1,192 @@
+import { appPersonaTest as test, expect } from "../../fixtures/persona";
+import {
+  signInThroughUI,
+  waitForProviderChoices,
+} from "../../fixtures/loginFlow";
+import { waitForAccessMap } from "../../fixtures/readiness";
+import type { Page } from "@playwright/test";
+
+/**
+ * Deep links into gated content are the common entry point from a shared link,
+ * and the OIDC `redirect_uri` is pinned to the origin — so the destination only
+ * survives if the client carries and restores it itself.
+ *
+ * `blog2-eng` is seeded into `group-private-content`, which a guest never
+ * receives, so it renders the unauthenticated not-found page. `blog1-eng` is
+ * public and readable without signing in.
+ */
+const PRIVATE_ARTICLE_PATH = "/blog2-eng";
+const PRIVATE_ARTICLE_TITLE = "Blog 2";
+const PUBLIC_ARTICLE_PATH = "/blog1-eng";
+
+const REDIRECT_TIMEOUT = 30_000;
+
+/** Login is gated behind policy acceptance, so clear it before driving the prompt. */
+async function acceptPrivacyPolicy(page: Page): Promise<void> {
+  const accept = page.locator('button[name="accept"]').first();
+  if (await accept.isVisible().catch(() => false)) await accept.click();
+}
+
+async function startLoginFromNotFoundPage(page: Page): Promise<void> {
+  const prompt = page.locator('[data-test="login-prompt"]');
+  await expect(prompt).toBeVisible({ timeout: REDIRECT_TIMEOUT });
+  await acceptPrivacyPolicy(page);
+  await prompt.click();
+  await acceptPrivacyPolicy(page);
+}
+
+async function currentLocation(page: Page): Promise<string> {
+  const url = new URL(page.url());
+  return url.pathname + url.search + url.hash;
+}
+
+test.describe("App login return-to", () => {
+  test("returns to the gated article the login was started from", async ({
+    page,
+    idp,
+  }) => {
+    const primary = idp.providers.primary;
+    await page.goto(PRIVATE_ARTICLE_PATH);
+
+    await startLoginFromNotFoundPage(page);
+    await waitForProviderChoices(page, [primary.label]);
+    await signInThroughUI(page, {
+      providerLabel: primary.label,
+      persona: "privateUser",
+    });
+    await waitForAccessMap(page);
+
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: REDIRECT_TIMEOUT })
+      .toBe(PRIVATE_ARTICLE_PATH);
+    await expect(
+      page.getByRole("heading", { name: PRIVATE_ARTICLE_TITLE }).first(),
+    ).toBeVisible({ timeout: REDIRECT_TIMEOUT });
+  });
+
+  test("preserves the query string and hash of the original link", async ({
+    page,
+    idp,
+  }) => {
+    const primary = idp.providers.primary;
+    const link = `${PRIVATE_ARTICLE_PATH}?autoplay=true#section`;
+    await page.goto(link);
+
+    await startLoginFromNotFoundPage(page);
+    await waitForProviderChoices(page, [primary.label]);
+    await signInThroughUI(page, {
+      providerLabel: primary.label,
+      persona: "privateUser",
+    });
+    await waitForAccessMap(page);
+
+    await expect
+      .poll(() => currentLocation(page), { timeout: REDIRECT_TIMEOUT })
+      .toBe(link);
+  });
+
+  test("leaves no authorization code on the restored article URL", async ({
+    page,
+    idp,
+  }) => {
+    const primary = idp.providers.primary;
+    await page.goto(PRIVATE_ARTICLE_PATH);
+
+    await startLoginFromNotFoundPage(page);
+    await waitForProviderChoices(page, [primary.label]);
+    await signInThroughUI(page, {
+      providerLabel: primary.label,
+      persona: "privateUser",
+    });
+    await waitForAccessMap(page);
+
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: REDIRECT_TIMEOUT })
+      .toBe(PRIVATE_ARTICLE_PATH);
+    const restored = new URL(page.url());
+    expect(restored.searchParams.has("code")).toBe(false);
+    expect(restored.searchParams.has("state")).toBe(false);
+  });
+
+  /**
+   * The destination is captured from wherever the user was, so a reader who
+   * still lacks access must land back on the article rather than the home page.
+   */
+  test("returns to the article even when the signed-in user still cannot read it", async ({
+    page,
+    idp,
+  }) => {
+    const primary = idp.providers.primary;
+    await page.goto(PRIVATE_ARTICLE_PATH);
+
+    await startLoginFromNotFoundPage(page);
+    await waitForProviderChoices(page, [primary.label]);
+    await signInThroughUI(page, {
+      providerLabel: primary.label,
+      persona: "publicUser",
+    });
+    await waitForAccessMap(page);
+
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: REDIRECT_TIMEOUT })
+      .toBe(PRIVATE_ARTICLE_PATH);
+    // Signed in now, so the not-found page drops its login prompt.
+    await expect(page.locator('[data-test="login-prompt"]')).toHaveCount(0);
+  });
+
+  // The top-bar login button is the other entry point into the same redirect,
+  // and it only renders below the desktop breakpoint.
+  test.describe("from the top-bar login button", () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test("returns to a readable page the login was started from", async ({
+      page,
+      idp,
+    }) => {
+      const primary = idp.providers.primary;
+      await page.goto(PUBLIC_ARTICLE_PATH);
+      await acceptPrivacyPolicy(page);
+
+      const loginButton = page.locator('[data-test="mobileLoginButton"]');
+      await expect(loginButton).toBeVisible({ timeout: REDIRECT_TIMEOUT });
+      await loginButton.click();
+      await acceptPrivacyPolicy(page);
+
+      await waitForProviderChoices(page, [primary.label]);
+      await signInThroughUI(page, {
+        providerLabel: primary.label,
+        persona: "publicUser",
+      });
+      await waitForAccessMap(page);
+
+      await expect
+        .poll(() => new URL(page.url()).pathname, { timeout: REDIRECT_TIMEOUT })
+        .toBe(PUBLIC_ARTICLE_PATH);
+    });
+
+    test("stays on the home page when the login was started there", async ({
+      page,
+      idp,
+    }) => {
+      const primary = idp.providers.primary;
+      await page.goto("/");
+      await acceptPrivacyPolicy(page);
+
+      const loginButton = page.locator('[data-test="mobileLoginButton"]');
+      await expect(loginButton).toBeVisible({ timeout: REDIRECT_TIMEOUT });
+      await loginButton.click();
+      await acceptPrivacyPolicy(page);
+
+      await waitForProviderChoices(page, [primary.label]);
+      await signInThroughUI(page, {
+        providerLabel: primary.label,
+        persona: "publicUser",
+      });
+      await waitForAccessMap(page);
+
+      await expect
+        .poll(() => new URL(page.url()).pathname, { timeout: REDIRECT_TIMEOUT })
+        .toBe("/");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Signing in from a gated deep link now returns the reader to the page they asked for, instead of dropping them on the home page.
- The OIDC `redirect_uri` is pinned to the origin, so the destination can't ride on it — it travels in the OIDC **local** state store and is restored client-side after the callback.
- Applies to any gated route (articles, video pages), not just posts.

## Changes
- `app/src/auth.ts` — `currentReturnTo()` captures the router-relative path (query + hash, minus any spent `code`/`state`); `signinArgs()` puts it in `signinRedirect({ state })`; the `setupAuth()` callback branch reads it back and `router.replace()`s once `router.isReady()` settles. `sanitizeReturnTo()` accepts app-internal paths only — `//host`, `/\host` and absolute URLs are rejected, so a value returned from the provider can never navigate off-site.
- `app/src/auth.ts` — `openProviderModal(returnTo?)` stores the destination in `providerModalReturnTo` at open time, with `closeProviderModal()` to clear it. Capturing at click time matters because the privacy-policy modal's "Read more" navigates to `/privacy-policy` while the login stays pending; resolving the destination lazily at redirect time would return the user there instead of to the article.
- `app/src/composables/useAuthWithPrivacyPolicy.ts` — both entry points capture the destination when the user clicks login: the installed-provider path passes it to `loginWithRedirect`, and the provider-picker fallback passes it to `openProviderModal`.
- `app/src/components/authProvider/AuthProviderSelectionModal.vue` — forwards `providerModalReturnTo` into `loginWithProvider`.
- `app/src/pages/NotFoundPage.vue` — `data-test="login-prompt"` hook for the E2E flow.

## Test plan
- [ ] Logged out, open a link to a group-restricted article; sign in from the prompt — land back on the article with it readable, not on `/`.
- [ ] Same with `?autoplay=true#section` on the link — query and hash survive the round trip.
- [ ] Restored URL carries no `code`/`state`, and history holds no redeemable authorization code.
- [ ] Sign in as a user who still lacks access — still returns to the article, not the home page.
- [ ] Start login from the privacy-policy modal's "Read more" (navigates away), accept, then pick a provider — return to the original article, not `/privacy-policy`.
- [ ] Top-bar login on the home page still stays on `/`.

## Notes
- `stripAuthCallbackParams()` behaviour is unchanged; it still runs on both the pre- and post-router-ready paths.
- Unit coverage: `app/src/auth.spec.ts`, `useAuthWithPrivacyPolicy.spec.ts`, `AuthProviderSelectionModal.spec.ts`. E2E: `playwright-tests/app/flows/login-return-to.spec.ts` (6 flows). The deferred "Read more" case is unit-covered only.
- The failing `e2e` check on this PR is a stale run of **E2E Tests (Deployed Dev)** from when these commits were briefly on `main` (GitHub attaches check runs to the SHA). That workflow has failed on every main push since at least Aug 21, including on `0a96cf03` both before and after this branch, because its job doesn't declare `environment: end-to-end` and so reads empty `APP_BASE_URL`/`CMS_BASE_URL`. Unrelated to this change; tracked separately.
- **E2E Tests (Local Stack)** is the job that actually covers this work, and it passes on this PR — 36 tests, all six `login-return-to` flows green.

Closes #1955
